### PR TITLE
Revert "Fuzzy search should find the closest element that is greater than or equal to."

### DIFF
--- a/lib/source-map/binary-search.js
+++ b/lib/source-map/binary-search.js
@@ -8,6 +8,7 @@ if (typeof define !== 'function') {
     var define = require('amdefine')(module, require);
 }
 define(function (require, exports, module) {
+
   /**
    * Recursive implementation of binary search.
    *
@@ -16,21 +17,18 @@ define(function (require, exports, module) {
    * @param aNeedle The element being searched for.
    * @param aHaystack The non-empty array being searched.
    * @param aCompare Function which takes two elements and returns -1, 0, or 1.
-   * @param aBias Either 'binarySearch.LEAST_UPPER_BOUND' or
-   *     'binarySearch.GREATEST_LOWER_BOUND'. Specifies whether to return the
-   *     closest element that is smaller than or greater than the element we are
-   *     searching for if the exact element cannot be found.
    */
-  function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
+  function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare) {
     // This function terminates when one of the following is true:
     //
     //   1. We find the exact element we are looking for.
     //
     //   2. We did not find the exact element, but we can return the index of
-    //      the next closest element.
+    //      the next closest element that is less than that element.
     //
     //   3. We did not find the exact element, and there is no next-closest
-    //      element than the one we are searching for, so we return -1.
+    //      element which is less than the one we are searching for, so we
+    //      return -1.
     var mid = Math.floor((aHigh - aLow) / 2) + aLow;
     var cmp = aCompare(aNeedle, aHaystack[mid], true);
     if (cmp === 0) {
@@ -38,41 +36,30 @@ define(function (require, exports, module) {
       return mid;
     }
     else if (cmp > 0) {
-      // Our needle is greater than aHaystack[mid].
+      // aHaystack[mid] is greater than our needle.
       if (aHigh - mid > 1) {
         // The element is in the upper half.
-        return recursiveSearch(mid, aHigh, aNeedle, aHaystack, aCompare, aBias);
+        return recursiveSearch(mid, aHigh, aNeedle, aHaystack, aCompare);
       }
-      // The exact needle element was not found in this haystack. Determine if
-      // we are in termination case (3) or (2) and return the appropriate thing.
-      if (aBias == exports.LEAST_UPPER_BOUND) {
-        return aHigh < aHaystack.length ? aHigh : -1;
-      } else {
-        return mid;
-      }
+      // We did not find an exact match, return the next closest one
+      // (termination case 2).
+      return mid;
     }
     else {
-      // Our needle is less than aHaystack[mid].
+      // aHaystack[mid] is less than our needle.
       if (mid - aLow > 1) {
         // The element is in the lower half.
-        return recursiveSearch(aLow, mid, aNeedle, aHaystack, aCompare, aBias);
+        return recursiveSearch(aLow, mid, aNeedle, aHaystack, aCompare);
       }
       // The exact needle element was not found in this haystack. Determine if
-      // we are in termination case (3) or (2) and return the appropriate thing.
-      if (aBias == exports.LEAST_UPPER_BOUND) {
-        return mid;
-      } else {
-        return aLow < 0 ? -1 : aLow;
-      }
+      // we are in termination case (2) or (3) and return the appropriate thing.
+      return aLow < 0 ? -1 : aLow;
     }
   }
 
-  exports.LEAST_UPPER_BOUND = 1;
-  exports.GREATEST_LOWER_BOUND = 2;
-
   /**
    * This is an implementation of binary search which will always try and return
-   * the index of next highest value checked if there is no exact hit. This is
+   * the index of next lowest value checked if there is no exact hit. This is
    * because mappings between original and generated line/col pairs are single
    * points, and there is an implicit region between each of them, so a miss
    * just means that you aren't on the very start of a region.
@@ -82,19 +69,12 @@ define(function (require, exports, module) {
    * @param aCompare A function which takes the needle and an element in the
    *     array and returns -1, 0, or 1 depending on whether the needle is less
    *     than, equal to, or greater than the element, respectively.
-   * @param aBias Either 'exports.LEAST_UPPER_BOUND' or
-   *     'exports.GREATEST_LOWER_BOUND'. Specifies whether to return the
-   *     closest element that is smaller than or greater than the element we are
-   *     searching for if the exact element cannot be found. Defaults to
-   *     'exports.LEAST_UPPER_BOUND'.
    */
-  exports.search = function search(aNeedle, aHaystack, aCompare, aBias) {
-    var aBias = aBias || exports.LEAST_UPPER_BOUND;
-
+  exports.search = function search(aNeedle, aHaystack, aCompare) {
     if (aHaystack.length === 0) {
       return -1;
     }
-    return recursiveSearch(-1, aHaystack.length, aNeedle, aHaystack, aCompare, aBias)
+    return recursiveSearch(-1, aHaystack.length, aNeedle, aHaystack, aCompare)
   };
 
 });

--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -109,9 +109,6 @@ define(function (require, exports, module) {
   SourceMapConsumer.GENERATED_ORDER = 1;
   SourceMapConsumer.ORIGINAL_ORDER = 2;
 
-  SourceMapConsumer.LEAST_UPPER_BOUND = 1;
-  SourceMapConsumer.GREATEST_LOWER_BOUND = 2;
-
   /**
    * Iterate over each mapping between an original source/line/column and a
    * generated line/column in this source map.
@@ -177,10 +174,14 @@ define(function (require, exports, module) {
    */
   SourceMapConsumer.prototype.allGeneratedPositionsFor =
     function SourceMapConsumer_allGeneratedPositionsFor(aArgs) {
+      // When there is no exact match, BasicSourceMapConsumer.prototype._findMapping
+      // returns the index of the closest mapping less than the needle. By
+      // setting needle.originalColumn to Infinity, we thus find the last
+      // mapping for the given line, provided such a mapping exists.
       var needle = {
         source: util.getArg(aArgs, 'source'),
         originalLine: util.getArg(aArgs, 'line'),
-        originalColumn: 0
+        originalColumn: Infinity
       };
 
       if (this.sourceRoot != null) {
@@ -197,9 +198,6 @@ define(function (require, exports, module) {
       if (index >= 0) {
         var mapping = this._originalMappings[index];
 
-        // Iterate until either we run out of mappings, or we run into
-        // a mapping for a different line. Since mappings are sorted, this is
-        // guaranteed to find all mappings for the line we are interested in.
         while (mapping && mapping.originalLine === needle.originalLine) {
           mappings.push({
             line: util.getArg(mapping, 'generatedLine', null),
@@ -207,11 +205,11 @@ define(function (require, exports, module) {
             lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
           });
 
-          mapping = this._originalMappings[++index];
+          mapping = this._originalMappings[--index];
         }
       }
 
-      return mappings;
+      return mappings.reverse();
     };
 
   exports.SourceMapConsumer = SourceMapConsumer;
@@ -782,7 +780,7 @@ define(function (require, exports, module) {
 
           return (needle.generatedColumn -
                   section.generatedOffset.generatedColumn);
-        }, binarySearch.GREATEST_LOWER_BOUND);
+        });
       var section = this._sections[sectionIndex];
 
       if (!section) {

--- a/test/source-map/test-binary-search.js
+++ b/test/source-map/test-binary-search.js
@@ -15,8 +15,19 @@ define(function (require, exports, module) {
     return a - b;
   }
 
-  exports['test too high with lub bias'] = function (assert, util) {
+  exports['test too high'] = function (assert, util) {
     var needle = 30;
+    var haystack = [2,4,6,8,10,12,14,16,18,20];
+
+    assert.doesNotThrow(function () {
+      binarySearch.search(needle, haystack, numberCompare);
+    });
+
+    assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare)], 20);
+  };
+
+  exports['test too low'] = function (assert, util) {
+    var needle = 1;
     var haystack = [2,4,6,8,10,12,14,16,18,20];
 
     assert.doesNotThrow(function () {
@@ -26,69 +37,18 @@ define(function (require, exports, module) {
     assert.equal(binarySearch.search(needle, haystack, numberCompare), -1);
   };
 
-  exports['test too low with lub bias'] = function (assert, util) {
-    var needle = 1;
-    var haystack = [2,4,6,8,10,12,14,16,18,20];
-
-    assert.doesNotThrow(function () {
-      binarySearch.search(needle, haystack, numberCompare, true);
-    });
-
-    assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare)], 2);
-  };
-
-  exports['test exact search with lub bias'] = function (assert, util) {
+  exports['test exact search'] = function (assert, util) {
     var needle = 4;
     var haystack = [2,4,6,8,10,12,14,16,18,20];
 
     assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare)], 4);
   };
 
-  exports['test fuzzy search with lub bias'] = function (assert, util) {
+  exports['test fuzzy search'] = function (assert, util) {
     var needle = 19;
     var haystack = [2,4,6,8,10,12,14,16,18,20];
 
-    assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare)], 20);
+    assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare)], 18);
   };
 
-  exports['test too high with glb bias'] = function (assert, util) {
-    var needle = 30;
-    var haystack = [2,4,6,8,10,12,14,16,18,20];
-
-    assert.doesNotThrow(function () {
-      binarySearch.search(needle, haystack, numberCompare);
-    });
-
-    assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare,
-                                              binarySearch.GREATEST_LOWER_BOUND)], 20);
-  };
-
-  exports['test too low with glb bias'] = function (assert, util) {
-    var needle = 1;
-    var haystack = [2,4,6,8,10,12,14,16,18,20];
-
-    assert.doesNotThrow(function () {
-      binarySearch.search(needle, haystack, numberCompare,
-                          binarySearch.GREATEST_LOWER_BOUND);
-    });
-
-    assert.equal(binarySearch.search(needle, haystack, numberCompare,
-                                     binarySearch.GREATEST_LOWER_BOUND), -1);
-  };
-
-  exports['test exact search with glb bias'] = function (assert, util) {
-    var needle = 4;
-    var haystack = [2,4,6,8,10,12,14,16,18,20];
-
-    assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare,
-                          binarySearch.GREATEST_LOWER_BOUND)], 4);
-  };
-
-  exports['test fuzzy search with glb bias'] = function (assert, util) {
-    var needle = 19;
-    var haystack = [2,4,6,8,10,12,14,16,18,20];
-
-    assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare,
-                          binarySearch.GREATEST_LOWER_BOUND)], 18);
-  };
 });

