### PR TITLE
Handle empty root in util.relative

### DIFF
--- a/lib/source-map/util.js
+++ b/lib/source-map/util.js
@@ -192,6 +192,10 @@ define(function (require, exports, module) {
    * @param aPath The path or URL to be made relative to aRoot.
    */
   function relative(aRoot, aPath) {
+    if (aRoot === "") {
+      aRoot = ".";
+    }
+
     aRoot = aRoot.replace(/\/$/, '');
 
     // XXX: It is possible to remove this block, and the tests still pass!

--- a/test/source-map/test-util.js
+++ b/test/source-map/test-util.js
@@ -203,6 +203,14 @@ define(function (require, exports, module) {
   exports['test relative()'] = function (assert, util) {
     assert.equal(libUtil.relative('/the/root', '/the/root/one.js'), 'one.js');
     assert.equal(libUtil.relative('/the/root', '/the/rootone.js'), '/the/rootone.js');
+
+    assert.equal(libUtil.relative('', '/the/root/one.js'), '/the/root/one.js');
+    assert.equal(libUtil.relative('.', '/the/root/one.js'), '/the/root/one.js');
+    assert.equal(libUtil.relative('', 'the/root/one.js'), 'the/root/one.js');
+    assert.equal(libUtil.relative('.', 'the/root/one.js'), 'the/root/one.js');
+
+    assert.equal(libUtil.relative('/', '/the/root/one.js'), 'the/root/one.js');
+    assert.equal(libUtil.relative('/', 'the/root/one.js'), 'the/root/one.js');
   };
 
 });


### PR DESCRIPTION
Re #128, an empty root passed to util.relative should return `aPath` as-is. This avoids stripping the leading `/` off of absolute file paths.

Since we don't know whether the empty string is a URL or a file path, we cannot make an assumption either way and should return the path unmodified.

See webpack/core#5 for context around this fix. Specifically, https://github.com/webpack/core/pull/5#issuecomment-50284072 and https://github.com/webpack/core/pull/5#issuecomment-50285215.
