### PR TITLE
Support for workers

### DIFF
--- a/build/suffix-browser.js
+++ b/build/suffix-browser.js
@@ -1,7 +1,7 @@
 /* -*- Mode: js; js-indent-level: 2; -*- */
 ///////////////////////////////////////////////////////////////////////////////
 
-window.sourceMap = {
+this.sourceMap = {
   SourceMapConsumer: require('source-map/source-map-consumer').SourceMapConsumer,
   SourceMapGenerator: require('source-map/source-map-generator').SourceMapGenerator,
   SourceNode: require('source-map/source-node').SourceNode


### PR DESCRIPTION
Assign 'sourceMap' to 'this' instead of 'window' so that browser builds work inside workers.

r? @robcee
