### PR TITLE
Sort mappings on-demand to greatly improve performance

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -144,8 +144,11 @@ SourceMapConsumer.prototype.eachMapping =
 
     var sourceRoot = this.sourceRoot;
     mappings.map(function (mapping) {
-      var source = mapping.source === null ? null : this._sources.at(mapping.source);
-      source = util.computeSourceURL(sourceRoot, source, this._sourceMapURL);
+      var source = null;
+      if(mapping.source !== null) {
+        source = this._sources.at(mapping.source);
+        source = util.computeSourceURL(sourceRoot, source, this._sourceMapURL);
+      }
       return {
         source: source,
         generatedLine: mapping.generatedLine,

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -67,7 +67,7 @@ Object.defineProperty(SourceMapConsumer.prototype, '_generatedMappings', {
   enumerable: true,
   get: function () {
     if (!this.__generatedMappings) {
-      this._parseMappings(this._mappings, this.sourceRoot);
+      this._sortGeneratedMappings();
     }
 
     return this.__generatedMappings;
@@ -80,10 +80,36 @@ Object.defineProperty(SourceMapConsumer.prototype, '_originalMappings', {
   enumerable: true,
   get: function () {
     if (!this.__originalMappings) {
-      this._parseMappings(this._mappings, this.sourceRoot);
+      this._sortOriginalMappings();
     }
 
     return this.__originalMappings;
+  }
+});
+
+SourceMapConsumer.prototype.__generatedMappingsUnsorted = null;
+Object.defineProperty(SourceMapConsumer.prototype, '_generatedMappingsUnsorted', {
+  configurable: true,
+  enumerable: true,
+  get: function () {
+    if (!this.__generatedMappingsUnsorted) {
+      this._parseMappings(this._mappings, this.sourceRoot);
+    }
+
+    return this.__generatedMappingsUnsorted;
+  }
+});
+
+SourceMapConsumer.prototype.__originalMappingsUnsorted = null;
+Object.defineProperty(SourceMapConsumer.prototype, '_originalMappingsUnsorted', {
+  configurable: true,
+  enumerable: true,
+  get: function () {
+    if (!this.__originalMappingsUnsorted) {
+      this._parseMappings(this._mappings, this.sourceRoot);
+    }
+
+    return this.__originalMappingsUnsorted;
   }
 });
 
@@ -101,6 +127,20 @@ SourceMapConsumer.prototype._charIsMappingSeparator =
 SourceMapConsumer.prototype._parseMappings =
   function SourceMapConsumer_parseMappings(aStr, aSourceRoot) {
     throw new Error("Subclasses must implement _parseMappings");
+  };
+
+SourceMapConsumer.prototype._sortGeneratedMappings =
+  function SourceMapConsumer_sortGeneratedMappings() {
+    const mappings = this._generatedMappingsUnsorted;
+    quickSort(mappings, util.compareByGeneratedPositionsDeflated);
+    this.__generatedMappings = mappings;
+  };
+
+SourceMapConsumer.prototype._sortOriginalMappings =
+  function SourceMapConsumer_sortOriginalMappings() {
+    const mappings = this._originalMappingsUnsorted;
+    quickSort(mappings, util.compareByOriginalPositions);
+    this.__originalMappings = mappings;
   };
 
 SourceMapConsumer.GENERATED_ORDER = 1;
@@ -564,11 +604,9 @@ BasicSourceMapConsumer.prototype._parseMappings =
       }
     }
 
-    quickSort(generatedMappings, util.compareByGeneratedPositionsDeflated);
-    this.__generatedMappings = generatedMappings;
+    this.__generatedMappingsUnsorted = generatedMappings;
 
-    quickSort(originalMappings, util.compareByOriginalPositions);
-    this.__originalMappings = originalMappings;
+    this.__originalMappingsUnsorted = originalMappings;
   };
 
 /**
@@ -1097,8 +1135,8 @@ IndexedSourceMapConsumer.prototype.generatedPositionFor =
  */
 IndexedSourceMapConsumer.prototype._parseMappings =
   function IndexedSourceMapConsumer_parseMappings(aStr, aSourceRoot) {
-    this.__generatedMappings = [];
-    this.__originalMappings = [];
+    const generatedMappings = this.__generatedMappingsUnsorted = [];
+    const originalMappings = this.__originalMappingsUnsorted = [];
     for (var i = 0; i < this._sections.length; i++) {
       var section = this._sections[i];
       var sectionMappings = section.consumer._generatedMappings;
@@ -1134,15 +1172,12 @@ IndexedSourceMapConsumer.prototype._parseMappings =
           name: name
         };
 
-        this.__generatedMappings.push(adjustedMapping);
+        generatedMappings.push(adjustedMapping);
         if (typeof adjustedMapping.originalLine === 'number') {
-          this.__originalMappings.push(adjustedMapping);
+          originalMappings.push(adjustedMapping);
         }
       }
     }
-
-    quickSort(this.__generatedMappings, util.compareByGeneratedPositionsDeflated);
-    quickSort(this.__originalMappings, util.compareByOriginalPositions);
   };
 
 exports.IndexedSourceMapConsumer = IndexedSourceMapConsumer;

--- a/test/test-source-map-consumer.js
+++ b/test/test-source-map-consumer.js
@@ -270,6 +270,11 @@ exports['test eachMapping'] = function (assert) {
   map.eachMapping(function (mapping) {
     assert.ok(mapping.source === 'one.js' || mapping.source === 'two.js');
   });
+
+  map = new SourceMapConsumer(util.mapWithSourcelessMapping);
+  map.eachMapping(function (mapping) {
+    assert.ok(mapping.source === null || (typeof mapping.originalColumn === 'number' && typeof mapping.originalLine === 'number'));
+  });
 };
 
 exports['test eachMapping for indexed source maps'] = function(assert) {

--- a/test/util.js
+++ b/test/util.js
@@ -249,6 +249,13 @@ exports.emptyMap = {
   sources: [],
   mappings: ''
 };
+exports.mapWithSourcelessMapping = {
+  version: 3,
+  file: 'example.js',
+  names: [],
+  sources: ['example.js'],
+  mappings: 'AAgCA,C'
+};
 
 
 function assertMapping(generatedLine, generatedColumn, originalSource,


### PR DESCRIPTION
The current implementation of `SourceMapConsumer.prototype._parseMappings` eagerly sorts both generated and original mappings.  However, in certain situations, this is unnecessary.  For example, when composing 2 sourcemaps, I do something like this:

```
const jsToMinjsMap = new SourceMapConsumer(map1);
const generator = SourceMapGenerator.fromSourceMap(jsToMinjsMap);
generator.applySourceMap(new SourceMapConsumer(map2);
```

For both consumers, only the generated mappings are used, so the original mappings never need to be sorted.  This saves a big chunk of time.

Here are benchmarking results before and after the changes in this PR.  The "parse" benchmark accesses generated but not original mappings, which matches what happens in the example outlined above.

This PR is based off of #299 because benchmarks are broken on master.

#### Benchmark Before

> Parsing source map
> iteration: 4360.786ms
> iteration: 4122.001ms
> iteration: 4293.866ms
> iteration: 4114.573ms
> iteration: 4317.637ms
> iteration: 4068.610ms
> [Stats samples: 6, total: 25297 ms, mean: 4216.166666666667 ms, stddev: 137.68384073666743 ms]
> 
> Serializing source map
> iteration: 2061.736ms
> iteration: 2000.969ms
> iteration: 2161.078ms
> iteration: 2048.509ms
> iteration: 1940.526ms
> iteration: 2452.196ms
> iteration: 2112.322ms
> iteration: 2751.964ms
> iteration: 3024.207ms
> iteration: 3088.927ms
> iteration: 6230.904ms
> [Stats samples: 11, total: 29878 ms, mean: 2716.181818181818 ms, stddev: 1293.2112356455923 ms]
> 

#### Benchmark After

> Parsing source map
> iteration: 2260.933ms
> iteration: 2450.733ms
> iteration: 2124.171ms
> iteration: 2432.659ms
> iteration: 2404.654ms
> iteration: 3115.290ms
> iteration: 3107.850ms
> iteration: 3031.653ms
> iteration: 2939.054ms
> [Stats samples: 9, total: 23843 ms, mean: 2649.222222222222 ms, stddev: 415.21214457190433 ms]
> 
> Serializing source map
> iteration: 1929.926ms
> iteration: 1919.806ms
> iteration: 1899.222ms
> iteration: 1858.227ms
> iteration: 1845.405ms
> iteration: 2060.502ms
> iteration: 2000.878ms
> iteration: 2274.669ms
> iteration: 2494.753ms
> iteration: 2731.931ms
> iteration: 5644.601ms
> [Stats samples: 11, total: 26655 ms, mean: 2423.181818181818 ms, stddev: 1160.6862711344525 ms]