### PR TITLE
Bug 1182194 - Tweak in order to use source-map.js instead of SourceMap.jsm. r=fitzgen

### DIFF
--- a/build/assert-shim.js
+++ b/build/assert-shim.js
@@ -4,7 +4,7 @@
  * Licensed under the New BSD license. See LICENSE or:
  * http://opensource.org/licenses/BSD-3-Clause
  */
-define('test/source-map/assert', ['exports'], function (exports) {
+define('test/source-map/assert', ['require', 'exports'], function (require, exports) {
 
   let do_throw = function (msg) {
     throw new Error(msg);

--- a/build/prefix-utils.jsm
+++ b/build/prefix-utils.jsm
@@ -12,7 +12,8 @@
  * https://github.com/mozilla/source-map/
  */
 
-Components.utils.import('resource://gre/modules/devtools/Require.jsm');
-Components.utils.import('resource://gre/modules/devtools/SourceMap.jsm');
+let loader = Components.classes["@mozilla.org/moz/jssubscript-loader;1"]
+  .getService(Components.interfaces.mozIJSSubScriptLoader);
+loader.loadSubScript("resource://gre/modules/devtools/sourcemap/source-map.js", this);
 
 this.EXPORTED_SYMBOLS = [ "define", "runSourceMapTests" ];

--- a/build/suffix-browser.js
+++ b/build/suffix-browser.js
@@ -6,3 +6,6 @@ this.sourceMap = {
   SourceMapGenerator: require('source-map/source-map-generator').SourceMapGenerator,
   SourceNode: require('source-map/source-node').SourceNode
 };
+if (typeof module === "object" && module && module.exports) {
+  module.exports = this.sourceMap;
+}

--- a/test/source-map/test-api.js
+++ b/test/source-map/test-api.js
@@ -13,8 +13,8 @@ define(function (require, exports, module) {
   try {
     sourceMap = require('../../lib/source-map');
   } catch (e) {
-    sourceMap = {};
-    Components.utils.import('resource:///modules/devtools/SourceMap.jsm', sourceMap);
+    var loader = Components.utils.import("resource://gre/modules/devtools/Loader.jsm", {});
+    sourceMap = loader.devtools.require("devtools/toolkit/sourcemap/source-map");
   }
 
   exports['test that the api is properly exposed in the top level'] = function (assert, util) {


### PR DESCRIPTION
Two small changes.
I'm getting rid of Require.jsm usage on mozilla-central. Instead I'm using builtin module loading shipped within source-map.js and its module loader doesn't take care of `define` second argument `['exports`]`, it just always pass `require` and `exports`.

More context in the bug https://bugzilla.mozilla.org/show_bug.cgi?id=935366