### PR TITLE
make toString explicitly call toJSON, fixes #156

### DIFF
--- a/lib/source-map/source-map-generator.js
+++ b/lib/source-map/source-map-generator.js
@@ -392,7 +392,7 @@ define(function (require, exports, module) {
    */
   SourceMapGenerator.prototype.toString =
     function SourceMapGenerator_toString() {
-      return JSON.stringify(this);
+      return JSON.stringify(this.toJSON());
     };
 
   exports.SourceMapGenerator = SourceMapGenerator;


### PR DESCRIPTION
If the client system has remapped JSON to something else,
`generator.toString()` may not call `generator.toJSON()`,
so this change makes the call to `toJSON()` explicit to
make toString more robust in this case.