### PR TITLE
Update source-map TypeScript typings to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "url": "http://github.com/mozilla/source-map.git"
   },
   "main": "./source-map.js",
+  "types": "./source-map.d.ts",
   "files": [
     "source-map.js",
     "source-map.d.ts",

--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for source-map 0.5
+// Type definitions for source-map 0.7
 // Project: https://github.com/mozilla/source-map
 // Definitions by: Morten Houston Ludvigsen <https://github.com/MortenHoustonLudvigsen>,
-//                 Ron Buckton <https://github.com/rbuckton>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+//                 Ron Buckton <https://github.com/rbuckton>,
+//                 John Vilk <https://github.com/jvilk>
+// Definitions: https://github.com/mozilla/source-map
 export type SourceMapUrl = string;
 
 export interface StartOfSourceMap {
@@ -178,6 +179,11 @@ export interface SourceMapConsumer {
      *        `SourceMapConsumer.GENERATED_ORDER`.
      */
     eachMapping(callback: (mapping: MappingItem) => void, context?: any, order?: number): void;
+    /**
+     * Free this source map consumer's associated wasm data that is manually-managed.
+     * Alternatively, you can use SourceMapConsumer.with to avoid needing to remember to call destroy.
+     */
+    destroy(): void;
 }
 
 export interface SourceMapConsumerConstructor {
@@ -188,9 +194,9 @@ export interface SourceMapConsumerConstructor {
     GREATEST_LOWER_BOUND: number;
     LEAST_UPPER_BOUND: number;
 
-    new (rawSourceMap: RawSourceMap, sourceMapUrl?: SourceMapUrl): BasicSourceMapConsumer;
-    new (rawSourceMap: RawIndexMap, sourceMapUrl?: SourceMapUrl): IndexedSourceMapConsumer;
-    new (rawSourceMap: RawSourceMap | RawIndexMap | string, sourceMapUrl?: SourceMapUrl): BasicSourceMapConsumer | IndexedSourceMapConsumer;
+    new (rawSourceMap: RawSourceMap, sourceMapUrl?: SourceMapUrl): Promise<BasicSourceMapConsumer>;
+    new (rawSourceMap: RawIndexMap, sourceMapUrl?: SourceMapUrl): Promise<IndexedSourceMapConsumer>;
+    new (rawSourceMap: RawSourceMap | RawIndexMap | string, sourceMapUrl?: SourceMapUrl): Promise<BasicSourceMapConsumer | IndexedSourceMapConsumer>;
 
     /**
      * Create a BasicSourceMapConsumer from a SourceMapGenerator.
@@ -198,7 +204,39 @@ export interface SourceMapConsumerConstructor {
      * @param sourceMap
      *        The source map that will be consumed.
      */
-    fromSourceMap(sourceMap: SourceMapGenerator, sourceMapUrl?: SourceMapUrl): BasicSourceMapConsumer;
+    fromSourceMap(sourceMap: SourceMapGenerator, sourceMapUrl?: SourceMapUrl): Promise<BasicSourceMapConsumer>;
+
+    /**
+     * Construct a new `SourceMapConsumer` from `rawSourceMap` and `sourceMapUrl`
+     * (see the `SourceMapConsumer` constructor for details. Then, invoke the `async
+     * function f(SourceMapConsumer) -> T` with the newly constructed consumer, wait
+     * for `f` to complete, call `destroy` on the consumer, and return `f`'s return
+     * value.
+     *
+     * You must not use the consumer after `f` completes!
+     *
+     * By using `with`, you do not have to remember to manually call `destroy` on
+     * the consumer, since it will be called automatically once `f` completes.
+     *
+     * ```js
+     * const xSquared = await SourceMapConsumer.with(
+     *   myRawSourceMap,
+     *   null,
+     *   async function (consumer) {
+     *     // Use `consumer` inside here and don't worry about remembering
+     *     // to call `destroy`.
+     *
+     *     const x = await whatever(consumer);
+     *     return x * x;
+     *   }
+     * );
+     *
+     * // You may not use that `consumer` anymore out here; it has
+     * // been destroyed. But you can use `xSquared`.
+     * console.log(xSquared);
+     * ```
+     */
+    with<T>(rawSourceMap: RawSourceMap | RawIndexMap | string, sourceMapUrl: SourceMapUrl | null | undefined, callback: (consumer: BasicSourceMapConsumer | IndexedSourceMapConsumer) => Promise<T> | T): Promise<T>;
 }
 
 export const SourceMapConsumer: SourceMapConsumerConstructor;
@@ -213,7 +251,7 @@ export interface BasicSourceMapConsumer extends SourceMapConsumer {
 export interface BasicSourceMapConsumerConstructor {
     prototype: BasicSourceMapConsumer;
 
-    new (rawSourceMap: RawSourceMap | string): BasicSourceMapConsumer;
+    new (rawSourceMap: RawSourceMap | string): Promise<BasicSourceMapConsumer>;
 
     /**
      * Create a BasicSourceMapConsumer from a SourceMapGenerator.
@@ -221,7 +259,7 @@ export interface BasicSourceMapConsumerConstructor {
      * @param sourceMap
      *        The source map that will be consumed.
      */
-    fromSourceMap(sourceMap: SourceMapGenerator): BasicSourceMapConsumer;
+    fromSourceMap(sourceMap: SourceMapGenerator): Promise<BasicSourceMapConsumer>;
 }
 
 export const BasicSourceMapConsumer: BasicSourceMapConsumerConstructor;
@@ -233,7 +271,7 @@ export interface IndexedSourceMapConsumer extends SourceMapConsumer {
 export interface IndexedSourceMapConsumerConstructor {
     prototype: IndexedSourceMapConsumer;
 
-    new (rawSourceMap: RawIndexMap | string): IndexedSourceMapConsumer;
+    new (rawSourceMap: RawIndexMap | string): Promise<IndexedSourceMapConsumer>;
 }
 
 export const IndexedSourceMapConsumer: IndexedSourceMapConsumerConstructor;


### PR DESCRIPTION
First off: Congrats on the excellent 0.7.0 release! I look forward to measuring the performance impact on my memory leak debugger, [BLeak](https://github.com/plasma-umass/bleak).

The TypeScript typings contained within this repository are incorrect for the current version posted to NPM, which has breaking changes from 0.5.0. As a result, TypeScript code is unable to properly interoperate with the latest version of the library.

I have updated the typings to make the SourceMapConsumer constructors return a Promise and to add typings for the new `destroy()` and `with` methods.

I have also added a `types` field to `package.json`, so users of `source-map` can import from this module without requiring the `@types/source-map` metapackage.

**If you accept and merge this pull request, please publish a new version of source-map to NPM with these changes so TypeScript code can interoperate with 0.7.0!** Otherwise, TypeScript code will continue to use the invalid typings file published with the NPM module.