### PR TITLE
Fix for #192

### DIFF
--- a/lib/source-map/mapping-list.js
+++ b/lib/source-map/mapping-list.js
@@ -22,7 +22,7 @@ define(function (require, exports, module) {
     var columnA = mappingA.generatedColumn;
     var columnB = mappingB.generatedColumn;
     return lineB > lineA || lineB == lineA && columnB >= columnA ||
-           util.compareByGeneratedPositions(mappingA, mappingB) <= 0;
+           util.compareByGeneratedPositionsInflated(mappingA, mappingB) <= 0;
   }
 
   /**
@@ -75,7 +75,7 @@ define(function (require, exports, module) {
    */
   MappingList.prototype.toArray = function MappingList_toArray() {
     if (!this._sorted) {
-      this._array.sort(util.compareByGeneratedPositions);
+      this._array.sort(util.compareByGeneratedPositionsInflated);
       this._sorted = true;
     }
     return this._array;

--- a/lib/source-map/source-map-consumer.js
+++ b/lib/source-map/source-map-consumer.js
@@ -509,7 +509,7 @@ define(function (require, exports, module) {
         }
       }
 
-      quickSort(generatedMappings, util.compareByGeneratedPositions);
+      quickSort(generatedMappings, util.compareByGeneratedPositionsDeflated);
       this.__generatedMappings = generatedMappings;
 
       quickSort(originalMappings, util.compareByOriginalPositions);
@@ -599,7 +599,7 @@ define(function (require, exports, module) {
         this._generatedMappings,
         "generatedLine",
         "generatedColumn",
-        util.compareByGeneratedPositions,
+        util.compareByGeneratedPositionsDeflated,
         util.getArg(aArgs, 'bias', SourceMapConsumer.GREATEST_LOWER_BOUND)
       );
 
@@ -1068,7 +1068,7 @@ define(function (require, exports, module) {
         };
       };
 
-      quickSort(this.__generatedMappings, util.compareByGeneratedPositions);
+      quickSort(this.__generatedMappings, util.compareByGeneratedPositionsDeflated);
       quickSort(this.__originalMappings, util.compareByOriginalPositions);
     };
 

--- a/lib/source-map/source-map-generator.js
+++ b/lib/source-map/source-map-generator.js
@@ -297,7 +297,6 @@ define(function (require, exports, module) {
       var mapping;
 
       var mappings = this._mappings.toArray();
-
       for (var i = 0, len = mappings.length; i < len; i++) {
         mapping = mappings[i];
 
@@ -310,7 +309,7 @@ define(function (require, exports, module) {
         }
         else {
           if (i > 0) {
-            if (!util.compareByGeneratedPositions(mapping, mappings[i - 1])) {
+            if (!util.compareByGeneratedPositionsInflated(mapping, mappings[i - 1])) {
               continue;
             }
             result += ',';

--- a/lib/source-map/util.js
+++ b/lib/source-map/util.js
@@ -283,15 +283,15 @@ define(function (require, exports, module) {
   exports.compareByOriginalPositions = compareByOriginalPositions;
 
   /**
-   * Comparator between two mappings where the generated positions are
-   * compared.
+   * Comparator between two mappings with deflated source and name indices where
+   * the generated positions are compared.
    *
    * Optionally pass in `true` as `onlyCompareGenerated` to consider two
    * mappings with the same generated line and column, but different
    * source/name/original line and column the same. Useful when searching for a
    * mapping with a stubbed out mapping.
    */
-  function compareByGeneratedPositions(mappingA, mappingB, onlyCompareGenerated) {
+  function compareByGeneratedPositionsDeflated(mappingA, mappingB, onlyCompareGenerated) {
     var cmp = mappingA.generatedLine - mappingB.generatedLine;
     if (cmp !== 0) {
       return cmp;
@@ -319,6 +319,52 @@ define(function (require, exports, module) {
 
     return mappingA.name - mappingB.name;
   };
-  exports.compareByGeneratedPositions = compareByGeneratedPositions;
+  exports.compareByGeneratedPositionsDeflated = compareByGeneratedPositionsDeflated;
+
+  function strcmp(aStr1, aStr2) {
+    if (aStr1 === aStr2) {
+      return 0;
+    }
+
+    if (aStr1 > aStr2) {
+      return 1;
+    }
+
+    return -1;
+  }
+
+  /**
+   * Comparator between two mappings with inflated source and name strings where
+   * the generated positions are compared.
+   */
+  function compareByGeneratedPositionsInflated(mappingA, mappingB) {
+    var cmp = mappingA.generatedLine - mappingB.generatedLine;
+    if (cmp !== 0) {
+      return cmp;
+    }
+
+    cmp = mappingA.generatedColumn - mappingB.generatedColumn;
+    if (cmp !== 0) {
+      return cmp;
+    }
+
+    cmp = strcmp(mappingA.source, mappingB.source);
+    if (cmp !== 0) {
+      return cmp;
+    }
+
+    cmp = mappingA.originalLine - mappingB.originalLine;
+    if (cmp !== 0) {
+      return cmp;
+    }
+
+    cmp = mappingA.originalColumn - mappingB.originalColumn;
+    if (cmp !== 0) {
+      return cmp;
+    }
+
+    return strcmp(mappingA.name, mappingB.name);
+  };
+  exports.compareByGeneratedPositionsInflated = compareByGeneratedPositionsInflated;
 
 });

--- a/test/source-map/test-source-map-generator.js
+++ b/test/source-map/test-source-map-generator.js
@@ -718,4 +718,28 @@ define(function (require, exports, module) {
 
       util.assertEqualMaps(assert, map1.toJSON(), expectedMap.toJSON());
     };
+
+  exports['test issue #192'] = function (assert, util) {
+    var generator = new SourceMapGenerator();
+    generator.addMapping({
+      source: 'a.js',
+      generated: { line: 1, column: 10 },
+      original: { line: 1, column: 10 },
+    });
+    generator.addMapping({
+      source: 'b.js',
+      generated: { line: 1, column: 10 },
+      original: { line: 2, column: 20 },
+    });
+
+    var consumer = new SourceMapConsumer(generator.toJSON());
+
+    var n = 0;
+    consumer.eachMapping(function () { n++ });
+
+    assert.equal(n, 2,
+                 "Should not de-duplicate mappings that have the same " +
+                 "generated positions, but different original positions.");
+  };
+
 });


### PR DESCRIPTION
r? @jlongser 

Ok so in the process of moving to deflated mappings for source map parsing perf gains, the source map generating was now using a compare function that expected `.name` and `.source` to be indices rather than strings.

/me mumbles something about types and having a compiler find bugs for you

This PR splits `compareByGeneratedPosition` into two versions: one for inflated mappings and one for deflated mappings, and adds a regression test.

As I mentioned in #191, we should probably move `SourceMapGenerator` to using deflated mappings as well, since that will likely give a nice perf boost and also clean up these edge cases.