### PR TITLE
Fix off-by-one error

### DIFF
--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -119,6 +119,8 @@ define(function (require, exports, module) {
             temp = base64VLQ.decode(str);
             mapping.originalLine = previousOriginalLine + temp.value;
             previousOriginalLine = mapping.originalLine;
+            // Lines are stored 0-based
+            mapping.originalLine += 1;
             str = temp.rest;
             if (str.length === 0 || mappingSeparator.test(str.charAt(0))) {
               throw new Error('Found a source and line, but no column');

--- a/lib/source-map/source-map-generator.js
+++ b/lib/source-map/source-map-generator.js
@@ -148,9 +148,10 @@ define(function (require, exports, module) {
                                      - previousSource);
           previousSource = this._sources.indexOf(mapping.source);
 
-          result += base64VLQ.encode(mapping.original.line
+          // lines are stored 0-based in SourceMap spec version 3
+          result += base64VLQ.encode(mapping.original.line - 1
                                      - previousOriginalLine);
-          previousOriginalLine = mapping.original.line;
+          previousOriginalLine = mapping.original.line - 1;
 
           result += base64VLQ.encode(mapping.original.column
                                      - previousOriginalColumn);

--- a/test/test-source-map-generator.js
+++ b/test/test-source-map-generator.js
@@ -197,7 +197,7 @@ define(function (require, exports, module) {
     assert.deepEqual(map.names, ['bar', 'baz', 'n']);
     assert.deepEqual(map.sources, ['one.js', 'two.js']);
     assert.equal(map.sourceRoot, '/the/root');
-    assert.equal(map.mappings, 'CACC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA');
+    assert.equal(map.mappings, 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA');
   };
 
 });

--- a/test/util.js
+++ b/test/util.js
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
     names: ['bar', 'baz', 'n'],
     sources: ['one.js', 'two.js'],
     sourceRoot: '/the/root',
-    mappings: 'CACC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
+    mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
   };
 
   function assertMapping(generatedLine, generatedColumn, originalSource,


### PR DESCRIPTION
Lines should be stored 0-based according to the current version of the spec:

https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit

I clarified this instruction with concavelenz on irc://irc.freenode.net#chromium, and it is implemented that way in the current dev versions of chrome.
