### PR TITLE
fix TypeError when sourceContents is already deleted

### DIFF
--- a/lib/source-map/source-map-generator.js
+++ b/lib/source-map/source-map-generator.js
@@ -136,7 +136,7 @@ define(function (require, exports, module) {
           this._sourcesContents = {};
         }
         this._sourcesContents[util.toSetString(source)] = aSourceContent;
-      } else {
+      } else if (this._sourcesContents) {
         // Remove the source file from the _sourcesContents map.
         // If the _sourcesContents map is empty, set the property to null.
         delete this._sourcesContents[util.toSetString(source)];

--- a/test/source-map/test-source-map-generator.js
+++ b/test/source-map/test-source-map-generator.js
@@ -592,4 +592,11 @@ define(function (require, exports, module) {
     });
   };
 
+  exports['test setting sourcesContent to null when already null'] = function (assert, util) {
+    var smg = new SourceMapGenerator({ file: "foo.js" });
+    assert.doesNotThrow(function() {
+      smg.setSourceContent("bar.js", null);
+    });
+  };
+
 });


### PR DESCRIPTION
I'm seeing the following error when using `gulp-sourcemaps`, `gulp-less` and `gulp-concat` together:

```
/Users/montgomeryc/Projects/gulp-bundle-assets/node_modules/gulp-concat/node_modules/concat-with-sourcemaps/node_modules/source-map/lib/source-map/source-map-generator.js:143
        delete this._sourcesContents[util.toSetString(source)];
                                          ^
TypeError: Cannot convert null to object
    at SourceMapGenerator_setSourceContent [as setSourceContent] (/Users/montgomeryc/Projects/gulp-bundle-assets/node_modules/gulp-concat/node_modules/concat-with-sourcemaps/node_modules/source-map/lib/source-map/source-map-generator.js:143:43)
    at /Users/montgomeryc/Projects/gulp-bundle-assets/node_modules/gulp-concat/node_modules/concat-with-sourcemaps/index.js:63:28
    at Array.forEach (native)
    at Concat.add (/Users/montgomeryc/Projects/gulp-bundle-assets/node_modules/gulp-concat/node_modules/concat-with-sourcemaps/index.js:62:35)
    at Stream.bufferContents (/Users/montgomeryc/Projects/gulp-bundle-assets/node_modules/gulp-concat/index.js:25:12)
    at Stream.stream.write (/Users/montgomeryc/Projects/gulp-bundle-assets/node_modules/gulp-concat/node_modules/through/index.js:26:11)
    at write (/Users/montgomeryc/Projects/gulp-bundle-assets/node_modules/readable-stream/lib/_stream_readable.js:605:24)
    at flow (/Users/montgomeryc/Projects/gulp-bundle-assets/node_modules/readable-stream/lib/_stream_readable.js:614:7)
    at Transform.pipeOnReadable (/Users/montgomeryc/Projects/gulp-bundle-assets/node_modules/readable-stream/lib/_stream_readable.js:646:5)
    at Transform.emit (events.js:92:17)
```

Unsure why this is exactly happening but my change seems unobtrusive to the logic flow and results in my compiled less file and source map being created properly.

/cc @contra
