### PR TITLE
 allGeneratedPositionsFor for line with no mappings should return the next closest line.

### DIFF
--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -201,11 +201,12 @@ define(function (require, exports, module) {
                                     binarySearch.LEAST_UPPER_BOUND);
       if (index >= 0) {
         var mapping = this._originalMappings[index];
+        var originalLine = mapping.originalLine;
 
         // Iterate until either we run out of mappings, or we run into
         // a mapping for a different line. Since mappings are sorted, this is
         // guaranteed to find all mappings for the line we are searching for.
-        while (mapping && mapping.originalLine === needle.originalLine) {
+        while (mapping && mapping.originalLine === originalLine) {
           mappings.push({
             line: util.getArg(mapping, 'generatedLine', null),
             column: util.getArg(mapping, 'generatedColumn', null),

--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -641,11 +641,13 @@ define(function (require, exports, module) {
       if (index >= 0) {
         var mapping = this._originalMappings[index];
 
-        return {
-          line: util.getArg(mapping, 'generatedLine', null),
-          column: util.getArg(mapping, 'generatedColumn', null),
-          lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
-        };
+        if (mapping.source === needle.source) {
+          return {
+            line: util.getArg(mapping, 'generatedLine', null),
+            column: util.getArg(mapping, 'generatedColumn', null),
+            lastColumn: util.getArg(mapping, 'lastGeneratedColumn', null)
+          };
+        }
       }
 
       return {

--- a/test/source-map/test-source-map-consumer.js
+++ b/test/source-map/test-source-map-consumer.js
@@ -564,7 +564,9 @@ define(function (require, exports, module) {
       source: 'bar.coffee'
     });
 
-    assert.equal(mappings.length, 0);
+    assert.equal(mappings.length, 1);
+    assert.equal(mappings[0].line, 4);
+    assert.equal(mappings[0].column, 2);
   };
 
   exports['test allGeneratedPositionsFor source map with no mappings'] = function (assert, util) {

--- a/test/source-map/test-source-map-consumer.js
+++ b/test/source-map/test-source-map-consumer.js
@@ -239,6 +239,11 @@ define(function (require, exports, module) {
       generated: { line: 2, column: 2 },
       source: 'bar.js'
     });
+    smg.addMapping({
+      original: { line: 1, column: 1 },
+      generated: { line: 1, column: 1 },
+      source: 'baz.js'
+    });
 
     var map = SourceMapConsumer.fromSourceMap(smg);
 
@@ -247,6 +252,9 @@ define(function (require, exports, module) {
 
     // When finding generated positions, mappings do not end at the end of the line.
     util.assertMapping(1, 1, 'bar.js', 2, 1, null, null, map, assert, null, true);
+
+    // When finding generated positions with, mappings end at the end of the source.
+    util.assertMapping(null, null, 'bar.js', 3, 1, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
   };
 
   exports['test creating source map consumers with )]}\' prefix'] = function (assert, util) {


### PR DESCRIPTION
We assume that allGeneratedPositionsFor returns an empty list if and only if we've reached the end of the original source: that is, there are no lines greater than or equal than the one we are searching for that have any mappings. We use this in breakpoint sliding for source-mapped sources to determine whether we've reached the end of the original source.

The problem is that allGeneratedPositionsFor also returns an empty lists if there are no mappings for the exact line we are looking for. What it should do is simply return the list of all mappings for the next closest line, if any. This is also consistent with how generatedPositionFor works (when using a LUB bias).