### PR TITLE
Add specific error message for when aOriginal is truthy but empty

### DIFF
--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -259,6 +259,18 @@ SourceMapGenerator.prototype.applySourceMap =
 SourceMapGenerator.prototype._validateMapping =
   function SourceMapGenerator_validateMapping(aGenerated, aOriginal, aSource,
                                               aName) {
+    // When aOriginal is truthy but has empty values for .line and .column,
+    // it is most likely a programmer error. In this case we throw a very
+    // specific error message to try to guide them the right way.
+    // For example: https://github.com/Polymer/polymer-bundler/pull/519
+    if (aOriginal && typeof aOriginal.line !== 'number' && typeof aOriginal.column !== 'number') {
+        throw new Error(
+            'original.line and original.column are not numbers -- you probably meant to omit ' +
+            'the original mapping entirely and only map the generated position. If so, pass ' +
+            'null for the original mapping instead of an object with empty or null values.'
+        );
+    }
+
     if (aGenerated && 'line' in aGenerated && 'column' in aGenerated
         && aGenerated.line > 0 && aGenerated.column >= 0
         && !aOriginal && !aSource && !aName) {


### PR DESCRIPTION
(As discussed in Slack. This PR replaces #264.)

A programmer implementing `source-map` in their own program might think that if they don't specify `original.line` and `original.column` that `source-map` will automatically interpret the mapping as a so-called "Case 1" map, which contains just a generated position and nothing else. However, this is not the case, as the validation in `_validateMapping` is very strict, and expects `aOriginal` to be omitted entirely (or otherwise falsey).

An example of this happening is https://github.com/Polymer/polymer-bundler/pull/519

This PR adds a very specific error message to try to let the person reading the error understand _why_ the error is happening, and what they should probably do to fix it. There's certainly an argument to be made that hyperspecific errors like this don't scale, but seeing as this tripped up people on a project as big as Polymer I figured it might be worth adding.