### PR TITLE
🐒 Fix use on the web documentation to actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ This is a library to generate and consume the source map format
 
 ## Use on the Web
 
-    <script src="https://raw.githubusercontent.com/mozilla/source-map/master/dist/source-map.min.js" defer></script>
+    <script src="https://unpkg.com/source-map@0.7.0/dist/source-map.js"></script>
+    <script>
+        sourceMap.SourceMapConsumer.initialize({
+            "lib/mappings.wasm": "https://unpkg.com/source-map@0.7.0/lib/mappings.wasm"
+        });
+    </script>
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
There are two fixes:

The old path is no longer part of the dist folder.
The new package that uses wasm requires the user to initialize the path to the lib for things to work.