### PR TITLE
ArraySet.prototype.has dies when a "hasOwnProperty" property is added

### DIFF
--- a/lib/source-map/array-set.js
+++ b/lib/source-map/array-set.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
    * @param String str
    */
   ArraySet.prototype.has = function ArraySet_has(aStr) {
-    return util.hasOwn(this._set, aStr);
+    return Object.prototype.hasOwnProperty.call(this._set, aStr);
   };
 
   /**

--- a/lib/source-map/util.js
+++ b/lib/source-map/util.js
@@ -33,10 +33,5 @@ define(function (require, exports, module) {
       : aRoot.replace(/\/*$/, '') + '/' + aPath;
   }
   exports.join = join;
-  
-  function hasOwn(obj, key) {
-    return Object.prototype.hasOwnProperty.call(obj, key);
-  }
-  exports.hasOwn = hasOwn;
 
 });


### PR DESCRIPTION
So I've been playing around with this and came across the `has` method failing due to it being overwritten by a method with the same name. In my source I have jquery which when creating a source map has a `hasOwnProperty` look up, so when that's added it throws and you can't continue.

I added a util method `hasOwn` to avoid the collision.
