### PR TITLE
Allow nested consumer usage

### DIFF
--- a/dist/source-map.js
+++ b/dist/source-map.js
@@ -2919,7 +2919,7 @@ module.exports = function wasm() {
     return cachedWasm;
   }
 
-  let currentCallback = null;
+  const callbackStack = [];
 
   cachedWasm = readWasm().then(buffer => {
       return WebAssembly.instantiate(buffer, {
@@ -2960,7 +2960,7 @@ module.exports = function wasm() {
               }
             }
 
-            currentCallback(mapping);
+            callbackStack[callbackStack.length - 1](mapping);
           },
 
           start_all_generated_locations_for: function () { console.time("all_generated_locations_for"); },
@@ -2989,11 +2989,11 @@ module.exports = function wasm() {
     return {
       exports: wasm.instance.exports,
       withMappingCallback: (mappingCallback, f) => {
-        currentCallback = mappingCallback;
+        callbackStack.push(mappingCallback)
         try {
           f();
         } finally {
-          currentCallback = null;
+          callbackStack.pop()
         }
       }
     };

--- a/lib/wasm.js
+++ b/lib/wasm.js
@@ -20,7 +20,7 @@ module.exports = function wasm() {
     return cachedWasm;
   }
 
-  let currentCallback = null;
+  const callbackStack = [];
 
   cachedWasm = readWasm().then(buffer => {
       return WebAssembly.instantiate(buffer, {
@@ -61,7 +61,7 @@ module.exports = function wasm() {
               }
             }
 
-            currentCallback(mapping);
+            callbackStack[callbackStack.length - 1](mapping);
           },
 
           start_all_generated_locations_for: function () { console.time("all_generated_locations_for"); },
@@ -90,11 +90,11 @@ module.exports = function wasm() {
     return {
       exports: wasm.instance.exports,
       withMappingCallback: (mappingCallback, f) => {
-        currentCallback = mappingCallback;
+        callbackStack.push(mappingCallback)
         try {
           f();
         } finally {
-          currentCallback = null;
+          callbackStack.pop()
         }
       }
     };

--- a/test/test-nested-consumer-usage.js
+++ b/test/test-nested-consumer-usage.js
@@ -1,0 +1,80 @@
+const {SourceMapConsumer, SourceMapGenerator} = require('../')
+
+const tsMap = {
+  version: 3,
+  file: "blah.js",
+  sourceRoot: "",
+  sources: ["blah.tsx"],
+  names: [],
+  mappings:
+    ";;AAKA;IACE,MAAM,CAAC,EAAC,MAAM,EAAE,SAAS,EAAC,CAAC;AAC7B,CAAC;AAFD,yBAEC",
+  sourcesContent: [
+    "\ntype Cheese = {\n  readonly cheese: string\n}\n\nexport default function Cheese(): Cheese {\n  return {cheese: 'stilton'};\n}\n"
+  ]
+};
+
+const babelMap = {
+  version: 3,
+  sources: ["blah.tsx"],
+  names: [
+    "Object",
+    "defineProperty",
+    "exports",
+    "value",
+    "Cheese",
+    "cheese",
+    "default"
+  ],
+  mappings:
+    "AAAA;;AACAA,OAAOC,cAAP,CAAsBC,OAAtB,EAA+B,YAA/B,EAA6C,EAAEC,OAAO,IAAT,EAA7C;AACA,SAASC,MAAT,GAAkB;AACd,WAAO,EAAEC,QAAQ,SAAV,EAAP;AACH;AACDH,QAAQI,OAAR,GAAkBF,MAAlB",
+  sourcesContent: [
+    '"use strict";\nObject.defineProperty(exports, "__esModule", { value: true });\nfunction Cheese() {\n    return { cheese: \'stilton\' };\n}\nexports.default = Cheese;\n//# sourceMappingURL=blah.js.map'
+  ]
+};
+
+
+async function composeSourceMaps(
+  tsMap,
+  babelMap,
+  tsFileName,
+) {
+  const tsConsumer = await new SourceMapConsumer(tsMap)
+  const babelConsumer = await new SourceMapConsumer(babelMap)
+  const map = new SourceMapGenerator()
+  babelConsumer.eachMapping(
+    ({
+      source,
+      generatedLine,
+      generatedColumn,
+      originalLine,
+      originalColumn,
+      name,
+    }) => {
+      if (originalLine) {
+        const original = tsConsumer.originalPositionFor({
+          line: originalLine,
+          column: originalColumn,
+        })
+        if (original.line) {
+          map.addMapping({
+            generated: {
+              line: generatedLine,
+              column: generatedColumn,
+            },
+            original: {
+              line: original.line,
+              column: original.column,
+            },
+            source: tsFileName,
+            name: name,
+          })
+        }
+      }
+    }
+  )
+  return map.toJSON()
+}
+
+exports["test nested consumer usage"] = async function (assert) {
+  await composeSourceMaps(tsMap, babelMap, 'blah.tsx')
+};


### PR DESCRIPTION
Hi! :wave:

I was excited to test out the latest source-map for [react-native-typescript-transformer](https://github.com/ds300/react-native-typescript-transformer) and ran into an issue with the way the wasm consumer bindings are written. They assume that the callback passed to, e.g. eachMapping will not make use of another consumer. This resulted in an error which I created a regression test for in this PR, along with a fix.

Cheers!