### PR TITLE
Ensure that _generatedMappings is always sorted

### DIFF
--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -257,6 +257,7 @@ define(function (require, exports, module) {
         }
       }
 
+      this.__generatedMappings.sort(util.compareByGeneratedPositions);
       this.__originalMappings.sort(util.compareByOriginalPositions);
     };
 


### PR DESCRIPTION
Note that, eg, `SourceNode.fromStringWithSourceMap` depends on this
property. It implicitly assumes that generatedColumn is non-decreasing
within a line, and ends up passing negative numbers to substr otherwise!  (So given such a map, round-tripping a source file through `fromStringWithSourceMap` and `toString` can actually corrupt the original file!)

I discovered this because a user presented me with a source map generated by ClojureScript (I think) which had non-monotonic generated columns: https://raw2.github.com/mystor/meteor-sourcemap-bug/master/client.cjs.map https://github.com/meteor/meteor/issues/1782

I really can't tell from reading the spec if this violates the spec!

I realize that there's something minorly sketchy about doing this sort, since source maps describe ranges using the adjacency of mappings.  I'm really not sure what the overlapping ranges described by the map file our user has are supposed to represent!  But it seems pretty bad for `_generatedMappings` to not be sorted given that `fromStringWithSourceMap` really assumes that it is.
