### PR TITLE
allow 'version' to be a string

### DIFF
--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
     var mappings = util.getArg(sourceMap, 'mappings');
     var file = util.getArg(sourceMap, 'file', null);
 
-    if (version !== this._version) {
+    if (version != this._version) {
       throw new Error('Unsupported version: ' + version);
     }
 


### PR DESCRIPTION
Sass 3.3 uses a string 'version' property.
