### PR TITLE
Use files in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-bench/
-test/

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
     "lib": "./lib"
   },
   "main": "./lib/source-map.js",
+  "files": [
+    "lib/",
+    "build/"
+  ],
   "engines": {
     "node": ">=0.8.0"
   },


### PR DESCRIPTION
http://hastebin.com/ibumineyag.sh vs. http://hastebin.com/xutifitico.sh

Difference is dotfiles and `Makefile.dryice.js`.

I'm unsure if `build/` is actually needed for npm, but as it's included now, I left it in :smile: 