### PR TITLE
Fix #123: Empty string as sourceRoot

### DIFF
--- a/lib/source-map/util.js
+++ b/lib/source-map/util.js
@@ -143,6 +143,12 @@ define(function (require, exports, module) {
    * - Joining for example 'http://' and 'www.example.com' is also supported.
    */
   function join(aRoot, aPath) {
+    if (aRoot === "") {
+      aRoot = ".";
+    }
+    if (aPath === "") {
+      aPath = ".";
+    }
     var aPathUrl = urlParse(aPath);
     var aRootUrl = urlParse(aRoot);
     if (aRootUrl) {
@@ -180,6 +186,27 @@ define(function (require, exports, module) {
   exports.join = join;
 
   /**
+   * Make a path relative to a URL or another path.
+   *
+   * @param aRoot The root path or URL.
+   * @param aPath The path or URL to be made relative to aRoot.
+   */
+  function relative(aRoot, aPath) {
+    aRoot = aRoot.replace(/\/$/, '');
+
+    // XXX: It is possible to remove this block, and the tests still pass!
+    var url = urlParse(aRoot);
+    if (aPath.charAt(0) == "/" && url && url.path == "/") {
+      return aPath.slice(1);
+    }
+
+    return aPath.indexOf(aRoot + '/') === 0
+      ? aPath.substr(aRoot.length + 1)
+      : aPath;
+  }
+  exports.relative = relative;
+
+  /**
    * Because behavior goes wacky when you set `__proto__` on objects, we
    * have to prefix all the strings in our set with an arbitrary character.
    *
@@ -197,20 +224,6 @@ define(function (require, exports, module) {
     return aStr.substr(1);
   }
   exports.fromSetString = fromSetString;
-
-  function relative(aRoot, aPath) {
-    aRoot = aRoot.replace(/\/$/, '');
-
-    var url = urlParse(aRoot);
-    if (aPath.charAt(0) == "/" && url && url.path == "/") {
-      return aPath.slice(1);
-    }
-
-    return aPath.indexOf(aRoot + '/') === 0
-      ? aPath.substr(aRoot.length + 1)
-      : aPath;
-  }
-  exports.relative = relative;
 
   function strcmp(aStr1, aStr2) {
     var s1 = aStr1 || "";

--- a/test/source-map/test-source-map-generator.js
+++ b/test/source-map/test-source-map-generator.js
@@ -293,8 +293,8 @@ define(function (require, exports, module) {
     //       foo.coffee
     //     temp/
     //       bundle.js
-    //     temp_maps/
-    //       bundle.js.map
+    //       temp_maps/
+    //         bundle.js.map
     //     public/
     //       bundle.min.js
     //       bundle.min.js.map
@@ -308,9 +308,9 @@ define(function (require, exports, module) {
     bundleMap.addMapping({
       generated: { line: 3, column: 3 },
       original: { line: 2, column: 2 },
-      source: '../coffee/foo.coffee'
+      source: '../../coffee/foo.coffee'
     });
-    bundleMap.setSourceContent('../coffee/foo.coffee', 'foo coffee');
+    bundleMap.setSourceContent('../../coffee/foo.coffee', 'foo coffee');
     bundleMap.addMapping({
       generated: { line: 13, column: 13 },
       original: { line: 12, column: 12 },
@@ -383,21 +383,48 @@ define(function (require, exports, module) {
       return map.toJSON();
     }
 
-    util.assertEqualMaps(assert, actualMap('../temp_maps'), expectedMap([
+    util.assertEqualMaps(assert, actualMap('../temp/temp_maps'), expectedMap([
       'coffee/foo.coffee',
       '/bar.coffee',
       'http://www.example.com/baz.coffee'
     ]));
 
-    util.assertEqualMaps(assert, actualMap('/app/temp_maps'), expectedMap([
+    util.assertEqualMaps(assert, actualMap('/app/temp/temp_maps'), expectedMap([
       '/app/coffee/foo.coffee',
       '/bar.coffee',
       'http://www.example.com/baz.coffee'
     ]));
 
-    util.assertEqualMaps(assert, actualMap('http://foo.org/app/temp_maps'), expectedMap([
+    util.assertEqualMaps(assert, actualMap('http://foo.org/app/temp/temp_maps'), expectedMap([
       'http://foo.org/app/coffee/foo.coffee',
       'http://foo.org/bar.coffee',
+      'http://www.example.com/baz.coffee'
+    ]));
+
+    // If the third parameter is omitted or set to the current working
+    // directory we get incorrect source paths:
+
+    util.assertEqualMaps(assert, actualMap(), expectedMap([
+      '../coffee/foo.coffee',
+      '/bar.coffee',
+      'http://www.example.com/baz.coffee'
+    ]));
+
+    util.assertEqualMaps(assert, actualMap(''), expectedMap([
+      '../coffee/foo.coffee',
+      '/bar.coffee',
+      'http://www.example.com/baz.coffee'
+    ]));
+
+    util.assertEqualMaps(assert, actualMap('.'), expectedMap([
+      '../coffee/foo.coffee',
+      '/bar.coffee',
+      'http://www.example.com/baz.coffee'
+    ]));
+
+    util.assertEqualMaps(assert, actualMap('./'), expectedMap([
+      '../coffee/foo.coffee',
+      '/bar.coffee',
       'http://www.example.com/baz.coffee'
     ]));
   };

--- a/test/source-map/test-util.js
+++ b/test/source-map/test-util.js
@@ -28,7 +28,14 @@ define(function (require, exports, module) {
     assertUrl('//www.example.com');
     assertUrl('file:///www.example.com');
 
+    assert.equal(libUtil.urlParse(''), null);
+    assert.equal(libUtil.urlParse('.'), null);
+    assert.equal(libUtil.urlParse('..'), null);
+    assert.equal(libUtil.urlParse('a'), null);
+    assert.equal(libUtil.urlParse('a/b'), null);
     assert.equal(libUtil.urlParse('a//b'), null);
+    assert.equal(libUtil.urlParse('/a'), null);
+    assert.equal(libUtil.urlParse('data:foo,bar'), null);
   };
 
   exports['test normalize()'] = function (assert, util) {
@@ -50,6 +57,7 @@ define(function (require, exports, module) {
     assert.equal(libUtil.normalize('/././././a/b/c'), '/a/b/c');
     assert.equal(libUtil.normalize('/a/b/c/./././d/././e'), '/a/b/c/d/e');
 
+    assert.equal(libUtil.normalize(''), '.');
     assert.equal(libUtil.normalize('.'), '.');
     assert.equal(libUtil.normalize('./'), '.');
     assert.equal(libUtil.normalize('././a'), 'a');
@@ -88,6 +96,73 @@ define(function (require, exports, module) {
     assert.equal(libUtil.join('a', 'data:foo,bar'), 'data:foo,bar');
 
 
+    assert.equal(libUtil.join('', 'b'), 'b');
+    assert.equal(libUtil.join('.', 'b'), 'b');
+    assert.equal(libUtil.join('', 'b/'), 'b/');
+    assert.equal(libUtil.join('.', 'b/'), 'b/');
+    assert.equal(libUtil.join('', 'b//'), 'b/');
+    assert.equal(libUtil.join('.', 'b//'), 'b/');
+
+    assert.equal(libUtil.join('', '..'), '..');
+    assert.equal(libUtil.join('.', '..'), '..');
+    assert.equal(libUtil.join('', '../b'), '../b');
+    assert.equal(libUtil.join('.', '../b'), '../b');
+
+    assert.equal(libUtil.join('', '.'), '.');
+    assert.equal(libUtil.join('.', '.'), '.');
+    assert.equal(libUtil.join('', './b'), 'b');
+    assert.equal(libUtil.join('.', './b'), 'b');
+
+    assert.equal(libUtil.join('', 'http://www.example.com'), 'http://www.example.com');
+    assert.equal(libUtil.join('.', 'http://www.example.com'), 'http://www.example.com');
+    assert.equal(libUtil.join('', 'data:foo,bar'), 'data:foo,bar');
+    assert.equal(libUtil.join('.', 'data:foo,bar'), 'data:foo,bar');
+
+
+    assert.equal(libUtil.join('..', 'b'), '../b');
+    assert.equal(libUtil.join('..', 'b/'), '../b/');
+    assert.equal(libUtil.join('..', 'b//'), '../b/');
+
+    assert.equal(libUtil.join('..', '..'), '../..');
+    assert.equal(libUtil.join('..', '../b'), '../../b');
+
+    assert.equal(libUtil.join('..', '.'), '..');
+    assert.equal(libUtil.join('..', './b'), '../b');
+
+    assert.equal(libUtil.join('..', 'http://www.example.com'), 'http://www.example.com');
+    assert.equal(libUtil.join('..', 'data:foo,bar'), 'data:foo,bar');
+
+
+    assert.equal(libUtil.join('a', ''), 'a');
+    assert.equal(libUtil.join('a', '.'), 'a');
+    assert.equal(libUtil.join('a/', ''), 'a');
+    assert.equal(libUtil.join('a/', '.'), 'a');
+    assert.equal(libUtil.join('a//', ''), 'a');
+    assert.equal(libUtil.join('a//', '.'), 'a');
+    assert.equal(libUtil.join('/a', ''), '/a');
+    assert.equal(libUtil.join('/a', '.'), '/a');
+    assert.equal(libUtil.join('', ''), '.');
+    assert.equal(libUtil.join('.', ''), '.');
+    assert.equal(libUtil.join('.', ''), '.');
+    assert.equal(libUtil.join('.', '.'), '.');
+    assert.equal(libUtil.join('..', ''), '..');
+    assert.equal(libUtil.join('..', '.'), '..');
+    assert.equal(libUtil.join('http://foo.org/a', ''), 'http://foo.org/a');
+    assert.equal(libUtil.join('http://foo.org/a', '.'), 'http://foo.org/a');
+    assert.equal(libUtil.join('http://foo.org/a/', ''), 'http://foo.org/a');
+    assert.equal(libUtil.join('http://foo.org/a/', '.'), 'http://foo.org/a');
+    assert.equal(libUtil.join('http://foo.org/a//', ''), 'http://foo.org/a');
+    assert.equal(libUtil.join('http://foo.org/a//', '.'), 'http://foo.org/a');
+    assert.equal(libUtil.join('http://foo.org', ''), 'http://foo.org/');
+    assert.equal(libUtil.join('http://foo.org', '.'), 'http://foo.org/');
+    assert.equal(libUtil.join('http://foo.org/', ''), 'http://foo.org/');
+    assert.equal(libUtil.join('http://foo.org/', '.'), 'http://foo.org/');
+    assert.equal(libUtil.join('http://foo.org//', ''), 'http://foo.org/');
+    assert.equal(libUtil.join('http://foo.org//', '.'), 'http://foo.org/');
+    assert.equal(libUtil.join('//www.example.com', ''), '//www.example.com/');
+    assert.equal(libUtil.join('//www.example.com', '.'), '//www.example.com/');
+
+
     assert.equal(libUtil.join('http://foo.org/a', 'b'), 'http://foo.org/a/b');
     assert.equal(libUtil.join('http://foo.org/a/', 'b'), 'http://foo.org/a/b');
     assert.equal(libUtil.join('http://foo.org/a//', 'b'), 'http://foo.org/a/b');
@@ -122,6 +197,12 @@ define(function (require, exports, module) {
 
     assert.equal(libUtil.join('http://www.example.com', '//foo.org/bar'), 'http://foo.org/bar');
     assert.equal(libUtil.join('//www.example.com', '//foo.org/bar'), '//foo.org/bar');
+  };
+
+  // TODO Issue #128: Define and test this function properly.
+  exports['test relative()'] = function (assert, util) {
+    assert.equal(libUtil.relative('/the/root', '/the/root/one.js'), 'one.js');
+    assert.equal(libUtil.relative('/the/root', '/the/rootone.js'), '/the/rootone.js');
   };
 
 });

--- a/test/source-map/util.js
+++ b/test/source-map/util.js
@@ -40,6 +40,21 @@ define(function (require, exports, module) {
     sourceRoot: '/the/root',
     mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
   };
+  exports.testMapNoSourceRoot = {
+    version: 3,
+    file: 'min.js',
+    names: ['bar', 'baz', 'n'],
+    sources: ['one.js', 'two.js'],
+    mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
+  };
+  exports.testMapEmptySourceRoot = {
+    version: 3,
+    file: 'min.js',
+    names: ['bar', 'baz', 'n'],
+    sources: ['one.js', 'two.js'],
+    sourceRoot: '',
+    mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
+  };
   exports.testMapWithSourcesContent = {
     version: 3,
     file: 'min.js',


### PR DESCRIPTION
Setting the `sourceRoot` property of a source-map to the empty string
incorrectly made relative sources absolute, due to a bug in `util.join`.
Now, setting the `sourceRoot` to the empty string is equivalent to
setting it to `.`, which in turn is equivalent to omitting the property
altogether.

This commit fixes the handling of empty strings in `util.join`, and adds
test cases for it. Since `util.normalize` and `util.urlParse` are used
by `util.join` they got a couple of new tests as well. Finally, all code
that uses `util.join` had their tests updated to test for empty strings
as well.

Note that this commit might not solve _all_ bugs related to the
`sourceRoot` being an empty string, since `sourceRoot` is often also
used together with `util.relative`. However, fixing that is a different
issue. I added TODO comments and a few initial tests, though, so it
won’t be forgotten.
