### PR TITLE
Add a third parameter to `SourceNode.fromStringWithSourceMap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,13 +332,16 @@ use before outputting the generated JS and source map.
 
 * `name`: Optional. The original identifier.
 
-#### SourceNode.fromStringWithSourceMap(code, sourceMapConsumer)
+#### SourceNode.fromStringWithSourceMap(code, sourceMapConsumer[, relativePath])
 
 Creates a SourceNode from generated code and a SourceMapConsumer.
 
 * `code`: The generated code
 
 * `sourceMapConsumer` The SourceMap for the generated code
+
+* `relativePath` The optional path that relative sources in `sourceMapConsumer`
+  should be relative to.
 
 #### SourceNode.prototype.add(chunk)
 

--- a/lib/source-map/source-node.js
+++ b/lib/source-map/source-node.js
@@ -46,9 +46,11 @@ define(function (require, exports, module) {
    *
    * @param aGeneratedCode The generated code
    * @param aSourceMapConsumer The SourceMap for the generated code
+   * @param aRelativePath Optional. The path that relative sources in the
+   *        SourceMapConsumer should be relative to.
    */
   SourceNode.fromStringWithSourceMap =
-    function SourceNode_fromStringWithSourceMap(aGeneratedCode, aSourceMapConsumer) {
+    function SourceNode_fromStringWithSourceMap(aGeneratedCode, aSourceMapConsumer, aRelativePath) {
       // The SourceNode we want to fill with the generated code
       // and the SourceMap
       var node = new SourceNode();
@@ -129,6 +131,9 @@ define(function (require, exports, module) {
       aSourceMapConsumer.sources.forEach(function (sourceFile) {
         var content = aSourceMapConsumer.sourceContentFor(sourceFile);
         if (content) {
+          if (aRelativePath != null) {
+            sourceFile = util.join(aRelativePath, sourceFile);
+          }
           node.setSourceContent(sourceFile, content);
         }
       });
@@ -139,9 +144,12 @@ define(function (require, exports, module) {
         if (mapping === null || mapping.source === undefined) {
           node.add(code);
         } else {
+          var source = aRelativePath
+            ? util.join(aRelativePath, mapping.source)
+            : mapping.source;
           node.add(new SourceNode(mapping.originalLine,
                                   mapping.originalColumn,
-                                  mapping.source,
+                                  source,
                                   code,
                                   mapping.name));
         }


### PR DESCRIPTION
An important use case for `SourceNode`s, and especially for
`SourceNode.fromStringWithSourceMap`, is to concatenate files with
source map support. This works well as long as all the input source maps
and the concatenated file¿s source map are next to each other. That’s
because any relative source paths in any input source map have to be
rewritten to be relative to the concatenated file’s source map. This
commit adds a third parameter to `SourceNode.fromStringWithSourceMap`
allowing you to do this.
