### PR TITLE
Fix source-map breaking on PhantomJS where bind isn't available

### DIFF
--- a/build/mini-require.js
+++ b/build/mini-require.js
@@ -6,6 +6,19 @@
  */
 
 /**
+ * Environment such PhantomJS 1.8.* does not provides the bind method on Function prototype.
+ * This shim will ensure that source-map will not break when running on PhantomJS.
+ */
+if(!Function.prototype.bind) {
+  Function.prototype.bind = function(scope){
+    var self = this;
+    return function(){ 
+      return self.apply(scope, arguments); 
+    };
+  }
+}
+
+/**
  * Define a module along with a payload.
  * @param {string} moduleName Name for the payload
  * @param {ignored} deps Ignored. For compatibility with CommonJS AMD Spec


### PR DESCRIPTION
PhantomJS (1.9.1 and below) does not provides the `Function.prototype.bind` method. Since PhantomJS is already
used in production in CI environment such TravisCI it may be simpler for source-map to have a shim rather than waiting for
PhantomJS to fix that.
