### PR TITLE
Add "files" array to package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+bench/
+test/


### PR DESCRIPTION
Currently, this module is 15MB:

```
 15M	./bench
 40K	./build
112K	./lib
132K	./test
 16M	total
```

npm has a [`files` whitelist](https://docs.npmjs.com/files/package.json#files), which activates when publishing to npm. By excluding some files that aren't used (or cannot be used) by packages that depend on this module, we can shrink the required size drastically:

```
112K	./lib
156K	total
```

I have set `files` to include `lib/`, `LICENSE`, and `README`.