### PR TITLE
s/consequtive/consecutive/g - fixing a spelling mistake

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -69,7 +69,7 @@ exports.urlGenerate = urlGenerate;
 /**
  * Normalizes a path, or the path portion of a URL:
  *
- * - Replaces consequtive slashes with one slash.
+ * - Replaces consecutive slashes with one slash.
  * - Removes unnecessary '.' parts.
  * - Removes unnecessary '<dir>/..' parts.
  *


### PR DESCRIPTION
I recently made the same exact spelling mistake in my code, and a grep through my code base revealed it here too. I didn't run `npm run build`, but can if needed.