### PR TITLE
Remove RegExes in SourceNode.toStringWithSourceMap

### DIFF
--- a/lib/source-map/source-node.js
+++ b/lib/source-map/source-node.js
@@ -16,8 +16,8 @@ define(function (require, exports, module) {
   // operating systems these days (capturing the result).
   var REGEX_NEWLINE = /(\r?\n)/;
 
-  // Matches a Windows-style newline, or any character.
-  var REGEX_CHARACTER = /\r\n|[\s\S]/g;
+  // Newline character code for charCodeAt() comparisons
+  var NEWLINE_CODE = 10;
 
   // Private symbol for identifying `SourceNode`s when multiple versions of
   // the source-map library are loaded. This MUST NOT CHANGE across
@@ -375,12 +375,12 @@ define(function (require, exports, module) {
         lastOriginalSource = null;
         sourceMappingActive = false;
       }
-      chunk.match(REGEX_CHARACTER).forEach(function (ch, idx, array) {
-        if (REGEX_NEWLINE.test(ch)) {
+      for (var idx = 0, length = chunk.length; idx < length; idx++) {
+        if (chunk.charCodeAt(idx) === NEWLINE_CODE) {
           generated.line++;
           generated.column = 0;
           // Mappings end at eol
-          if (idx + 1 === array.length) {
+          if (idx + 1 === length) {
             lastOriginalSource = null;
             sourceMappingActive = false;
           } else if (sourceMappingActive) {
@@ -398,9 +398,9 @@ define(function (require, exports, module) {
             });
           }
         } else {
-          generated.column += ch.length;
+          generated.column++;
         }
-      });
+      }
     });
     this.walkSourceContents(function (sourceFile, sourceContent) {
       map.setSourceContent(sourceFile, sourceContent);


### PR DESCRIPTION
Faster implementation that passes all tests.  I made some [jsperf.com benchmarks](http://jsperf.com/match-vs-replace-split) that measure the discrete changes.  The remaining use of `REGEX_NEWLINE` could be replaced with the same `replace("\r\n","\n").split('')` approach and be *supremely* faster in SpiderMonkey, but slightly slower in V8.  Given that it's likely most source map generation is happening in node.js processes it seems better to optimize for that case.