### PR TITLE
Fix SourceNode.fromStringWithSourceMap for empty maps.

### DIFF
--- a/lib/source-map/source-node.js
+++ b/lib/source-map/source-node.js
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
       return node;
 
       function addMappingWithCode(mapping, code) {
-        if (mapping.source === undefined) {
+        if (mapping === null || mapping.source === undefined) {
           node.add(code);
         } else {
           node.add(new SourceNode(mapping.originalLine,

--- a/test/source-map/test-source-node.js
+++ b/test/source-map/test-source-node.js
@@ -207,6 +207,25 @@ define(function (require, exports, module) {
     assert.equal(map.mappings, util.testMap.mappings);
   };
 
+  exports['test .fromStringWithSourceMap() empty map'] = function (assert, util) {
+    var node = SourceNode.fromStringWithSourceMap(
+                              util.testGeneratedCode,
+                              new SourceMapConsumer(util.emptyMap));
+    var result = node.toStringWithSourceMap({
+      file: 'min.js'
+    });
+    var map = result.map;
+    var code = result.code;
+
+    assert.equal(code, util.testGeneratedCode);
+    assert.ok(map instanceof SourceMapGenerator, 'map instanceof SourceMapGenerator');
+    map = map.toJSON();
+    assert.equal(map.version, util.emptyMap.version);
+    assert.equal(map.file, util.emptyMap.file);
+    assert.equal(map.mappings.length, util.emptyMap.mappings.length);
+    assert.equal(map.mappings, util.emptyMap.mappings);
+  };
+
   exports['test .fromStringWithSourceMap() complex version'] = function (assert, util) {
     var input = new SourceNode(null, null, null, [
       "(function() {\n",

--- a/test/source-map/util.js
+++ b/test/source-map/util.js
@@ -56,6 +56,14 @@ define(function (require, exports, module) {
     sourceRoot: '/the/root',
     mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
   };
+  exports.emptyMap = {
+    version: 3,
+    file: 'min.js',
+    names: [],
+    sources: [],
+    mappings: ''
+  };
+
 
   function assertMapping(generatedLine, generatedColumn, originalSource,
                          originalLine, originalColumn, name, map, assert,


### PR DESCRIPTION
Without this fix, if aSourceMapConsumer.eachMapping executes its callback zero
times, the lastMapping passed to the "remaining code" call to addMappingWithCode
will be null, causing a crash.
