### PR TITLE
Skipping mappings that exceed line count in generated code

### DIFF
--- a/lib/source-map/source-node.js
+++ b/lib/source-map/source-node.js
@@ -66,6 +66,7 @@ define(function (require, exports, module) {
       // (since `REGEX_NEWLINE` captures its match).
       // Processed fragments are removed from this array, by calling `shiftNextLine`.
       var remainingLines = aGeneratedCode.split(REGEX_NEWLINE);
+      var lineCount = remainingLines.length;
       var shiftNextLine = function() {
         var lineContents = remainingLines.shift();
         // The last line of a file might not have a newline.
@@ -82,6 +83,9 @@ define(function (require, exports, module) {
       var lastMapping = null;
 
       aSourceMapConsumer.eachMapping(function (mapping) {
+        if(mapping.generatedLine > lineCount || !remainingLines.length) {
+          return;
+        }
         if (lastMapping !== null) {
           // We add the code from "lastMapping" to "mapping":
           // First check if there is a new line in between.

--- a/test/source-map/test-source-node.js
+++ b/test/source-map/test-source-node.js
@@ -248,6 +248,43 @@ define(function (require, exports, module) {
     assert.equal(map.mappings, util.emptyMap.mappings);
   });
 
+  exports['test .fromStringWithSourceMap() map with lots of lines'] = forEachNewline(function (assert, util, nl) {
+    var inMap = new SourceMapGenerator({
+      file: 'min.js'
+    });
+    inMap.addMapping({
+      generated: { line: 10, column: 0 },
+      source: 'a.js',
+      original: { line: 10, column: 0 }
+    });
+    inMap.addMapping({
+      generated: { line: 10, column: 1 },
+      source: 'a.js',
+      original: { line: 10, column: 1 }
+    });
+    inMap.addMapping({
+      generated: { line: 1, column: 0 },
+      source: 'a.js',
+      original: { line: 1, column: 0 }
+    });
+    var myMap = inMap.toJSON();
+    var node = SourceNode.fromStringWithSourceMap(
+                              util.testGeneratedCode.replace(/\n/g, nl),
+                              new SourceMapConsumer(myMap));
+    var result = node.toStringWithSourceMap({
+      file: 'min.js'
+    });
+    var map = result.map;
+    var code = result.code;
+
+    assert.equal(code, util.testGeneratedCode.replace(/\n/g, nl));
+    assert.ok(map instanceof SourceMapGenerator, 'map instanceof SourceMapGenerator');
+    map = map.toJSON();
+    assert.equal(map.version, myMap.version);
+    assert.equal(map.file, myMap.file);
+    assert.equal(map.mappings.length, 4, "There are 4 mappings, latter ones ignored");
+  });
+
   exports['test .fromStringWithSourceMap() complex version'] = forEachNewline(function (assert, util, nl) {
     var input = new SourceNode(null, null, null, [
       "(function() {" + nl,
@@ -259,7 +296,6 @@ define(function (require, exports, module) {
     input = input.toStringWithSourceMap({
       file: 'foo.js'
     });
-
     var node = SourceNode.fromStringWithSourceMap(
                               input.code,
                               new SourceMapConsumer(input.map.toString()));


### PR DESCRIPTION
This is a fix for #174. In `fromStringWithSourceMap` we should not
attempt to create mappings for the SourceNode when there are mappings
for lines that exceed the number of lines in the generated code. This
can happen in scenarios where a sourcemap has been transformed a number
of times and new mappings are added each time. There will be "dead
mappings" that refer to generatedLines that no longer exceed in the
generated code. We can safely ignore these. Fixes #174