### PR TITLE
ignore empty chunks

### DIFF
--- a/lib/source-map/source-node.js
+++ b/lib/source-map/source-node.js
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
       }, this);
     }
     else if (aChunk instanceof SourceNode || typeof aChunk === "string") {
-      this.children.push(aChunk);
+      if(aChunk) this.children.push(aChunk);
     }
     else {
       throw new TypeError(


### PR DESCRIPTION
This is not only helpful for performance and simplicity, but also improves `replaceRight` behaviour, since it will be guaranteed to operate on a non-empty source chunk.
