### PR TITLE
Add component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,20 @@
+{
+  "name": "source-map",
+  "repo": "mozilla/source-map",
+  "version": "0.1.31",
+  "main": "lib/source-map.js",
+  "scripts": [
+    "lib/source-map.js",
+    "lib/source-map/array-set.js",
+    "lib/source-map/base64-vlq.js",
+    "lib/source-map/base64.js",
+    "lib/source-map/binary-search.js",
+    "lib/source-map/source-map-consumer.js",
+    "lib/source-map/source-map-generator.js",
+    "lib/source-map/source-node.js",
+    "lib/source-map/util.js"
+  ],
+  "dependencies": {
+    "jrburke/amdefine": ">=0.0.4"
+  }
+}


### PR DESCRIPTION
TJ’s [Component](https://github.com/component/component/wiki/F.A.Q) is a great tool to build standalone JS from npm package (to work in browser or any non-node environments).

For example, [Autoprefixer](https://github.com/ai/autoprefixer) uses Component to pack all it files and npm dependencies in one `autoprefixer.js` and run it in `autoprefixer-rails` (Autoprefixer integration to Rails/Ruby). It is necessary, because JS runtime in Ruby doesn’t work with file system and doesn’t have `require()`.

To support Component you need only `component.json` (like `bower.json`) in project repo (no special publish commands).

A lot of npm libraries contains `component.js`: underscore, mocha, async, jade.

I make this pull request, because Autoprefixer 1.0 will use `source-map` and `component.json` in `source-map` is required to build `autoprefixer-rails` standalone file.
