### PR TITLE
originalPositionFor for should have a GREATEST_LOWER_BOUND search bias.

### DIFF
--- a/lib/source-map/binary-search.js
+++ b/lib/source-map/binary-search.js
@@ -18,8 +18,8 @@ define(function (require, exports, module) {
    * @param aCompare Function which takes two elements and returns -1, 0, or 1.
    * @param aBias Either 'binarySearch.LEAST_UPPER_BOUND' or
    *     'binarySearch.GREATEST_LOWER_BOUND'. Specifies whether to return the
-   *     closest element that is smaller than or greater than the element we are
-   *     searching for if the exact element cannot be found.
+   *     closest element that is greater than or less than the element we are
+   *     searching for (respectively), if the exact element cannot be found.
    */
   function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
     // This function terminates when one of the following is true:
@@ -84,9 +84,9 @@ define(function (require, exports, module) {
    *     than, equal to, or greater than the element, respectively.
    * @param aBias Either 'exports.LEAST_UPPER_BOUND' or
    *     'exports.GREATEST_LOWER_BOUND'. Specifies whether to return the
-   *     closest element that is smaller than or greater than the element we are
-   *     searching for if the exact element cannot be found. Defaults to
-   *     'exports.LEAST_UPPER_BOUND'.
+   *     closest element that is greater than or less than the element we are
+   *     searching for (respectively), if the exact element cannot be found.
+   *     Defaults to 'exports.LEAST_UPPER_BOUND'.
    */
   exports.search = function search(aNeedle, aHaystack, aCompare, aBias) {
     var aBias = aBias || exports.LEAST_UPPER_BOUND;

--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -347,7 +347,7 @@ define(function (require, exports, module) {
       var index = 0;
       var cachedValues = {};
       var temp = {};
-      var mapping, str, values, end;
+      var mapping, end, str, values, value;
 
       while (index < length) {
         if (aStr.charAt(index) === ';') {
@@ -437,7 +437,7 @@ define(function (require, exports, module) {
    */
   BasicSourceMapConsumer.prototype._findMapping =
     function SourceMapConsumer_findMapping(aNeedle, aMappings, aLineName,
-                                           aColumnName, aComparator) {
+                                           aColumnName, aComparator, aBias) {
       // To return the position we are searching for, we must first find the
       // mapping for the given position and then return the opposite position it
       // points to. Because the mappings are sorted, we can use binary search to
@@ -452,7 +452,7 @@ define(function (require, exports, module) {
                             + aNeedle[aColumnName]);
       }
 
-      return binarySearch.search(aNeedle, aMappings, aComparator);
+      return binarySearch.search(aNeedle, aMappings, aComparator, aBias);
     };
 
   /**
@@ -508,7 +508,8 @@ define(function (require, exports, module) {
                                     this._generatedMappings,
                                     "generatedLine",
                                     "generatedColumn",
-                                    util.compareByGeneratedPositions);
+                                    util.compareByGeneratedPositions,
+                                    binarySearch.GREATEST_LOWER_BOUND);
 
       if (index >= 0) {
         var mapping = this._generatedMappings[index];
@@ -615,7 +616,8 @@ define(function (require, exports, module) {
                                     this._originalMappings,
                                     "originalLine",
                                     "originalColumn",
-                                    util.compareByOriginalPositions);
+                                    util.compareByOriginalPositions,
+                                    binarySearch.LEAST_UPPER_BOUND);
 
       if (index >= 0) {
         var mapping = this._originalMappings[index];

--- a/test/source-map/test-dog-fooding.js
+++ b/test/source-map/test-dog-fooding.js
@@ -60,17 +60,17 @@ define(function (require, exports, module) {
     // Fuzzy
 
     // Generated to original
-    util.assertMapping(2, 0, '/wu/tang/gza.coffee', 1, 0, null, smc, assert, true);
-    util.assertMapping(2, 9, null, null, null, null, smc, assert, true);
-    util.assertMapping(3, 0, '/wu/tang/gza.coffee', 2, 0, null, smc, assert, true);
-    util.assertMapping(3, 9, null, null, null, null, smc, assert, true);
-    util.assertMapping(4, 0, '/wu/tang/gza.coffee', 3, 0, null, smc, assert, true);
-    util.assertMapping(4, 9, null, null, null, null, smc, assert, true);
-    util.assertMapping(5, 0, '/wu/tang/gza.coffee', 4, 0, null, smc, assert, true);
-    util.assertMapping(5, 9, null, null, null, null, smc, assert, true);
-    util.assertMapping(6, 0, '/wu/tang/gza.coffee', 5, 10, null, smc, assert, true);
-    util.assertMapping(6, 9, '/wu/tang/gza.coffee', 5, 10, null, smc, assert, true);
-    util.assertMapping(6, 13, null, null, null, null, smc, assert, true);
+    util.assertMapping(2, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(2, 9, '/wu/tang/gza.coffee', 1, 0, null, smc, assert, true);
+    util.assertMapping(3, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(3, 9, '/wu/tang/gza.coffee', 2, 0, null, smc, assert, true);
+    util.assertMapping(4, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(4, 9, '/wu/tang/gza.coffee', 3, 0, null, smc, assert, true);
+    util.assertMapping(5, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(5, 9, '/wu/tang/gza.coffee', 4, 0, null, smc, assert, true);
+    util.assertMapping(6, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(6, 9, null, null, null, null, smc, assert, true);
+    util.assertMapping(6, 13, '/wu/tang/gza.coffee', 5, 10, null, smc, assert, true);
 
     // Original to generated
     util.assertMapping(3, 2, '/wu/tang/gza.coffee', 1, 1, null, smc, assert, null, true);

--- a/test/source-map/test-source-map-consumer.js
+++ b/test/source-map/test-source-map-consumer.js
@@ -181,9 +181,9 @@ define(function (require, exports, module) {
     var map = new SourceMapConsumer(util.testMap);
 
     // Finding original positions
-    util.assertMapping(1, 16, '/the/root/one.js', 1, 21, 'bar', map, assert, true);
-    util.assertMapping(1, 26, '/the/root/one.js', 2, 10, 'baz', map, assert, true);
-    util.assertMapping(2, 6, '/the/root/two.js', 1, 11, null, map, assert, true);
+    util.assertMapping(1, 18, '/the/root/one.js', 1, 21, 'bar', map, assert, true);
+    util.assertMapping(1, 28, '/the/root/one.js', 2, 10, 'baz', map, assert, true);
+    util.assertMapping(2, 12, '/the/root/two.js', 1, 11, null, map, assert, true);
 
     // Finding generated positions
     util.assertMapping(1, 18, '/the/root/one.js', 1, 20, 'bar', map, assert, null, true);
@@ -195,9 +195,9 @@ define(function (require, exports, module) {
     var map = new SourceMapConsumer(util.indexedTestMap);
 
     // Finding original positions
-    util.assertMapping(1, 16, '/the/root/one.js', 1, 21, 'bar', map, assert, true);
+    util.assertMapping(1, 18, '/the/root/one.js', 1, 21, 'bar', map, assert, true);
     util.assertMapping(1, 28, '/the/root/one.js', 2, 10, 'baz', map, assert, true);
-    util.assertMapping(2, 6, '/the/root/two.js', 1, 11, null, map, assert, true);
+    util.assertMapping(2, 12, '/the/root/two.js', 1, 11, null, map, assert, true);
 
     // Finding generated positions
     util.assertMapping(1, 18, '/the/root/one.js', 1, 20, 'bar', map, assert, null, true);
@@ -223,7 +223,7 @@ define(function (require, exports, module) {
     var map = SourceMapConsumer.fromSourceMap(smg);
 
     // When finding original positions, mappings end at the end of the line.
-    util.assertMapping(2, 3, null, null, null, null, map, assert, true)
+    util.assertMapping(2, 1, null, null, null, null, map, assert, true)
 
     // When finding generated positions, mappings do not end at the end of the line.
     util.assertMapping(2, 2, 'bar.js', 1, 2, null, map, assert, null, true);


### PR DESCRIPTION
As we discussed per e-mail, we actually only want a LEAST_UPPER_BOUND search bias for generatedPositionOf, not originalPositionOf, so this patch reverts the change in behavior introduced by the earlier patch.