### PR TITLE
Always pass `require` through to amdefine

### DIFF
--- a/lib/source-map/array-set.js
+++ b/lib/source-map/array-set.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/lib/source-map/base64-vlq.js
+++ b/lib/source-map/base64-vlq.js
@@ -35,7 +35,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/lib/source-map/base64.js
+++ b/lib/source-map/base64.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/lib/source-map/binary-search.js
+++ b/lib/source-map/binary-search.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/lib/source-map/source-map-generator.js
+++ b/lib/source-map/source-map-generator.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/lib/source-map/source-node.js
+++ b/lib/source-map/source-node.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/lib/source-map/util.js
+++ b/lib/source-map/util.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/test/source-map/test-api.js
+++ b/test/source-map/test-api.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/test/source-map/test-array-set.js
+++ b/test/source-map/test-array-set.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/test/source-map/test-base64-vlq.js
+++ b/test/source-map/test-base64-vlq.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/test/source-map/test-base64.js
+++ b/test/source-map/test-base64.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/test/source-map/test-binary-search.js
+++ b/test/source-map/test-binary-search.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/test/source-map/test-dog-fooding.js
+++ b/test/source-map/test-dog-fooding.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/test/source-map/test-source-map-consumer.js
+++ b/test/source-map/test-source-map-consumer.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/test/source-map/test-source-map-generator.js
+++ b/test/source-map/test-source-map-generator.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/test/source-map/test-source-node.js
+++ b/test/source-map/test-source-node.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 

--- a/test/source-map/util.js
+++ b/test/source-map/util.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 if (typeof define !== 'function') {
-    var define = require('amdefine')(module);
+    var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
 


### PR DESCRIPTION
amdefine allows you to provide an explicit `require` function. source-maps threads whatever require function is made available to it through to amdefine rather than having amdefine try to pluck one out of the environment.

This allows source-map to be bundled for browser-side consumption via browserify.
