### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ column information associated between those snippets and the original source
 code. This is useful as the final intermediate representation a compiler might
 use before outputting the generated JS and source map.
 
-#### new SourceNode(line, column, source[, chunk[, name]])
+#### new SourceNode([line, column, source[, chunk[, name]]])
 
 * `line`: The original line number associated with this source node, or null if
   it isn't associated with an original line.
@@ -314,7 +314,7 @@ use before outputting the generated JS and source map.
 * `column`: The original column number associated with this source node, or null
   if it isn't associated with an original column.
 
-* `source`: The original source's filename.
+* `source`: The original source's filename; null if no filename is provided.
 
 * `chunk`: Optional. Is immediately passed to `SourceNode.prototype.add`, see
   below.


### PR DESCRIPTION
This is minor, but the docs suggest that the first three arguments of `sourceNode` are required when in reality [they all seem to be optional](https://github.com/mozilla/source-map/blob/master/lib/source-map/source-node.js#L27-L35), by which I mean that no error is thrown when you simply have `var x = new SourceNode();` before working with the node.
