### PR TITLE
fix bugs at path join and relative

### DIFF
--- a/lib/source-map/util.js
+++ b/lib/source-map/util.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
   function join(aRoot, aPath) {
     return aPath.charAt(0) === '/'
       ? aPath
-      : aRoot.replace(/\/*$/, '') + '/' + aPath;
+      : aRoot.replace(/\/$/, '') + '/' + aPath;
   }
   exports.join = join;
 
@@ -52,7 +52,8 @@ define(function (require, exports, module) {
   exports.toSetString = toSetString;
 
   function relative(aRoot, aPath) {
-    return aPath.indexOf(aRoot.replace(/\/*$/, '') + '/') === 0
+    aRoot = aRoot.replace(/\/$/, '');
+    return aPath.indexOf(aRoot + '/') === 0
       ? aPath.substr(aRoot.length + 1)
       : aPath;
   }


### PR DESCRIPTION
fixed a bug in relative if root has "/" postfix.

Only remove a single "/" from root.
Elsewise it fails at:
root = "http://"
path = "www.example.com"
-> "http:/www.example.com" :(
correct is "http://www.example.com" :)
