### PR TITLE
Don’t add `file` property if no file was given

### DIFF
--- a/lib/source-map/source-map-generator.js
+++ b/lib/source-map/source-map-generator.js
@@ -369,11 +369,13 @@ define(function (require, exports, module) {
     function SourceMapGenerator_toJSON() {
       var map = {
         version: this._version,
-        file: this._file,
         sources: this._sources.toArray(),
         names: this._names.toArray(),
         mappings: this._serializeMappings()
       };
+      if (this._file != null) {
+        map.file = this._file;
+      }
       if (this._sourceRoot) {
         map.sourceRoot = this._sourceRoot;
       }

--- a/test/source-map/test-source-map-generator.js
+++ b/test/source-map/test-source-map-generator.js
@@ -21,8 +21,9 @@ define(function (require, exports, module) {
     });
     assert.ok(true);
 
-    var map = new SourceMapGenerator();
-    assert.ok(true);
+    var map = new SourceMapGenerator().toJSON();
+    assert.ok(!('file' in map));
+    assert.ok(!('sourceRoot' in map));
   };
 
   exports['test JSON serialization'] = function (assert, util) {

--- a/test/source-map/test-source-node.js
+++ b/test/source-map/test-source-node.js
@@ -144,6 +144,7 @@ define(function (require, exports, module) {
 
     assert.ok(map instanceof SourceMapGenerator, 'map instanceof SourceMapGenerator');
     assert.ok(mapWithoutOptions instanceof SourceMapGenerator, 'mapWithoutOptions instanceof SourceMapGenerator');
+    assert.ok(!('file' in mapWithoutOptions));
     mapWithoutOptions._file = 'foo.js';
     util.assertEqualMaps(assert, map.toJSON(), mapWithoutOptions.toJSON());
 


### PR DESCRIPTION
Previously, if you didn’t pass the `file` option to
`new SourceMapGenerator()` or
`SourceNode.prototype.toStringWithSourceMap()`, `"file": null` would be
present in the source map. Now, the file property isn’t added at all
instead, which is more intuitive.
