### PR TITLE
When finding generated positions, mappings should end at the end of the source

### DIFF
--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -641,11 +641,13 @@ define(function (require, exports, module) {
       if (index >= 0) {
         var mapping = this._originalMappings[index];
 
-        return {
-          line: util.getArg(mapping, 'generatedLine', null),
-          column: util.getArg(mapping, 'generatedColumn', null),
-          lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
-        };
+        if (mapping.source === needle.source) {
+          return {
+            line: util.getArg(mapping, 'generatedLine', null),
+            column: util.getArg(mapping, 'generatedColumn', null),
+            lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
+          };
+        }
       }
 
       return {

--- a/test/source-map/test-source-map-consumer.js
+++ b/test/source-map/test-source-map-consumer.js
@@ -239,6 +239,11 @@ define(function (require, exports, module) {
       generated: { line: 2, column: 2 },
       source: 'bar.js'
     });
+    smg.addMapping({
+      original: { line: 1, column: 1 },
+      generated: { line: 1, column: 1 },
+      source: 'baz.js'
+    });
 
     var map = SourceMapConsumer.fromSourceMap(smg);
 
@@ -247,6 +252,9 @@ define(function (require, exports, module) {
 
     // When finding generated positions, mappings do not end at the end of the line.
     util.assertMapping(1, 1, 'bar.js', 2, 1, null, null, map, assert, null, true);
+
+    // When finding generated positions with, mappings end at the end of the source.
+    util.assertMapping(null, null, 'bar.js', 3, 1, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
   };
 
   exports['test creating source map consumers with )]}\' prefix'] = function (assert, util) {


### PR DESCRIPTION
I ran into this when implementing the new sliding breakpoint algorithm for source mapped sources. I assumed that generatedPositionOf returns a null mapping if there is no closest mapping that is greater than the one we are searching for *for the same original source*. If we use generatedPositionOf with a least upper bound bias, this means we get a null mapping if and only if we went past the last line in the original source, in which case the breakpoint sliding algorithm failed.

The problem is that when we have two original sources A and B, such that A comes lexicographically before B, all mappings for B are considered to be greater than A, so that when we go past the last line in A, generatedPositionOf returns the first mapping for B instead of a null mapping.