### PR TITLE
Make SourceNodes work with other newlines than \n

### DIFF
--- a/lib/source-map/source-node.js
+++ b/lib/source-map/source-node.js
@@ -12,11 +12,9 @@ define(function (require, exports, module) {
   var SourceMapGenerator = require('./source-map-generator').SourceMapGenerator;
   var util = require('./util');
 
-  // Matches one of the following newlines (capturing the result):
-  // - `\r\n` (Windows)
-  // - `\r` (Old Macs)
-  // - `\n` (unix and new Macs)
-  var REGEX_NEWLINE = /(\r\n?|\n)/g;
+  // Matches a Windows-style `\r\n` newline or a `\n` newline used by all other
+  // operating systems these days (capturing the result).
+  var REGEX_NEWLINE = /(\r?\n)/g;
 
   // Matches a Windows-style newline, or any character.
   var REGEX_CHARACTER = /\r\n|[\s\S]/g;

--- a/test/source-map/test-source-node.js
+++ b/test/source-map/test-source-node.js
@@ -15,7 +15,7 @@ define(function (require, exports, module) {
 
   function forEachNewline(fn) {
     return function (assert, util) {
-      ['\n', '\r', '\r\n'].forEach(fn.bind(null, assert, util));
+      ['\n', '\r\n'].forEach(fn.bind(null, assert, util));
     }
   }
 


### PR DESCRIPTION
- Makes `.toStringWithSourceMap()` work correctly with other newlines.
- Makes `.fromStringWithSourceMap()` preserve the newlines of the input.
  This is useful when using SourceNodes to concatenate files with source
  map support, without modifying the files.
