### PR TITLE
allow 'names' to be undefined, default to an empty array

### DIFF
--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -52,7 +52,7 @@ define(function (require, exports, module) {
 
     var version = util.getArg(sourceMap, 'version');
     var sources = util.getArg(sourceMap, 'sources');
-    var names = util.getArg(sourceMap, 'names');
+    var names = util.getArg(sourceMap, 'names', []); // Sass 3.3 leaves out 'names'
     var sourceRoot = util.getArg(sourceMap, 'sourceRoot', null);
     var sourcesContent = util.getArg(sourceMap, 'sourcesContent', null);
     var mappings = util.getArg(sourceMap, 'mappings');


### PR DESCRIPTION
SASS currently generates source maps without a 'names' property.