--- a/test/source-map/test-dog-fooding.js
+++ b/test/source-map/test-dog-fooding.js
@@ -60,25 +60,25 @@ define(function (require, exports, module) {
     // Fuzzy
 
     // Generated to original
-    util.assertMapping(2, 0, '/wu/tang/gza.coffee', 1, 0, null, smc, assert, true);
-    util.assertMapping(2, 9, null, null, null, null, smc, assert, true);
-    util.assertMapping(3, 0, '/wu/tang/gza.coffee', 2, 0, null, smc, assert, true);
-    util.assertMapping(3, 9, null, null, null, null, smc, assert, true);
-    util.assertMapping(4, 0, '/wu/tang/gza.coffee', 3, 0, null, smc, assert, true);
-    util.assertMapping(4, 9, null, null, null, null, smc, assert, true);
-    util.assertMapping(5, 0, '/wu/tang/gza.coffee', 4, 0, null, smc, assert, true);
-    util.assertMapping(5, 9, null, null, null, null, smc, assert, true);
-    util.assertMapping(6, 0, '/wu/tang/gza.coffee', 5, 10, null, smc, assert, true);
-    util.assertMapping(6, 9, '/wu/tang/gza.coffee', 5, 10, null, smc, assert, true);
-    util.assertMapping(6, 13, null, null, null, null, smc, assert, true);
+    util.assertMapping(2, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(2, 9, '/wu/tang/gza.coffee', 1, 0, null, smc, assert, true);
+    util.assertMapping(3, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(3, 9, '/wu/tang/gza.coffee', 2, 0, null, smc, assert, true);
+    util.assertMapping(4, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(4, 9, '/wu/tang/gza.coffee', 3, 0, null, smc, assert, true);
+    util.assertMapping(5, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(5, 9, '/wu/tang/gza.coffee', 4, 0, null, smc, assert, true);
+    util.assertMapping(6, 0, null, null, null, null, smc, assert, true);
+    util.assertMapping(6, 9, null, null, null, null, smc, assert, true);
+    util.assertMapping(6, 13, '/wu/tang/gza.coffee', 5, 10, null, smc, assert, true);
 
     // Original to generated
-    util.assertMapping(3, 2, '/wu/tang/gza.coffee', 1, 1, null, smc, assert, null, true);
-    util.assertMapping(4, 2, '/wu/tang/gza.coffee', 2, 3, null, smc, assert, null, true);
-    util.assertMapping(5, 2, '/wu/tang/gza.coffee', 3, 6, null, smc, assert, null, true);
-    util.assertMapping(6, 12, '/wu/tang/gza.coffee', 4, 9, null, smc, assert, null, true);
-    util.assertMapping(6, 12, '/wu/tang/gza.coffee', 5, 9, null, smc, assert, null, true);
-    util.assertMapping(null, null, '/wu/tang/gza.coffee', 6, 19, null, smc, assert, null, true);
+    util.assertMapping(2, 2, '/wu/tang/gza.coffee', 1, 1, null, smc, assert, null, true);
+    util.assertMapping(3, 2, '/wu/tang/gza.coffee', 2, 3, null, smc, assert, null, true);
+    util.assertMapping(4, 2, '/wu/tang/gza.coffee', 3, 6, null, smc, assert, null, true);
+    util.assertMapping(5, 2, '/wu/tang/gza.coffee', 4, 9, null, smc, assert, null, true);
+    util.assertMapping(5, 2, '/wu/tang/gza.coffee', 5, 9, null, smc, assert, null, true);
+    util.assertMapping(6, 12, '/wu/tang/gza.coffee', 6, 19, null, smc, assert, null, true);
   };
 
 });

--- a/test/source-map/test-source-map-consumer.js
+++ b/test/source-map/test-source-map-consumer.js
@@ -181,28 +181,28 @@ define(function (require, exports, module) {
     var map = new SourceMapConsumer(util.testMap);
 
     // Finding original positions
-    util.assertMapping(1, 16, '/the/root/one.js', 1, 21, 'bar', map, assert, true);
-    util.assertMapping(1, 26, '/the/root/one.js', 2, 10, 'baz', map, assert, true);
-    util.assertMapping(2, 6, '/the/root/two.js', 1, 11, null, map, assert, true);
+    util.assertMapping(1, 20, '/the/root/one.js', 1, 21, 'bar', map, assert, true);
+    util.assertMapping(1, 30, '/the/root/one.js', 2, 10, 'baz', map, assert, true);
+    util.assertMapping(2, 12, '/the/root/two.js', 1, 11, null, map, assert, true);
 
     // Finding generated positions
-    util.assertMapping(1, 18, '/the/root/one.js', 1, 20, 'bar', map, assert, null, true);
-    util.assertMapping(1, 28, '/the/root/one.js', 2, 7, 'baz', map, assert, null, true);
-    util.assertMapping(2, 9, '/the/root/two.js', 1, 6, null, map, assert, null, true);
+    util.assertMapping(1, 18, '/the/root/one.js', 1, 22, 'bar', map, assert, null, true);
+    util.assertMapping(1, 28, '/the/root/one.js', 2, 13, 'baz', map, assert, null, true);
+    util.assertMapping(2, 9, '/the/root/two.js', 1, 16, null, map, assert, null, true);
   };
 
   exports['test mapping tokens fuzzy in indexed source map'] = function (assert, util) {
     var map = new SourceMapConsumer(util.indexedTestMap);
 
     // Finding original positions
-    util.assertMapping(1, 16, '/the/root/one.js', 1, 21, 'bar', map, assert, true);
-    util.assertMapping(1, 28, '/the/root/one.js', 2, 10, 'baz', map, assert, true);
-    util.assertMapping(2, 6, '/the/root/two.js', 1, 11, null, map, assert, true);
+    util.assertMapping(1, 20, '/the/root/one.js', 1, 21, 'bar', map, assert, true);
+    util.assertMapping(1, 30, '/the/root/one.js', 2, 10, 'baz', map, assert, true);
+    util.assertMapping(2, 12, '/the/root/two.js', 1, 11, null, map, assert, true);
 
     // Finding generated positions
-    util.assertMapping(1, 18, '/the/root/one.js', 1, 20, 'bar', map, assert, null, true);
-    util.assertMapping(1, 28, '/the/root/one.js', 2, 7, 'baz', map, assert, null, true);
-    util.assertMapping(2, 9, '/the/root/two.js', 1, 6, null, map, assert, null, true);
+    util.assertMapping(1, 18, '/the/root/one.js', 1, 22, 'bar', map, assert, null, true);
+    util.assertMapping(1, 28, '/the/root/one.js', 2, 13, 'baz', map, assert, null, true);
+    util.assertMapping(2, 9, '/the/root/two.js', 1, 16, null, map, assert, null, true);
   };
 
   exports['test mappings and end of lines'] = function (assert, util) {
@@ -223,10 +223,10 @@ define(function (require, exports, module) {
     var map = SourceMapConsumer.fromSourceMap(smg);
 
     // When finding original positions, mappings end at the end of the line.
-    util.assertMapping(2, 3, null, null, null, null, map, assert, true)
+    util.assertMapping(2, 1, null, null, null, null, map, assert, true)
 
     // When finding generated positions, mappings do not end at the end of the line.
-    util.assertMapping(2, 2, 'bar.js', 1, 2, null, map, assert, null, true);
+    util.assertMapping(1, 1, 'bar.js', 2, 1, null, map, assert, null, true);
   };
 
   exports['test creating source map consumers with )]}\' prefix'] = function (assert, util) {
@@ -597,7 +597,7 @@ define(function (require, exports, module) {
     });
 
     assert.equal(mappings.length, 1);
-    // assert.equal(mappings[0].lastColumn, Infinity);
+    assert.equal(mappings[0].lastColumn, Infinity);
 
     var mappings = map.allGeneratedPositionsFor({
       line: 2,


### PR DESCRIPTION
This reverts commit 3c89b7be288c7f34eb886a541376ee38e0579a65, effectively reverting the fuzzy search algorithm back to its original behavior. 