### PR TITLE
Follow the spec: Mappings end at EOL

### DIFF
--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -312,7 +312,7 @@ define(function (require, exports, module) {
                                       "generatedColumn",
                                       util.compareByGeneratedPositions);
 
-      if (mapping) {
+      if (mapping && mapping.generatedLine === needle.generatedLine) {
         var source = util.getArg(mapping, 'source', null);
         if (source && this.sourceRoot) {
           source = util.join(this.sourceRoot, source);

--- a/test/source-map/test-dog-fooding.js
+++ b/test/source-map/test-dog-fooding.js
@@ -42,6 +42,12 @@ define(function (require, exports, module) {
       generated: { line: 5, column: 2 }
     });
 
+    smg.addMapping({
+      source: 'gza.coffee',
+      original: { line: 5, column: 10 },
+      generated: { line: 6, column: 12 }
+    });
+
     var smc = new SourceMapConsumer(smg.toString());
 
     // Exact
@@ -49,24 +55,30 @@ define(function (require, exports, module) {
     util.assertMapping(3, 2, '/wu/tang/gza.coffee', 2, 0, null, smc, assert);
     util.assertMapping(4, 2, '/wu/tang/gza.coffee', 3, 0, null, smc, assert);
     util.assertMapping(5, 2, '/wu/tang/gza.coffee', 4, 0, null, smc, assert);
+    util.assertMapping(6, 12, '/wu/tang/gza.coffee', 5, 10, null, smc, assert);
 
     // Fuzzy
 
-    // Original to generated
+    // Generated to original
     util.assertMapping(2, 0, null, null, null, null, smc, assert, true);
     util.assertMapping(2, 9, '/wu/tang/gza.coffee', 1, 0, null, smc, assert, true);
-    util.assertMapping(3, 0, '/wu/tang/gza.coffee', 1, 0, null, smc, assert, true);
+    util.assertMapping(3, 0, null, null, null, null, smc, assert, true);
     util.assertMapping(3, 9, '/wu/tang/gza.coffee', 2, 0, null, smc, assert, true);
-    util.assertMapping(4, 0, '/wu/tang/gza.coffee', 2, 0, null, smc, assert, true);
+    util.assertMapping(4, 0, null, null, null, null, smc, assert, true);
     util.assertMapping(4, 9, '/wu/tang/gza.coffee', 3, 0, null, smc, assert, true);
-    util.assertMapping(5, 0, '/wu/tang/gza.coffee', 3, 0, null, smc, assert, true);
+    util.assertMapping(5, 0, null, null, null, null, smc, assert, true);
     util.assertMapping(5, 9, '/wu/tang/gza.coffee', 4, 0, null, smc, assert, true);
+    util.assertMapping(6, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(6, 9, null, null, null, null, smc, assert, true);
+    util.assertMapping(6, 13, '/wu/tang/gza.coffee', 5, 10, null, smc, assert, true);
 
-    // Generated to original
+    // Original to generated
     util.assertMapping(2, 2, '/wu/tang/gza.coffee', 1, 1, null, smc, assert, null, true);
     util.assertMapping(3, 2, '/wu/tang/gza.coffee', 2, 3, null, smc, assert, null, true);
     util.assertMapping(4, 2, '/wu/tang/gza.coffee', 3, 6, null, smc, assert, null, true);
     util.assertMapping(5, 2, '/wu/tang/gza.coffee', 4, 9, null, smc, assert, null, true);
+    util.assertMapping(5, 2, '/wu/tang/gza.coffee', 5, 9, null, smc, assert, null, true);
+    util.assertMapping(6, 12, '/wu/tang/gza.coffee', 6, 19, null, smc, assert, null, true);
   };
 
 });

--- a/test/source-map/test-source-map-consumer.js
+++ b/test/source-map/test-source-map-consumer.js
@@ -80,6 +80,30 @@ define(function (require, exports, module) {
     util.assertMapping(2, 9, '/the/root/two.js', 1, 16, null, map, assert, null, true);
   };
 
+  exports['test mappings and end of lines'] = function (assert, util) {
+    var smg = new SourceMapGenerator({
+      file: 'foo.js'
+    });
+    smg.addMapping({
+      original: { line: 1, column: 1 },
+      generated: { line: 1, column: 1 },
+      source: 'bar.js'
+    });
+    smg.addMapping({
+      original: { line: 2, column: 2 },
+      generated: { line: 2, column: 2 },
+      source: 'bar.js'
+    });
+
+    var map = SourceMapConsumer.fromSourceMap(smg);
+
+    // When finding original positions, mappings end at the end of the line.
+    util.assertMapping(2, 1, null, null, null, null, map, assert, true)
+
+    // When finding generated positions, mappings do not end at the end of the line.
+    util.assertMapping(1, 1, 'bar.js', 2, 1, null, map, assert, null, true);
+  };
+
   exports['test creating source map consumers with )]}\' prefix'] = function (assert, util) {
     assert.doesNotThrow(function () {
       var map = new SourceMapConsumer(")]}'" + JSON.stringify(util.testMap));


### PR DESCRIPTION
This is to follow the spec.

As discussed in the [mailing list](https://groups.google.com/forum/#!topic/mozilla.dev.js-sourcemap/Uo26hB5v5oY), when getting original positions,
mappings end at the end of the line. However, when getting generated
positions, mappings do not end at the end of the line.

Getting original positions:

For a generated position (L,C), find a mapping (L,X) such that X<=C and
X is as great as possible. If no such mapping can be found, then there
is no mapping for (L,C). This is because according to the spec, mappings
end at the end of the line. Previously, we used to look for mappings on
lines <L too.

Getting generated positions:

For a generated position (L,C), find a mapping (A,B) such that A<=L, A
is as great as possible, B<=C and B is as great as possible. If there
are multiple such mappings, I don't know which is or should be chosen.
The spec doesn't say anything about it. The idea is at least that
multiline source statements usually (ideally) only have a mapping at the
beginning of the multiline statement. Then it is convienient to be able
to get the generated position even if you're not at the first line.

Note that this change is backwards incompatible. There were even tests
for the faulty behavior in test/source-map/test-dogfooding.js! I had to
change them, which of course breaks backwards compatibility.
