### PR TITLE
Fixed "readFileSync" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ Creates a SourceNode from generated code and a SourceMapConsumer.
   should be relative to.
 
 ```js
-var consumer = new SourceMapConsumer(fs.readFileSync("path/to/my-file.js.map"));
+var consumer = new SourceMapConsumer(fs.readFileSync("path/to/my-file.js.map", "utf8"));
 var node = SourceNode.fromStringWithSourceMap(fs.readFileSync("path/to/my-file.js"),
                                               consumer);
 ```


### PR DESCRIPTION
The method `fs.readFileSync` returns a Buffer when no encoding is specified (https://nodejs.org/api/fs.html#fs_fs_readfilesync_file_options) and this causes the `SourceMapConsumer` to fail because it expects a string to execute `JSON.parse`. Therefore an encoding needs to be specified, otherwise SourceMapsConsumer fails with `Error: "version" is a required argument`.