### PR TITLE
Fix Travis CI by removing install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ cache:
   directories:
     - node_modules
 
-install:
-  - npm i -g npm@latest
-  - npm install
-
 os:
   - linux
   - osx


### PR DESCRIPTION
- `npm i -g npm@latest` breaks testing on old node.js version since latest npm stopped supporting them; also travis installs a proper version of npm related to used node.js, no update is needed
- `npm install` is redundant, since travis runs it anyway

Btw, `os` section may be removed too. Difference between platforms is not important for package. But need wait too long on build because of OSX builds for OSS projects queue.