### PR TITLE
Google Closure Compiler fails on "char" variable

### DIFF
--- a/lib/source-map/source-node.js
+++ b/lib/source-map/source-node.js
@@ -181,8 +181,8 @@ define(function (require, exports, module) {
           }
         });
       }
-      chunk.split('').forEach(function (char) {
-        if (char === '\n') {
+      chunk.split('').forEach(function (ch) {
+        if (ch === '\n') {
           generated.line++;
           generated.column = 0;
         } else {


### PR DESCRIPTION
Changing variable from "char" to "ch".
