### PR TITLE
Add option to skip mapping validation in generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ You may pass an object with the following properties:
 
 * `sourceRoot`: A root for all relative URLs in this source map.
 
+* `skipValidation`: Optional flag to disable validation of mappings as they
+  are added. This can improve performance but should be used with discretion.
+  Even then one should avoid using when running tests, if possible.
+
 #### SourceMapGenerator.fromSourceMap(sourceMapConsumer)
 
 Creates a new SourceMapGenerator based on a SourceMapConsumer

--- a/lib/source-map/source-map-generator.js
+++ b/lib/source-map/source-map-generator.js
@@ -27,6 +27,7 @@ define(function (require, exports, module) {
     }
     this._file = util.getArg(aArgs, 'file', null);
     this._sourceRoot = util.getArg(aArgs, 'sourceRoot', null);
+    this._skipValidation = util.getArg(aArgs, 'skipValidation', false);
     this._sources = new ArraySet();
     this._names = new ArraySet();
     this._mappings = [];
@@ -99,7 +100,9 @@ define(function (require, exports, module) {
       var source = util.getArg(aArgs, 'source', null);
       var name = util.getArg(aArgs, 'name', null);
 
-      this._validateMapping(generated, original, source, name);
+      if (!this._skipValidation) {
+        this._validateMapping(generated, original, source, name);
+      }
 
       if (source != null && !this._sources.has(source)) {
         this._sources.add(source);

--- a/test/source-map/test-source-map-generator.js
+++ b/test/source-map/test-source-map-generator.js
@@ -98,6 +98,27 @@ define(function (require, exports, module) {
     });
   };
 
+  exports['test adding mappings with skipValidation'] = function (assert, util) {
+    var map = new SourceMapGenerator({
+      file: 'generated-foo.js',
+      sourceRoot: '.',
+      skipValidation: true
+    });
+
+    // Not enough info, caught by `util.getArgs`
+    assert.throws(function () {
+      map.addMapping({});
+    });
+
+    // Original file position, but no source. Not checked.
+    assert.doesNotThrow(function () {
+      map.addMapping({
+        generated: { line: 1, column: 1 },
+        original: { line: 1, column: 1 }
+      });
+    });
+  };
+
   exports['test that the correct mappings are being generated'] = function (assert, util) {
     var map = new SourceMapGenerator({
       file: 'min.js',


### PR DESCRIPTION
A performance boosting option for use in trusted contexts.

Extra context: #148