### PR TITLE
Fix missing semicolons.

### DIFF
--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -274,7 +274,7 @@ define(function (require, exports, module) {
                                       this._generatedMappings,
                                       "generatedLine",
                                       "generatedColumn",
-                                      this._compareGeneratedPositions)
+                                      this._compareGeneratedPositions);
 
       if (mapping) {
         var source = util.getArg(mapping, 'source', null);
@@ -353,7 +353,7 @@ define(function (require, exports, module) {
                                       this._originalMappings,
                                       "originalLine",
                                       "originalColumn",
-                                      this._compareOriginalPositions)
+                                      this._compareOriginalPositions);
 
       if (mapping) {
         return {

--- a/lib/source-map/source-node.js
+++ b/lib/source-map/source-node.js
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
   SourceNode.prototype.join = function SourceNode_join(aSep) {
     var newChildren;
     var i;
-    var len = this.children.length
+    var len = this.children.length;
     if (len > 0) {
       newChildren = [];
       for (i = 0; i < len-1; i++) {

--- a/lib/source-map/util.js
+++ b/lib/source-map/util.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
    * @param String aStr
    */
   function toSetString(aStr) {
-    return '$' + aStr
+    return '$' + aStr;
   }
   exports.toSetString = toSetString;
 


### PR DESCRIPTION
```
I know this is a minor change, but I'm currently trying to set up a
build process that npm installs the latest source-map, and then wraps
it to look like an ES6 module (at least in traceur's eyes). The build
settings are currently set up to complain about missing semicolons.

Implementing some sort of "nolint" is the right long-term solution for
incorporating third-party source code into a build process, but I'd
like to buy a little time before I have to do that.

Besides, what could be better than semicolons?
```
