### PR TITLE
Improve serialization perf

### DIFF
--- a/bench/bench-shell-bindings.js
+++ b/bench/bench-shell-bindings.js
@@ -1,3 +1,16 @@
+if (typeof load !== "function") {
+  var fs = require("fs");
+  var vm = require("vm");
+  load = function(file) {
+    var src = fs.readFileSync(file, "utf8");
+    vm.runInThisContext(src);
+  };
+}
+
+if (typeof print !== "function") {
+  print = console.log.bind(console);
+}
+
 load("./scalajs-runtime-sourcemap.js");
 load("./stats.js");
 load("../dist/source-map.js");

--- a/lib/source-map/array-set.js
+++ b/lib/source-map/array-set.js
@@ -49,13 +49,14 @@ define(function (require, exports, module) {
    * @param String aStr
    */
   ArraySet.prototype.add = function ArraySet_add(aStr, aAllowDuplicates) {
-    var isDuplicate = this.has(aStr);
+    var sStr = util.toSetString(aStr);
+    var isDuplicate = this._set.hasOwnProperty(sStr);
     var idx = this._array.length;
     if (!isDuplicate || aAllowDuplicates) {
       this._array.push(aStr);
     }
     if (!isDuplicate) {
-      this._set[util.toSetString(aStr)] = idx;
+      this._set[sStr] = idx;
     }
   };
 
@@ -65,8 +66,8 @@ define(function (require, exports, module) {
    * @param String aStr
    */
   ArraySet.prototype.has = function ArraySet_has(aStr) {
-    return Object.prototype.hasOwnProperty.call(this._set,
-                                                util.toSetString(aStr));
+    var sStr = util.toSetString(aStr);
+    return this._set.hasOwnProperty(sStr);
   };
 
   /**
@@ -75,8 +76,9 @@ define(function (require, exports, module) {
    * @param String aStr
    */
   ArraySet.prototype.indexOf = function ArraySet_indexOf(aStr) {
-    if (this.has(aStr)) {
-      return this._set[util.toSetString(aStr)];
+    var sStr = util.toSetString(aStr);
+    if (this._set.hasOwnProperty(sStr)) {
+      return this._set[sStr];
     }
     throw new Error('"' + aStr + '" is not in the set.');
   };

--- a/lib/source-map/source-map-generator.js
+++ b/lib/source-map/source-map-generator.js
@@ -295,6 +295,8 @@ define(function (require, exports, module) {
       var previousSource = 0;
       var result = '';
       var mapping;
+      var nameIdx;
+      var sourceIdx;
 
       var mappings = this._mappings.toArray();
       for (var i = 0, len = mappings.length; i < len; i++) {
@@ -321,9 +323,9 @@ define(function (require, exports, module) {
         previousGeneratedColumn = mapping.generatedColumn;
 
         if (mapping.source != null) {
-          result += base64VLQ.encode(this._sources.indexOf(mapping.source)
-                                     - previousSource);
-          previousSource = this._sources.indexOf(mapping.source);
+          sourceIdx = this._sources.indexOf(mapping.source);
+          result += base64VLQ.encode(sourceIdx - previousSource);
+          previousSource = sourceIdx;
 
           // lines are stored 0-based in SourceMap spec version 3
           result += base64VLQ.encode(mapping.originalLine - 1
@@ -335,9 +337,9 @@ define(function (require, exports, module) {
           previousOriginalColumn = mapping.originalColumn;
 
           if (mapping.name != null) {
-            result += base64VLQ.encode(this._names.indexOf(mapping.name)
-                                       - previousName);
-            previousName = this._names.indexOf(mapping.name);
+            nameIdx = this._names.indexOf(mapping.name);
+            result += base64VLQ.encode(nameIdx - previousName);
+            previousName = nameIdx;
           }
         }
       }


### PR DESCRIPTION
The "Serializing source map" benchmark time was cut in half. About half of those gains are from reducing the calls to `util.toSetString` in `ArraySet`, the other half is from removing the duplicate calls to `indexOf`.

Before:

```
❯ node bench-shell-bindings.js
Parsing source map
iteration: 5080ms
iteration: 4665ms
iteration: 5053ms
iteration: 4730ms
iteration: 4986ms
{ unit: 'ms', x2: 120325071, x1: 24513, x0: 5 }

Serializing source map
iteration: 8028ms
iteration: 8019ms
iteration: 7959ms
{ unit: 'ms', x2: 192098826, x1: 24006, x0: 3 }
```

After:
```
❯ node bench-shell-bindings.js
Parsing source map
iteration: 4951ms
iteration: 4692ms
iteration: 4969ms
iteration: 4765ms
iteration: 5050ms
{ unit: 'ms', x2: 119416422, x1: 24426, x0: 5 }

Serializing source map
iteration: 3915ms
iteration: 3843ms
iteration: 3778ms
iteration: 3766ms
iteration: 3943ms
iteration: 4147ms
{ unit: 'ms', x2: 91296772, x1: 23392, x0: 6 }
```