### PR TITLE
Fix "Issue #116." creating a heading in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@
   source map will no longer have a `null` file property. The property will
   simply not exist. Issue #104.
 
-* Fixed a bug where consecutive newlines were ignored in `SourceNode`s. Issue
-  #116.
+* Fixed a bug where consecutive newlines were ignored in `SourceNode`s.
+  Issue #116.
 
 ## 0.1.34
 


### PR DESCRIPTION
The CHANGELOG.md file wrapped a line so that "#116" started the line. This
caused it to create a heading, which is not the intended formatting.

I fixed this by wrapping the line differently.
