### PR TITLE
fix eachMapping with ORIGINAL_ORDER

### DIFF
--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -185,7 +185,9 @@ define(function (require, exports, module) {
           }
 
           this._generatedMappings.push(mapping);
-          this._originalMappings.push(mapping);
+          if (typeof mapping.originalLine === 'number') {
+            this._originalMappings.push(mapping);
+          }
         }
       }
 


### PR DESCRIPTION
There were mappings without original source position in the originalMappings list, which causes the comperator the return NaN and do not sort correctly.
