### PR TITLE
Add source-map typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,6 @@
   "devDependencies": {
     "doctoc": "^0.15.0",
     "webpack": "^1.12.0"
-  }
+  },
+  "typings": "source-map"
 }

--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -1,0 +1,90 @@
+export interface StartOfSourceMap {
+    file?: string;
+    sourceRoot?: string;
+}
+
+export interface RawSourceMap extends StartOfSourceMap {
+    version: string;
+    sources: string[];
+    names: string[];
+    sourcesContent?: string[];
+    mappings: string;
+}
+
+export interface Position {
+    line: number;
+    column: number;
+}
+
+export interface FindPosition extends Position {
+    // SourceMapConsumer.GREATEST_LOWER_BOUND or SourceMapConsumer.LEAST_UPPER_BOUND
+    bias?: number;
+}
+
+export interface MappedPosition extends Position {
+    source: string;
+    name?: string;
+}
+
+export interface MappingItem {
+    source: string;
+    generatedLine: number;
+    generatedColumn: number;
+    originalLine: number;
+    originalColumn: number;
+    name: string;
+}
+
+export class SourceMapConsumer {
+    static GENERATED_ORDER: number;
+    static ORIGINAL_ORDER: number;
+
+    static GREATEST_LOWER_BOUND: number;
+    static LEAST_UPPER_BOUND: number;
+
+    constructor(rawSourceMap: RawSourceMap);
+    computeColumnSpans(): void;
+    originalPositionFor(generatedPosition: FindPosition): MappedPosition;
+    generatedPositionFor(originalPosition: FindPosition): Position;
+    allGeneratedPositionsFor(originalPosition: MappedPosition): Position[];
+    hasContentsOfAllSources(): boolean;
+    sourceContentFor(source: string, returnNullOnMissing?: boolean): string;
+    eachMapping(callback: (mapping: MappingItem) => void, context?: any, order?: number): void;
+}
+
+export interface Mapping {
+    generated: Position;
+    original: Position;
+    source: string;
+    name?: string;
+}
+
+export class SourceMapGenerator {
+    constructor(startOfSourceMap?: StartOfSourceMap);
+    static fromSourceMap(sourceMapConsumer: SourceMapConsumer): SourceMapGenerator;
+    addMapping(mapping: Mapping): void;
+    setSourceContent(sourceFile: string, sourceContent: string): void;
+    applySourceMap(sourceMapConsumer: SourceMapConsumer, sourceFile?: string, sourceMapPath?: string): void;
+    toString(): string;
+}
+
+export interface CodeWithSourceMap {
+    code: string;
+    map: SourceMapGenerator;
+}
+
+export class SourceNode {
+    constructor();
+    constructor(line: number, column: number, source: string);
+    constructor(line: number, column: number, source: string, chunk?: string, name?: string);
+    static fromStringWithSourceMap(code: string, sourceMapConsumer: SourceMapConsumer, relativePath?: string): SourceNode;
+    add(chunk: string): void;
+    prepend(chunk: string): void;
+    setSourceContent(sourceFile: string, sourceContent: string): void;
+    walk(fn: (chunk: string, mapping: MappedPosition) => void): void;
+    walkSourceContents(fn: (file: string, content: string) => void): void;
+    join(sep: string): SourceNode;
+    replaceRight(pattern: string, replacement: string): SourceNode;
+    toString(): string;
+    toStringWithSourceMap(startOfSourceMap?: StartOfSourceMap): CodeWithSourceMap;
+}

--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -16,9 +16,17 @@ export interface Position {
     column: number;
 }
 
+export interface LineRange extends Position {
+    lastColumn: number;
+}
+
 export interface FindPosition extends Position {
     // SourceMapConsumer.GREATEST_LOWER_BOUND or SourceMapConsumer.LEAST_UPPER_BOUND
     bias?: number;
+}
+
+export interface SourceFindPosition extends FindPosition {
+    source: string;
 }
 
 export interface MappedPosition extends Position {
@@ -45,7 +53,7 @@ export class SourceMapConsumer {
     constructor(rawSourceMap: RawSourceMap);
     computeColumnSpans(): void;
     originalPositionFor(generatedPosition: FindPosition): MappedPosition;
-    generatedPositionFor(originalPosition: FindPosition): Position;
+    generatedPositionFor(originalPosition: SourceFindPosition): LineRange;
     allGeneratedPositionsFor(originalPosition: MappedPosition): Position[];
     hasContentsOfAllSources(): boolean;
     sourceContentFor(source: string, returnNullOnMissing?: boolean): string;


### PR DESCRIPTION
TypeScript is now able to find typings that are included with npm packages, using the `typings` property in `package.json`. It would be great if source-map would include typings this way. With this, people using this library with TS will have intellisense and type checks out of the box - much easier than configuring tsd/typings and adjusting their build process.

These typings are based on https://github.com/typed-typings/npm-source-map with some updates.
