### PR TITLE
Always return the smallest element when there is more than one match.

### DIFF
--- a/lib/source-map/binary-search.js
+++ b/lib/source-map/binary-search.js
@@ -95,8 +95,23 @@ define(function (require, exports, module) {
       return -1;
     }
 
-    return recursiveSearch(-1, aHaystack.length, aNeedle, aHaystack, aCompare,
-                           aBias || exports.GREATEST_LOWER_BOUND);
+    var index = recursiveSearch(-1, aHaystack.length, aNeedle, aHaystack,
+                                aCompare, aBias || exports.GREATEST_LOWER_BOUND);
+    if (index < 0) {
+      return -1;
+    }
+
+    // We have found either the exact element, or the next-closest element than
+    // the one we are searching for. However, there may be more than one such
+    // element. Make sure we always return the smallest of these.
+    while (index - 1 >= 0) {
+      if (aCompare(aHaystack[index], aHaystack[index - 1], true) !== 0) {
+        break;
+      }
+      --index;
+    }
+
+    return index;
   };
 
 });

--- a/lib/source-map/util.js
+++ b/lib/source-map/util.js
@@ -261,7 +261,7 @@ define(function (require, exports, module) {
       return cmp;
     }
 
-    cmp = strcmp(mappingA.name, mappingB.name);
+    cmp = mappingA.generatedColumn - mappingB.generatedColumn;
     if (cmp) {
       return cmp;
     }
@@ -271,7 +271,7 @@ define(function (require, exports, module) {
       return cmp;
     }
 
-    return mappingA.generatedColumn - mappingB.generatedColumn;
+    return strcmp(mappingA.name, mappingB.name);
   };
   exports.compareByOriginalPositions = compareByOriginalPositions;
 

--- a/test/source-map/test-binary-search.js
+++ b/test/source-map/test-binary-search.js
@@ -83,4 +83,20 @@ define(function (require, exports, module) {
                                               binarySearch.LEAST_UPPER_BOUND)], 20);
   };
 
+  exports['test multiple matches'] = function (assert, util) {
+    var needle = 5;
+    var haystack = [1, 1, 2, 5, 5, 5, 13, 21];
+
+    assert.equal(binarySearch.search(needle, haystack, numberCompare,
+                                     binarySearch.LEAST_UPPER_BOUND), 3);
+  };
+
+  exports['test multiple matches at the beginning'] = function (assert, util) {
+    var needle = 1;
+    var haystack = [1, 1, 2, 5, 5, 5, 13, 21];
+
+    assert.equal(binarySearch.search(needle, haystack, numberCompare,
+                                     binarySearch.LEAST_UPPER_BOUND), 0);
+  };
+
 });


### PR DESCRIPTION
I forgot to put this pull request up again yesterday. This changes the search algorithm so that if there is more than one (inexact) match, it always returns the smallest one.

I'm going to merge the current version of the source-map library, with this included, to fx-team.