### PR TITLE
Updated a comment on quicksort's run-time complexity.

### DIFF
--- a/lib/quick-sort.js
+++ b/lib/quick-sort.js
@@ -68,7 +68,7 @@ function doQuickSort(ary, comparator, p, r) {
     // all the elements that are greater than it after it. The effect is that
     // once partition is done, the pivot is in the exact place it will be when
     // the array is put in sorted order, and it will not need to be moved
-    // again. This runs in O(n) time.
+    // again. This runs in O(n log n) time.
 
     // Always choose a random pivot so that an input array which is reverse
     // sorted does not cause O(n^2) running time.


### PR DESCRIPTION
The lower-bound on deterministic comparison-based sorting algorithms is Ω(n log n) [1], as opposed to O(n). 
[1] - https://www.cs.cmu.edu/~avrim/451f11/lectures/lect0913.pdf