### PR TITLE
Add SourceMapGenerator#toJSON

### DIFF
--- a/lib/source-map/source-map-generator.js
+++ b/lib/source-map/source-map-generator.js
@@ -172,10 +172,10 @@ define(function (require, exports, module) {
     };
 
   /**
-   * Render the source map being generated to a string.
+   * Externalize the source map.
    */
-  SourceMapGenerator.prototype.toString =
-    function SourceMapGenerator_toString() {
+  SourceMapGenerator.prototype.toJSON =
+    function SourceMapGenerator_toJSON() {
       var map = {
         version: this._version,
         file: this._file,
@@ -186,7 +186,15 @@ define(function (require, exports, module) {
       if (this._sourceRoot) {
         map.sourceRoot = this._sourceRoot;
       }
-      return JSON.stringify(map);
+      return map;
+    };
+
+  /**
+   * Render the source map being generated to a string.
+   */
+  SourceMapGenerator.prototype.toString =
+    function SourceMapGenerator_toString() {
+      return JSON.stringify(this);
     };
 
   exports.SourceMapGenerator = SourceMapGenerator;

--- a/test/source-map/test-source-map-generator.js
+++ b/test/source-map/test-source-map-generator.js
@@ -19,6 +19,14 @@ define(function (require, exports, module) {
     assert.ok(true);
   };
 
+  exports['test JSON serialization'] = function (assert, util) {
+    var map = new SourceMapGenerator({
+      file: 'foo.js',
+      sourceRoot: '.'
+    });
+    assert.equal(map.toString(), JSON.stringify(map));
+  };
+
   exports['test adding mappings (case 1)'] = function (assert, util) {
     var map = new SourceMapGenerator({
       file: 'generated-foo.js',


### PR DESCRIPTION
This way `JSON.stringify(map)` will return the same external representation as `map.toString()` does. 
