### PR TITLE
Add a column argument to allGeneratedPositionsFor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,13 +237,18 @@ and an object is returned with the following properties:
 
 #### SourceMapConsumer.prototype.allGeneratedPositionsFor(originalPosition)
 
-Returns all generated line and column information for the original source
-and line provided. The only argument is an object with the following
-properties:
+Returns all generated line and column information for the original source,
+line, and column provided. If no column is provided, returns all mappings
+corresponding to a single line. Otherwise, returns all mappings corresponding to
+a single line and column.
+
+The only argument is an object with the following properties:
 
 * `source`: The filename of the original source.
 
 * `line`: The line number in the original source.
+
+* `column`: Optional. The column number in the original source.
 
 and an array of objects is returned, each with the following properties:
 

--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -163,12 +163,16 @@ define(function (require, exports, module) {
     };
 
   /**
-   * Returns all generated line and column information for the original source
-   * and line provided. The only argument is an object with the following
-   * properties:
+   * Returns all generated line and column information for the original source,
+   * line, and column provided. If no column is provided, returns all mappings
+   * corresponding to a single line. Otherwise, returns all mappings
+   * corresponding to a single line and column.
+   *
+   * The only argument is an object with the following properties:
    *
    *   - source: The filename of the original source.
    *   - line: The line number in the original source.
+   *   - column: Optional. the column number in the original source.
    *
    * and an array of objects is returned, each with the following properties:
    *
@@ -179,12 +183,12 @@ define(function (require, exports, module) {
     function SourceMapConsumer_allGeneratedPositionsFor(aArgs) {
       // When there is no exact match, BasicSourceMapConsumer.prototype._findMapping
       // returns the index of the closest mapping less than the needle. By
-      // setting needle.originalColumn to Infinity, we thus find the last
-      // mapping for the given line, provided such a mapping exists.
+      // setting needle.originalColumn to 0, we thus find the last mapping for
+      // the given line, provided such a mapping exists.
       var needle = {
         source: util.getArg(aArgs, 'source'),
         originalLine: util.getArg(aArgs, 'line'),
-        originalColumn: 0
+        originalColumn: util.getArg(aArgs, 'column', 0)
       };
 
       if (this.sourceRoot != null) {
@@ -202,11 +206,14 @@ define(function (require, exports, module) {
       if (index >= 0) {
         var mapping = this._originalMappings[index];
         var originalLine = mapping.originalLine;
+        var originalColumn = mapping.originalColumn;
 
         // Iterate until either we run out of mappings, or we run into
         // a mapping for a different line. Since mappings are sorted, this is
         // guaranteed to find all mappings for the line we are searching for.
-        while (mapping && mapping.originalLine === originalLine) {
+        while (mapping && mapping.originalLine === originalLine &&
+               (aArgs.column === undefined ||
+                mapping.originalColumn === originalColumn)) {
           mappings.push({
             line: util.getArg(mapping, 'generatedLine', null),
             column: util.getArg(mapping, 'generatedColumn', null),

--- a/test/source-map/test-source-map-consumer.js
+++ b/test/source-map/test-source-map-consumer.js
@@ -495,7 +495,7 @@ define(function (require, exports, module) {
     assert.equal(pos.column, 2);
   };
 
-  exports['test allGeneratedPositionsFor'] = function (assert, util) {
+  exports['test allGeneratedPositionsFor for line'] = function (assert, util) {
     var map = new SourceMapGenerator({
       file: 'generated.js'
     });
@@ -538,7 +538,7 @@ define(function (require, exports, module) {
     assert.equal(mappings[1].column, 3);
   };
 
-  exports['test allGeneratedPositionsFor for line with no mappings'] = function (assert, util) {
+  exports['test allGeneratedPositionsFor for line fuzzy'] = function (assert, util) {
     var map = new SourceMapGenerator({
       file: 'generated.js'
     });
@@ -569,7 +569,7 @@ define(function (require, exports, module) {
     assert.equal(mappings[0].column, 2);
   };
 
-  exports['test allGeneratedPositionsFor source map with no mappings'] = function (assert, util) {
+  exports['test allGeneratedPositionsFor for empty source map'] = function (assert, util) {
     var map = new SourceMapGenerator({
       file: 'generated.js'
     });
@@ -581,6 +581,64 @@ define(function (require, exports, module) {
     });
 
     assert.equal(mappings.length, 0);
+  };
+
+  exports['test allGeneratedPositionsFor for column'] = function (assert, util) {
+    var map = new SourceMapGenerator({
+      file: 'generated.js'
+    });
+    map.addMapping({
+      original: { line: 1, column: 1 },
+      generated: { line: 1, column: 2 },
+      source: 'foo.coffee'
+    });
+    map.addMapping({
+      original: { line: 1, column: 1 },
+      generated: { line: 1, column: 3 },
+      source: 'foo.coffee'
+    });
+    map = new SourceMapConsumer(map.toString());
+
+    var mappings = map.allGeneratedPositionsFor({
+      line: 1,
+      column: 1,
+      source: 'foo.coffee'
+    });
+
+    assert.equal(mappings.length, 2);
+    assert.equal(mappings[0].line, 1);
+    assert.equal(mappings[0].column, 2);
+    assert.equal(mappings[1].line, 1);
+    assert.equal(mappings[1].column, 3);
+  };
+
+  exports['test allGeneratedPositionsFor for column fuzzy'] = function (assert, util) {
+    var map = new SourceMapGenerator({
+      file: 'generated.js'
+    });
+    map.addMapping({
+      original: { line: 1, column: 1 },
+      generated: { line: 1, column: 2 },
+      source: 'foo.coffee'
+    });
+    map.addMapping({
+      original: { line: 1, column: 1 },
+      generated: { line: 1, column: 3 },
+      source: 'foo.coffee'
+    });
+    map = new SourceMapConsumer(map.toString());
+
+    var mappings = map.allGeneratedPositionsFor({
+      line: 1,
+      column: 0,
+      source: 'foo.coffee'
+    });
+
+    assert.equal(mappings.length, 2);
+    assert.equal(mappings[0].line, 1);
+    assert.equal(mappings[0].column, 2);
+    assert.equal(mappings[1].line, 1);
+    assert.equal(mappings[1].column, 3);
   };
 
   exports['test computeColumnSpans'] = function (assert, util) {


### PR DESCRIPTION
Some source maps define multiple mappings for a single original column. We need
a way to obtain all mappings for a given column, instead of just the first one.
This patch refactors allGeneratedPositionsFor so that it returns all mappings
for a single line if no column argument is passed (not necessarily the line that
was requested, due to fuzzy search), and all mappings for a single line and
column otherwise.