### PR TITLE
Add source-map.d.ts to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "main": "./source-map.js",
   "files": [
     "source-map.js",
+    "source-map.d.ts",
     "lib/",
     "dist/source-map.debug.js",
     "dist/source-map.js",


### PR DESCRIPTION
Add source-map.d.ts to files in package.json, to ensure it ends up in
the published package.
Fixes #273