### PR TITLE
Improve the performance of parseMappings.

### DIFF
--- a/lib/source-map/base64-vlq.js
+++ b/lib/source-map/base64-vlq.js
@@ -117,18 +117,17 @@ define(function (require, exports, module) {
    * Decodes the next base 64 VLQ value from the given string and returns the
    * value and the rest of the string via the out parameter.
    */
-  exports.decode = function base64VLQ_decode(aStr, aOutParam) {
-    var i = 0;
+  exports.decode = function base64VLQ_decode(aStr, aIndex, aOutParam) {
     var strLen = aStr.length;
     var result = 0;
     var shift = 0;
     var continuation, digit;
 
     do {
-      if (i >= strLen) {
+      if (aIndex >= strLen) {
         throw new Error("Expected more digits in base 64 VLQ value.");
       }
-      digit = base64.decode(aStr.charAt(i++));
+      digit = base64.decode(aStr.charAt(aIndex++));
       continuation = !!(digit & VLQ_CONTINUATION_BIT);
       digit &= VLQ_BASE_MASK;
       result = result + (digit << shift);
@@ -136,7 +135,7 @@ define(function (require, exports, module) {
     } while (continuation);
 
     aOutParam.value = fromVLQSigned(result);
-    aOutParam.rest = aStr.slice(i);
+    aOutParam.rest = aIndex;
   };
 
 });

--- a/lib/source-map/basic-source-map-consumer.js
+++ b/lib/source-map/basic-source-map-consumer.js
@@ -142,62 +142,63 @@ define(function (require, exports, module) {
       var previousOriginalColumn = 0;
       var previousSource = 0;
       var previousName = 0;
-      var str = aStr;
+      var length = aStr.length;
+      var index = 0;
       var temp = {};
       var mapping;
 
-      while (str.length > 0) {
-        if (str.charAt(0) === ';') {
+      while (index < length) {
+        if (aStr.charAt(index) === ';') {
           generatedLine++;
-          str = str.slice(1);
+          ++index;
           previousGeneratedColumn = 0;
         }
-        else if (str.charAt(0) === ',') {
-          str = str.slice(1);
+        else if (aStr.charAt(index) === ',') {
+          ++index;
         }
         else {
           mapping = {};
           mapping.generatedLine = generatedLine;
 
           // Generated column.
-          base64VLQ.decode(str, temp);
+          base64VLQ.decode(aStr, index, temp);
           mapping.generatedColumn = previousGeneratedColumn + temp.value;
           previousGeneratedColumn = mapping.generatedColumn;
-          str = temp.rest;
+          index = temp.rest;
 
-          if (str.length > 0 && !this._nextCharIsMappingSeparator(str)) {
+          if (index < length && !this._nextCharIsMappingSeparator(aStr, index)) {
             // Original source.
-            base64VLQ.decode(str, temp);
+            base64VLQ.decode(aStr, index, temp);
             mapping.source = this._sources.at(previousSource + temp.value);
             previousSource += temp.value;
-            str = temp.rest;
-            if (str.length === 0 || this._nextCharIsMappingSeparator(str)) {
+            index = temp.rest;
+            if (index == length || this._nextCharIsMappingSeparator(aStr, index)) {
               throw new Error('Found a source, but no line and column');
             }
 
             // Original line.
-            base64VLQ.decode(str, temp);
+            base64VLQ.decode(aStr, index, temp);
             mapping.originalLine = previousOriginalLine + temp.value;
             previousOriginalLine = mapping.originalLine;
             // Lines are stored 0-based
             mapping.originalLine += 1;
-            str = temp.rest;
-            if (str.length === 0 || this._nextCharIsMappingSeparator(str)) {
+            index = temp.rest;
+            if (index == length || this._nextCharIsMappingSeparator(aStr, index)) {
               throw new Error('Found a source and line, but no column');
             }
 
             // Original column.
-            base64VLQ.decode(str, temp);
+            base64VLQ.decode(aStr, index, temp);
             mapping.originalColumn = previousOriginalColumn + temp.value;
             previousOriginalColumn = mapping.originalColumn;
-            str = temp.rest;
+            index = temp.rest;
 
-            if (str.length > 0 && !this._nextCharIsMappingSeparator(str)) {
+            if (index < length && !this._nextCharIsMappingSeparator(aStr, index)) {
               // Original name.
-              base64VLQ.decode(str, temp);
+              base64VLQ.decode(aStr, index, temp);
               mapping.name = this._names.at(previousName + temp.value);
               previousName += temp.value;
-              str = temp.rest;
+              index = temp.rest;
             }
           }
 

--- a/lib/source-map/basic-source-map-consumer.js
+++ b/lib/source-map/basic-source-map-consumer.js
@@ -144,8 +144,9 @@ define(function (require, exports, module) {
       var previousName = 0;
       var length = aStr.length;
       var index = 0;
+      var cachedValues = {};
       var temp = {};
-      var mapping;
+      var mapping, str, values, end;
 
       while (index < length) {
         if (aStr.charAt(index) === ';') {
@@ -160,45 +161,61 @@ define(function (require, exports, module) {
           mapping = {};
           mapping.generatedLine = generatedLine;
 
-          // Generated column.
-          base64VLQ.decode(aStr, index, temp);
-          mapping.generatedColumn = previousGeneratedColumn + temp.value;
-          previousGeneratedColumn = mapping.generatedColumn;
-          index = temp.rest;
+          // Because each offset is encoded relative to the previous one,
+          // many segments often have the same encoding. We can exploit this
+          // fact by caching the parsed variable length fields of each segment,
+          // allowing us to avoid a second parse if we encounter the same
+          // segment again.
+          for (end = index; end < length; ++end) {
+            if (this._nextCharIsMappingSeparator(aStr, end)) {
+              break;
+            }
+          }
+          str = aStr.slice(index, end);
 
-          if (index < length && !this._nextCharIsMappingSeparator(aStr, index)) {
+          values = cachedValues[str];
+          if (values) {
+            index += str.length;
+          } else {
+            values = [];
+            while (index < end) {
+              base64VLQ.decode(aStr, index, temp);
+              value = temp.value;
+              index = temp.rest;
+              values.push(value);
+            }
+            cachedValues[str] = values;
+          }
+
+          // Generated column.
+          mapping.generatedColumn = previousGeneratedColumn + values[0];
+          previousGeneratedColumn = mapping.generatedColumn;
+
+          if (values.length > 1) {
             // Original source.
-            base64VLQ.decode(aStr, index, temp);
-            mapping.source = this._sources.at(previousSource + temp.value);
-            previousSource += temp.value;
-            index = temp.rest;
-            if (index == length || this._nextCharIsMappingSeparator(aStr, index)) {
+            mapping.source = this._sources.at(previousSource + values[1]);
+            previousSource += values[1];
+            if (values.length === 2) {
               throw new Error('Found a source, but no line and column');
             }
 
             // Original line.
-            base64VLQ.decode(aStr, index, temp);
-            mapping.originalLine = previousOriginalLine + temp.value;
+            mapping.originalLine = previousOriginalLine + values[2];
             previousOriginalLine = mapping.originalLine;
             // Lines are stored 0-based
             mapping.originalLine += 1;
-            index = temp.rest;
-            if (index == length || this._nextCharIsMappingSeparator(aStr, index)) {
+            if (values.length === 3) {
               throw new Error('Found a source and line, but no column');
             }
 
             // Original column.
-            base64VLQ.decode(aStr, index, temp);
-            mapping.originalColumn = previousOriginalColumn + temp.value;
+            mapping.originalColumn = previousOriginalColumn + values[3];
             previousOriginalColumn = mapping.originalColumn;
-            index = temp.rest;
 
-            if (index < length && !this._nextCharIsMappingSeparator(aStr, index)) {
+            if (values.length > 4) {
               // Original name.
-              base64VLQ.decode(aStr, index, temp);
-              mapping.name = this._names.at(previousName + temp.value);
-              previousName += temp.value;
-              index = temp.rest;
+              mapping.name = this._names.at(previousName + values[4]);
+              previousName += values[4];
             }
           }
 

--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -96,8 +96,8 @@ define(function (require, exports, module) {
   });
 
   SourceMapConsumer.prototype._nextCharIsMappingSeparator =
-    function SourceMapConsumer_nextCharIsMappingSeparator(aStr) {
-      var c = aStr.charAt(0);
+    function SourceMapConsumer_nextCharIsMappingSeparator(aStr, index) {
+      var c = aStr.charAt(index);
       return c === ";" || c === ",";
     };
 

--- a/test/source-map/test-base64-vlq.js
+++ b/test/source-map/test-base64-vlq.js
@@ -14,9 +14,10 @@ define(function (require, exports, module) {
   exports['test normal encoding and decoding'] = function (assert, util) {
     var result = {};
     for (var i = -255; i < 256; i++) {
-      base64VLQ.decode(base64VLQ.encode(i), result);
+      var str = base64VLQ.encode(i);
+      base64VLQ.decode(str, 0, result);
       assert.equal(result.value, i);
-      assert.equal(result.rest, "");
+      assert.equal(result.rest, str.length);
     }
   };
 


### PR DESCRIPTION
Based on our conversation yesterday, I wanted to see if I could come up with ways to improve the performance of parseMappings. I came up with two ideas:

1. We create a new string object for each iteration of the parse loop, using str.slice. Avoiding this leads to a 3% performance increase on my machine.

2. Huge source maps such as the scalajs-runtime.js.map show a lot of homogeneity between different segments (since we encode each offset relative to the previous one, this is what I would expect). Caching the parsed variable length fields for each segment leads to another 5% performance increase on my machine.

These are decent, but not huge wins. Moreover, there is some risk that 2. actually decreases performance in huge source maps where there is very little homogeneity between segments (although I expect such cases to be rare). I'll leave it up to you to decide whether it's worth adding these patches to the source-map library.