### PR TITLE
Always return the smallest element when there is more than one match.

### DIFF
--- a/lib/source-map/binary-search.js
+++ b/lib/source-map/binary-search.js
@@ -94,7 +94,24 @@ define(function (require, exports, module) {
     if (aHaystack.length === 0) {
       return -1;
     }
-    return recursiveSearch(-1, aHaystack.length, aNeedle, aHaystack, aCompare, aBias)
+
+    var index = recursiveSearch(-1, aHaystack.length, aNeedle, aHaystack,
+                                aCompare, aBias);
+    if (index < 0) {
+      return -1;
+    }
+
+    // We have found either the exact element, or the next-closest element than
+    // the one we are searching for. However, there may be more than one such
+    // element. Make sure we always return the smallest of these.
+    while (index - 1 > 0) {
+      if (aCompare(aHaystack[index], aHaystack[index - 1], true) !== 0) {
+        break;
+      }
+      --index;
+    }
+
+    return index;
   };
 
 });

--- a/lib/source-map/util.js
+++ b/lib/source-map/util.js
@@ -261,7 +261,7 @@ define(function (require, exports, module) {
       return cmp;
     }
 
-    cmp = strcmp(mappingA.name, mappingB.name);
+    cmp = mappingA.generatedColumn - mappingB.generatedColumn;
     if (cmp) {
       return cmp;
     }
@@ -271,7 +271,7 @@ define(function (require, exports, module) {
       return cmp;
     }
 
-    return mappingA.generatedColumn - mappingB.generatedColumn;
+    return strcmp(mappingA.name, mappingB.name);
   };
   exports.compareByOriginalPositions = compareByOriginalPositions;
 

--- a/test/source-map/test-binary-search.js
+++ b/test/source-map/test-binary-search.js
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
     var haystack = [2,4,6,8,10,12,14,16,18,20];
 
     assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare,
-                          binarySearch.GREATEST_LOWER_BOUND)], 4);
+                                              binarySearch.GREATEST_LOWER_BOUND)], 4);
   };
 
   exports['test fuzzy search with glb bias'] = function (assert, util) {
@@ -89,6 +89,14 @@ define(function (require, exports, module) {
     var haystack = [2,4,6,8,10,12,14,16,18,20];
 
     assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare,
-                          binarySearch.GREATEST_LOWER_BOUND)], 18);
+                                              binarySearch.GREATEST_LOWER_BOUND)], 18);
+  };
+
+  exports['test multiple matches'] = function (assert, util) {
+    var needle = 5;
+    var haystack = [1, 1, 2, 5, 5, 5, 13, 21];
+
+    assert.equal(binarySearch.search(needle, haystack, numberCompare,
+                                     binarySearch.LEAST_UPPER_BOUND), 3);
   };
 });


### PR DESCRIPTION
The title pretty much sums it up. As discussed per e-mail.