### PR TITLE
Apply the Firefox eslint rules, minus the Firefox-specific plugins.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,327 @@
+"use strict";
+
+module.exports = {
+  "env": {
+    "node": true,
+    "es6": true
+  },
+
+  "parserOptions": {
+    "ecmaVersion": 9
+  },
+
+  "globals": {
+    "fetch": false,
+    "WebAssembly": false
+  },
+
+  "rules": {
+    // Require spacing around =>
+    "arrow-spacing": "error",
+
+    // Braces only needed for multi-line arrow function blocks
+    // "arrow-body-style": ["error", "as-needed"]
+
+    // Always require spacing around a single line block
+    "block-spacing": "error",
+
+    // No newline before open brace for a block
+    "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
+
+    // No space before always a space after a comma
+    "comma-spacing": ["error", {"after": true, "before": false}],
+
+    // Commas at the end of the line not the start
+    "comma-style": "error",
+
+    // Warn about cyclomatic complexity in functions.
+    // XXX Get this down to 20?
+    "complexity": ["error", 25],
+
+    // Don't require spaces around computed properties
+    "computed-property-spacing": ["error", "never"],
+
+    // Functions must always return something or nothing
+    "consistent-return": "error",
+
+    // Require braces around blocks that start a new line
+    "curly": ["error", "multi-line"],
+
+    // Encourage the use of dot notation whenever possible.
+    "dot-notation": "error",
+
+    // Always require a trailing EOL
+    "eol-last": "error",
+
+    // No spaces between function name and parentheses
+    "func-call-spacing": "error",
+
+    // Require function* name()
+    "generator-star-spacing": ["error", {"after": true, "before": false}],
+
+    // Two space indent
+    // "indent": ["error", 2, { "SwitchCase": 1 }],
+
+    // Space after colon not before in property declarations
+    "key-spacing": ["error", {
+      "afterColon": true,
+      "beforeColon": false,
+      "mode": "minimum"
+    }],
+
+    // Require spaces before and after keywords
+    "keyword-spacing": "error",
+
+    // Unix linebreaks
+    "linebreak-style": ["error", "unix"],
+
+    // Don't enforce the maximum depth that blocks can be nested. The complexity
+    // rule is a better rule to check this.
+    "max-depth": "off",
+
+    // Maximum depth callbacks can be nested.
+    "max-nested-callbacks": ["error", 10],
+
+    // Always require parenthesis for new calls
+    "new-parens": "error",
+
+    // Use [] instead of Array()
+    "no-array-constructor": "error",
+
+    // Disallow use of arguments.caller or arguments.callee.
+    "no-caller": "error",
+
+    // Disallow modifying variables of class declarations.
+    "no-class-assign": "error",
+
+    // Disallow assignment operators in conditional statements
+    "no-cond-assign": "error",
+
+    // Disallow modifying variables that are declared using const.
+    "no-const-assign": "error",
+
+    // Disallow control characters in regular expressions.
+    "no-control-regex": "error",
+
+    // Disallow the use of debugger
+    "no-debugger": "error",
+
+    // Disallow deleting variables
+    "no-delete-var": "error",
+
+    // No duplicate arguments in function declarations
+    "no-dupe-args": "error",
+
+    // Disallow duplicate class members.
+    "no-dupe-class-members": "error",
+
+    // No duplicate keys in object declarations
+    "no-dupe-keys": "error",
+
+    // No duplicate cases in switch statements
+    "no-duplicate-case": "error",
+
+    // If an if block ends with a return no need for an else block
+    "no-else-return": "error",
+
+    // No empty statements
+    "no-empty": ["error", {"allowEmptyCatch": true}],
+
+    // No empty character classes in regex
+    "no-empty-character-class": "error",
+
+    // Disallow empty destructuring
+    "no-empty-pattern": "error",
+
+    // Disallow eval and setInteral/setTimeout with strings
+    "no-eval": "error",
+
+    // No assigning to exception variable
+    "no-ex-assign": "error",
+
+    // Disallow unnecessary calls to .bind()
+    "no-extra-bind": "error",
+
+    // No using !! where casting to boolean is already happening
+    "no-extra-boolean-cast": "error",
+
+    // No double semicolon
+    "no-extra-semi": "error",
+
+    // No overwriting defined functions
+    "no-func-assign": "error",
+
+    // Disallow eval and setInteral/setTimeout with strings
+    "no-implied-eval": "error",
+
+    // No invalid regular expressions
+    "no-invalid-regexp": "error",
+
+    // No odd whitespace characters
+    "no-irregular-whitespace": "error",
+
+    // Disallow the use of the __iterator__ property
+    "no-iterator": "error",
+
+     // No labels
+    "no-labels": "error",
+
+    // Disallow unnecessary nested blocks
+    "no-lone-blocks": "error",
+
+    // No single if block inside an else block
+    "no-lonely-if": "error",
+
+    // no-tabs disallows tabs completely.
+    // "no-mixed-spaces-and-tabs": "error",
+
+    // No unnecessary spacing
+    "no-multi-spaces": ["error", { exceptions: {
+      "ArrayExpression": true,
+      "AssignmentExpression": true,
+      "ObjectExpression": true,
+      "VariableDeclarator": true
+    } }],
+
+    // No reassigning native JS objects
+    "no-native-reassign": "error",
+
+    // Nested ternary statements are confusing
+    "no-nested-ternary": "error",
+
+    // Use {} instead of new Object()
+    "no-new-object": "error",
+
+    // Dissallow use of new wrappers
+    "no-new-wrappers": "error",
+
+    // No Math() or JSON()
+    "no-obj-calls": "error",
+
+    // No octal literals
+    "no-octal": "error",
+
+    // No redeclaring variables
+    "no-redeclare": "error",
+
+    // Disallow multiple spaces in regular expressions
+    "no-regex-spaces": "error",
+
+    // Disallows unnecessary `return await ...`.
+    "no-return-await": "error",
+
+    // Disallow assignments where both sides are exactly the same
+    "no-self-assign": "error",
+
+    // No unnecessary comparisons
+    "no-self-compare": "error",
+
+    // No declaring variables from an outer scope
+    "no-shadow": "error",
+
+    // No declaring variables that hide things like arguments
+    "no-shadow-restricted-names": "error",
+
+    // Disallow sparse arrays
+    "no-sparse-arrays": "error",
+
+    // Disallow tabs.
+    "no-tabs": "error",
+
+    // No trailing whitespace
+    "no-trailing-spaces": "error",
+
+    // No using undeclared variables
+    "no-undef": "error",
+
+    // Error on newline where a semicolon is needed
+    "no-unexpected-multiline": "error",
+
+    // Disallow the use of Boolean literals in conditional expressions.
+    "no-unneeded-ternary": "error",
+
+    // No unreachable statements
+    "no-unreachable": "error",
+
+    // Disallow control flow statements in finally blocks
+    "no-unsafe-finally": "error",
+
+    // No (!foo in bar) or (!object instanceof Class)
+    "no-unsafe-negation": "error",
+
+    // No declaring variables that are never used
+    "no-unused-vars": ["error", {
+      "args": "none",
+      "vars": "local"
+    }],
+
+    // No using variables before defined
+    "no-use-before-define": ["error", "nofunc"],
+
+    // Disallow unnecessary .call() and .apply()
+    "no-useless-call": "error",
+
+    // Don't concatenate string literals together (unless they span multiple
+    // lines)
+    "no-useless-concat": "error",
+
+    // Disallow redundant return statements
+    "no-useless-return": "error",
+
+    // Disallow whitespace before properties.
+    "no-whitespace-before-property": "error",
+
+    // No using with
+    "no-with": "error",
+
+    // Require object-literal shorthand with ES6 method syntax
+    "object-shorthand": ["error", "always", { "avoidQuotes": true }],
+
+    // Require double-quotes everywhere, except where quotes are escaped
+    // or template literals are used.
+    "quotes": ["error", "double", {
+      "allowTemplateLiterals": true,
+      "avoidEscape": true
+    }],
+
+    // No spacing inside rest or spread expressions
+    "rest-spread-spacing": "error",
+
+    // Always require semicolon at end of statement
+    "semi": ["error", "always"],
+
+    // Require space before blocks
+    "space-before-blocks": "error",
+
+    // Never use spaces before function parentheses
+    "space-before-function-paren": ["error", {
+      "anonymous": "never",
+      "asyncArrow": "always",
+      "named": "never"
+    }],
+
+    // No space padding in parentheses
+    "space-in-parens": ["error", "never"],
+
+    // Require spaces around operators
+    "space-infix-ops": ["error", { "int32Hint": true }],
+
+    // ++ and -- should not need spacing
+    "space-unary-ops": ["error", {
+      "nonwords": false,
+      "overrides": {
+        "typeof": false // We tend to use typeof as a function call
+      },
+      "words": true
+    }],
+
+    // Requires or disallows a whitespace (space or tab) beginning a comment
+    "spaced-comment": "error",
+
+    // No comparisons to NaN
+    "use-isnan": "error",
+
+    // Only check typeof against valid results
+    "valid-typeof": "error"
+  }
+};

--- a/dist/source-map.js
+++ b/dist/source-map.js
@@ -99,9 +99,9 @@ function getArg(aArgs, aName, aDefaultValue) {
     return aArgs[aName];
   } else if (arguments.length === 3) {
     return aDefaultValue;
-  } else {
-    throw new Error('"' + aName + '" is a required argument.');
   }
+    throw new Error('"' + aName + '" is a required argument.');
+
 }
 exports.getArg = getArg;
 
@@ -124,19 +124,19 @@ function urlParse(aUrl) {
 exports.urlParse = urlParse;
 
 function urlGenerate(aParsedUrl) {
-  var url = '';
+  var url = "";
   if (aParsedUrl.scheme) {
-    url += aParsedUrl.scheme + ':';
+    url += aParsedUrl.scheme + ":";
   }
-  url += '//';
+  url += "//";
   if (aParsedUrl.auth) {
-    url += aParsedUrl.auth + '@';
+    url += aParsedUrl.auth + "@";
   }
   if (aParsedUrl.host) {
     url += aParsedUrl.host;
   }
   if (aParsedUrl.port) {
-    url += ":" + aParsedUrl.port
+    url += ":" + aParsedUrl.port;
   }
   if (aParsedUrl.path) {
     url += aParsedUrl.path;
@@ -157,7 +157,7 @@ const MAX_CACHED_INPUTS = 32;
 function lruMemoize(f) {
   const cache = [];
 
-  return function (input) {
+  return function(input) {
     for (var i = 0; i < cache.length; i++) {
       if (cache[i].input === input) {
         var temp = cache[0];
@@ -223,14 +223,15 @@ var normalize = lruMemoize(function normalize(aPath) {
     }
   }
 
-  for (var part, up = 0, i = parts.length - 1; i >= 0; i--) {
-    part = parts[i];
-    if (part === '.') {
+  var up = 0;
+  for (i = parts.length - 1; i >= 0; i--) {
+    var part = parts[i];
+    if (part === ".") {
       parts.splice(i, 1);
-    } else if (part === '..') {
+    } else if (part === "..") {
       up++;
     } else if (up > 0) {
-      if (part === '') {
+      if (part === "") {
         // The first part is blank if the path is absolute. Trying to go
         // above the root is a no-op. Therefore we can remove all '..' parts
         // directly after the root.
@@ -242,10 +243,10 @@ var normalize = lruMemoize(function normalize(aPath) {
       }
     }
   }
-  path = parts.join('/');
+  path = parts.join("/");
 
-  if (path === '') {
-    path = isAbsolute ? '/' : '.';
+  if (path === "") {
+    path = isAbsolute ? "/" : ".";
   }
 
   if (url) {
@@ -282,7 +283,7 @@ function join(aRoot, aPath) {
   var aPathUrl = urlParse(aPath);
   var aRootUrl = urlParse(aRoot);
   if (aRootUrl) {
-    aRoot = aRootUrl.path || '/';
+    aRoot = aRootUrl.path || "/";
   }
 
   // `join(foo, '//www.example.org')`
@@ -303,9 +304,9 @@ function join(aRoot, aPath) {
     return urlGenerate(aRootUrl);
   }
 
-  var joined = aPath.charAt(0) === '/'
+  var joined = aPath.charAt(0) === "/"
     ? aPath
-    : normalize(aRoot.replace(/\/+$/, '') + '/' + aPath);
+    : normalize(aRoot.replace(/\/+$/, "") + "/" + aPath);
 
   if (aRootUrl) {
     aRootUrl.path = joined;
@@ -315,8 +316,8 @@ function join(aRoot, aPath) {
 }
 exports.join = join;
 
-exports.isAbsolute = function (aPath) {
-  return aPath.charAt(0) === '/' || urlRegexp.test(aPath);
+exports.isAbsolute = function(aPath) {
+  return aPath.charAt(0) === "/" || urlRegexp.test(aPath);
 };
 
 /**
@@ -330,14 +331,14 @@ function relative(aRoot, aPath) {
     aRoot = ".";
   }
 
-  aRoot = aRoot.replace(/\/$/, '');
+  aRoot = aRoot.replace(/\/$/, "");
 
   // It is possible for the path to be above the root. In this case, simply
   // checking whether the root is a prefix of the path won't work. Instead, we
   // need to remove components from the root one by one, until either we find
   // a prefix that fits, or we run out of components to remove.
   var level = 0;
-  while (aPath.indexOf(aRoot + '/') !== 0) {
+  while (aPath.indexOf(aRoot + "/") !== 0) {
     var index = aRoot.lastIndexOf("/");
     if (index < 0) {
       return aPath;
@@ -359,12 +360,12 @@ function relative(aRoot, aPath) {
 }
 exports.relative = relative;
 
-var supportsNullProto = (function () {
+var supportsNullProto = (function() {
   var obj = Object.create(null);
-  return !('__proto__' in obj);
+  return !("__proto__" in obj);
 }());
 
-function identity (s) {
+function identity(s) {
   return s;
 }
 
@@ -379,7 +380,7 @@ function identity (s) {
  */
 function toSetString(aStr) {
   if (isProtoString(aStr)) {
-    return '$' + aStr;
+    return "$" + aStr;
   }
 
   return aStr;
@@ -406,15 +407,15 @@ function isProtoString(s) {
     return false;
   }
 
-  if (s.charCodeAt(length - 1) !== 95  /* '_' */ ||
-      s.charCodeAt(length - 2) !== 95  /* '_' */ ||
+  if (s.charCodeAt(length - 1) !== 95 /* '_' */ ||
+      s.charCodeAt(length - 2) !== 95 /* '_' */ ||
       s.charCodeAt(length - 3) !== 111 /* 'o' */ ||
       s.charCodeAt(length - 4) !== 116 /* 't' */ ||
       s.charCodeAt(length - 5) !== 111 /* 'o' */ ||
       s.charCodeAt(length - 6) !== 114 /* 'r' */ ||
       s.charCodeAt(length - 7) !== 112 /* 'p' */ ||
-      s.charCodeAt(length - 8) !== 95  /* '_' */ ||
-      s.charCodeAt(length - 9) !== 95  /* '_' */) {
+      s.charCodeAt(length - 8) !== 95 /* '_' */ ||
+      s.charCodeAt(length - 9) !== 95 /* '_' */) {
     return false;
   }
 
@@ -564,7 +565,7 @@ exports.compareByGeneratedPositionsInflated = compareByGeneratedPositionsInflate
  * JSON.
  */
 function parseSourceMapInput(str) {
-  return JSON.parse(str.replace(/^\)]}'[^\n]*\n/, ''));
+  return JSON.parse(str.replace(/^\)]}'[^\n]*\n/, ""));
 }
 exports.parseSourceMapInput = parseSourceMapInput;
 
@@ -573,12 +574,12 @@ exports.parseSourceMapInput = parseSourceMapInput;
  * URL, and the source map's URL.
  */
 function computeSourceURL(sourceRoot, sourceURL, sourceMapURL) {
-  sourceURL = sourceURL || '';
+  sourceURL = sourceURL || "";
 
   if (sourceRoot) {
     // This follows what Chrome does.
-    if (sourceRoot[sourceRoot.length - 1] !== '/' && sourceURL[0] !== '/') {
-      sourceRoot += '/';
+    if (sourceRoot[sourceRoot.length - 1] !== "/" && sourceURL[0] !== "/") {
+      sourceRoot += "/";
     }
     // The spec says:
     //   Line 4: An optional source root, useful for relocating source
@@ -609,7 +610,7 @@ function computeSourceURL(sourceRoot, sourceURL, sourceMapURL) {
     }
     if (parsed.path) {
       // Strip the last path component, but keep the "/".
-      var index = parsed.path.lastIndexOf('/');
+      var index = parsed.path.lastIndexOf("/");
       if (index >= 0) {
         parsed.path = parsed.path.substring(0, index + 1);
       }
@@ -650,9 +651,9 @@ function SourceMapGenerator(aArgs) {
   if (!aArgs) {
     aArgs = {};
   }
-  this._file = util.getArg(aArgs, 'file', null);
-  this._sourceRoot = util.getArg(aArgs, 'sourceRoot', null);
-  this._skipValidation = util.getArg(aArgs, 'skipValidation', false);
+  this._file = util.getArg(aArgs, "file", null);
+  this._sourceRoot = util.getArg(aArgs, "sourceRoot", null);
+  this._skipValidation = util.getArg(aArgs, "skipValidation", false);
   this._sources = new ArraySet();
   this._names = new ArraySet();
   this._mappings = new MappingList();
@@ -671,9 +672,9 @@ SourceMapGenerator.fromSourceMap =
     var sourceRoot = aSourceMapConsumer.sourceRoot;
     var generator = new SourceMapGenerator({
       file: aSourceMapConsumer.file,
-      sourceRoot: sourceRoot
+      sourceRoot
     });
-    aSourceMapConsumer.eachMapping(function (mapping) {
+    aSourceMapConsumer.eachMapping(function(mapping) {
       var newMapping = {
         generated: {
           line: mapping.generatedLine,
@@ -699,7 +700,7 @@ SourceMapGenerator.fromSourceMap =
 
       generator.addMapping(newMapping);
     });
-    aSourceMapConsumer.sources.forEach(function (sourceFile) {
+    aSourceMapConsumer.sources.forEach(function(sourceFile) {
       var sourceRelative = sourceFile;
       if (sourceRoot !== null) {
         sourceRelative = util.relative(sourceRoot, sourceFile);
@@ -729,10 +730,10 @@ SourceMapGenerator.fromSourceMap =
  */
 SourceMapGenerator.prototype.addMapping =
   function SourceMapGenerator_addMapping(aArgs) {
-    var generated = util.getArg(aArgs, 'generated');
-    var original = util.getArg(aArgs, 'original', null);
-    var source = util.getArg(aArgs, 'source', null);
-    var name = util.getArg(aArgs, 'name', null);
+    var generated = util.getArg(aArgs, "generated");
+    var original = util.getArg(aArgs, "original", null);
+    var source = util.getArg(aArgs, "source", null);
+    var name = util.getArg(aArgs, "name", null);
 
     if (!this._skipValidation) {
       this._validateMapping(generated, original, source, name);
@@ -757,8 +758,8 @@ SourceMapGenerator.prototype.addMapping =
       generatedColumn: generated.column,
       originalLine: original != null && original.line,
       originalColumn: original != null && original.column,
-      source: source,
-      name: name
+      source,
+      name
     });
   };
 
@@ -812,7 +813,7 @@ SourceMapGenerator.prototype.applySourceMap =
     if (aSourceFile == null) {
       if (aSourceMapConsumer.file == null) {
         throw new Error(
-          'SourceMapGenerator.prototype.applySourceMap requires either an explicit source file, ' +
+          "SourceMapGenerator.prototype.applySourceMap requires either an explicit source file, " +
           'or the source map\'s "file" property. Both were omitted.'
         );
       }
@@ -831,7 +832,7 @@ SourceMapGenerator.prototype.applySourceMap =
     var newNames = new ArraySet();
 
     // Find mappings for the "sourceFile"
-    this._mappings.unsortedForEach(function (mapping) {
+    this._mappings.unsortedForEach(function(mapping) {
       if (mapping.source === sourceFile && mapping.originalLine != null) {
         // Check if it can be mapped by the source map, then update the mapping.
         var original = aSourceMapConsumer.originalPositionFor({
@@ -842,7 +843,7 @@ SourceMapGenerator.prototype.applySourceMap =
           // Copy mapping
           mapping.source = original.source;
           if (aSourceMapPath != null) {
-            mapping.source = util.join(aSourceMapPath, mapping.source)
+            mapping.source = util.join(aSourceMapPath, mapping.source);
           }
           if (sourceRoot != null) {
             mapping.source = util.relative(sourceRoot, mapping.source);
@@ -870,16 +871,16 @@ SourceMapGenerator.prototype.applySourceMap =
     this._names = newNames;
 
     // Copy sourcesContents of applied map.
-    aSourceMapConsumer.sources.forEach(function (sourceFile) {
-      var content = aSourceMapConsumer.sourceContentFor(sourceFile);
+    aSourceMapConsumer.sources.forEach(function(srcFile) {
+      var content = aSourceMapConsumer.sourceContentFor(srcFile);
       if (content != null) {
         if (aSourceMapPath != null) {
-          sourceFile = util.join(aSourceMapPath, sourceFile);
+          srcFile = util.join(aSourceMapPath, srcFile);
         }
         if (sourceRoot != null) {
-          sourceFile = util.relative(sourceRoot, sourceFile);
+          srcFile = util.relative(sourceRoot, srcFile);
         }
-        this.setSourceContent(sourceFile, content);
+        this.setSourceContent(srcFile, content);
       }
     }, this);
   };
@@ -902,30 +903,28 @@ SourceMapGenerator.prototype._validateMapping =
     // it is most likely a programmer error. In this case we throw a very
     // specific error message to try to guide them the right way.
     // For example: https://github.com/Polymer/polymer-bundler/pull/519
-    if (aOriginal && typeof aOriginal.line !== 'number' && typeof aOriginal.column !== 'number') {
+    if (aOriginal && typeof aOriginal.line !== "number" && typeof aOriginal.column !== "number") {
         throw new Error(
-            'original.line and original.column are not numbers -- you probably meant to omit ' +
-            'the original mapping entirely and only map the generated position. If so, pass ' +
-            'null for the original mapping instead of an object with empty or null values.'
+            "original.line and original.column are not numbers -- you probably meant to omit " +
+            "the original mapping entirely and only map the generated position. If so, pass " +
+            "null for the original mapping instead of an object with empty or null values."
         );
     }
 
-    if (aGenerated && 'line' in aGenerated && 'column' in aGenerated
+    if (aGenerated && "line" in aGenerated && "column" in aGenerated
         && aGenerated.line > 0 && aGenerated.column >= 0
         && !aOriginal && !aSource && !aName) {
       // Case 1.
-      return;
-    }
-    else if (aGenerated && 'line' in aGenerated && 'column' in aGenerated
-             && aOriginal && 'line' in aOriginal && 'column' in aOriginal
+
+    } else if (aGenerated && "line" in aGenerated && "column" in aGenerated
+             && aOriginal && "line" in aOriginal && "column" in aOriginal
              && aGenerated.line > 0 && aGenerated.column >= 0
              && aOriginal.line > 0 && aOriginal.column >= 0
              && aSource) {
       // Cases 2 and 3.
-      return;
-    }
-    else {
-      throw new Error('Invalid mapping: ' + JSON.stringify({
+
+    } else {
+      throw new Error("Invalid mapping: " + JSON.stringify({
         generated: aGenerated,
         source: aSource,
         original: aOriginal,
@@ -946,7 +945,7 @@ SourceMapGenerator.prototype._serializeMappings =
     var previousOriginalLine = 0;
     var previousName = 0;
     var previousSource = 0;
-    var result = '';
+    var result = "";
     var next;
     var mapping;
     var nameIdx;
@@ -955,23 +954,20 @@ SourceMapGenerator.prototype._serializeMappings =
     var mappings = this._mappings.toArray();
     for (var i = 0, len = mappings.length; i < len; i++) {
       mapping = mappings[i];
-      next = ''
+      next = "";
 
       if (mapping.generatedLine !== previousGeneratedLine) {
         previousGeneratedColumn = 0;
         while (mapping.generatedLine !== previousGeneratedLine) {
-          next += ';';
+          next += ";";
           previousGeneratedLine++;
         }
-      }
-      else {
-        if (i > 0) {
+      } else if (i > 0) {
           if (!util.compareByGeneratedPositionsInflated(mapping, mappings[i - 1])) {
             continue;
           }
-          next += ',';
+          next += ",";
         }
-      }
 
       next += base64VLQ.encode(mapping.generatedColumn
                                  - previousGeneratedColumn);
@@ -1006,7 +1002,7 @@ SourceMapGenerator.prototype._serializeMappings =
 
 SourceMapGenerator.prototype._generateSourcesContent =
   function SourceMapGenerator_generateSourcesContent(aSources, aSourceRoot) {
-    return aSources.map(function (source) {
+    return aSources.map(function(source) {
       if (!this._sourcesContents) {
         return null;
       }
@@ -1139,6 +1135,7 @@ function toVLQSigned(aValue) {
  *   2 (10 binary) becomes 1, 3 (11 binary) becomes -1
  *   4 (100 binary) becomes 2, 5 (101 binary) becomes -2
  */
+// eslint-disable-next-line no-unused-vars
 function fromVLQSigned(aValue) {
   var isNegative = (aValue & 1) === 1;
   var shifted = aValue >> 1;
@@ -1247,10 +1244,10 @@ ArraySet.prototype.add = function ArraySet_add(aStr, aAllowDuplicates) {
 ArraySet.prototype.has = function ArraySet_has(aStr) {
   if (hasNativeMap) {
     return this._set.has(aStr);
-  } else {
+  }
     var sStr = util.toSetString(aStr);
     return has.call(this._set, sStr);
-  }
+
 };
 
 /**
@@ -1283,7 +1280,7 @@ ArraySet.prototype.at = function ArraySet_at(aIdx) {
   if (aIdx >= 0 && aIdx < this._array.length) {
     return this._array[aIdx];
   }
-  throw new Error('No element indexed by ' + aIdx);
+  throw new Error("No element indexed by " + aIdx);
 };
 
 /**
@@ -1370,12 +1367,12 @@ exports.SourceNode = __webpack_require__(13).SourceNode;
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var intToCharMap = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'.split('');
+var intToCharMap = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
 
 /**
  * Encode an integer in the range of 0 to 63 to a single base 64 digit.
  */
-exports.encode = function (number) {
+exports.encode = function(number) {
   if (0 <= number && number < intToCharMap.length) {
     return intToCharMap[number];
   }
@@ -1482,13 +1479,13 @@ exports.MappingList = MappingList;
 var util = __webpack_require__(0);
 var binarySearch = __webpack_require__(9);
 var ArraySet = __webpack_require__(3).ArraySet;
-var base64VLQ = __webpack_require__(2);
+var base64VLQ = __webpack_require__(2); // eslint-disable-line no-unused-vars
 var readWasm = __webpack_require__(4);
 var wasm = __webpack_require__(12);
 
 function SourceMapConsumer(aSourceMap, aSourceMapURL) {
   var sourceMap = aSourceMap;
-  if (typeof aSourceMap === 'string') {
+  if (typeof aSourceMap === "string") {
     sourceMap = util.parseSourceMapInput(aSourceMap);
   }
 
@@ -1505,7 +1502,7 @@ SourceMapConsumer.initialize = opts => {
 
 SourceMapConsumer.fromSourceMap = function(aSourceMap, aSourceMapURL) {
   return BasicSourceMapConsumer.fromSourceMap(aSourceMap, aSourceMapURL);
-}
+};
 
 /**
  * Construct a new `SourceMapConsumer` from `rawSourceMap` and `sourceMapUrl`
@@ -1675,24 +1672,24 @@ exports.SourceMapConsumer = SourceMapConsumer;
  */
 function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   var sourceMap = aSourceMap;
-  if (typeof aSourceMap === 'string') {
+  if (typeof aSourceMap === "string") {
     sourceMap = util.parseSourceMapInput(aSourceMap);
   }
 
-  var version = util.getArg(sourceMap, 'version');
-  var sources = util.getArg(sourceMap, 'sources');
+  var version = util.getArg(sourceMap, "version");
+  var sources = util.getArg(sourceMap, "sources");
   // Sass 3.3 leaves out the 'names' array, so we deviate from the spec (which
   // requires the array) to play nice here.
-  var names = util.getArg(sourceMap, 'names', []);
-  var sourceRoot = util.getArg(sourceMap, 'sourceRoot', null);
-  var sourcesContent = util.getArg(sourceMap, 'sourcesContent', null);
-  var mappings = util.getArg(sourceMap, 'mappings');
-  var file = util.getArg(sourceMap, 'file', null);
+  var names = util.getArg(sourceMap, "names", []);
+  var sourceRoot = util.getArg(sourceMap, "sourceRoot", null);
+  var sourcesContent = util.getArg(sourceMap, "sourcesContent", null);
+  var mappings = util.getArg(sourceMap, "mappings");
+  var file = util.getArg(sourceMap, "file", null);
 
   // Once again, Sass deviates from the spec and supplies the version as a
   // string rather than a number, so we use loose equality checking here.
   if (version != this._version) {
-    throw new Error('Unsupported version: ' + version);
+    throw new Error("Unsupported version: " + version);
   }
 
   if (sourceRoot) {
@@ -1709,7 +1706,7 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
     // the source root, if the source root is absolute. Not doing this would
     // be particularly problematic when the source root is a prefix of the
     // source (valid, but why??). See github issue #199 and bugzil.la/1188982.
-    .map(function (source) {
+    .map(function(source) {
       return sourceRoot && util.isAbsolute(sourceRoot) && util.isAbsolute(source)
         ? util.relative(sourceRoot, source)
         : source;
@@ -1722,7 +1719,7 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   this._names = ArraySet.fromArray(names.map(String), true);
   this._sources = ArraySet.fromArray(sources, true);
 
-  this._absoluteSources = this._sources.toArray().map(function (s) {
+  this._absoluteSources = this._sources.toArray().map(function(s) {
     return util.computeSourceURL(sourceRoot, s, aSourceMapURL);
   });
 
@@ -1736,8 +1733,8 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   this._mappingsPtr = 0;
   this._wasm = null;
 
-  return wasm().then(wasm => {
-    this._wasm = wasm;
+  return wasm().then(w => {
+    this._wasm = w;
     return this;
   });
 }
@@ -1793,13 +1790,13 @@ BasicSourceMapConsumer.prototype._version = 3;
 /**
  * The list of original sources.
  */
-Object.defineProperty(BasicSourceMapConsumer.prototype, 'sources', {
-  get: function () {
+Object.defineProperty(BasicSourceMapConsumer.prototype, "sources", {
+  get() {
     return this._absoluteSources.slice();
   }
 });
 
-BasicSourceMapConsumer.prototype._getMappingsPtr = function () {
+BasicSourceMapConsumer.prototype._getMappingsPtr = function() {
   if (this._mappingsPtr === 0) {
     this._parseMappings(this._mappings, this.sourceRoot);
   }
@@ -1841,7 +1838,7 @@ BasicSourceMapConsumer.prototype._parseMappings =
           break;
         case 4:
           msg += "invalid base 64 character while parsing a VLQ";
-          break
+          break;
         default:
           msg += "unknown error code";
           break;
@@ -1889,8 +1886,8 @@ BasicSourceMapConsumer.prototype.eachMapping =
 
 BasicSourceMapConsumer.prototype.allGeneratedPositionsFor =
   function BasicSourceMapConsumer_allGeneratedPositionsFor(aArgs) {
-    var source = util.getArg(aArgs, 'source');
-    var originalLine = util.getArg(aArgs, 'line');
+    var source = util.getArg(aArgs, "source");
+    var originalLine = util.getArg(aArgs, "line");
     var originalColumn = aArgs.column || 0;
 
     source = this._findSourceIndex(source);
@@ -1924,7 +1921,7 @@ BasicSourceMapConsumer.prototype.allGeneratedPositionsFor =
           this._getMappingsPtr(),
           source,
           originalLine - 1,
-          'column' in aArgs,
+          "column" in aArgs,
           originalColumn
         );
       }
@@ -1982,8 +1979,8 @@ BasicSourceMapConsumer.prototype.computeColumnSpans =
 BasicSourceMapConsumer.prototype.originalPositionFor =
   function SourceMapConsumer_originalPositionFor(aArgs) {
     var needle = {
-      generatedLine: util.getArg(aArgs, 'line'),
-      generatedColumn: util.getArg(aArgs, 'column')
+      generatedLine: util.getArg(aArgs, "line"),
+      generatedColumn: util.getArg(aArgs, "column")
     };
 
     if (needle.generatedLine < 1) {
@@ -1994,7 +1991,7 @@ BasicSourceMapConsumer.prototype.originalPositionFor =
       throw new Error("Column numbers must be >= 0");
     }
 
-    var bias = util.getArg(aArgs, 'bias', SourceMapConsumer.GREATEST_LOWER_BOUND);
+    var bias = util.getArg(aArgs, "bias", SourceMapConsumer.GREATEST_LOWER_BOUND);
     if (bias == null) {
       bias = SourceMapConsumer.GREATEST_LOWER_BOUND;
     }
@@ -2011,22 +2008,22 @@ BasicSourceMapConsumer.prototype.originalPositionFor =
 
     if (mapping) {
       if (mapping.generatedLine === needle.generatedLine) {
-        var source = util.getArg(mapping, 'source', null);
+        var source = util.getArg(mapping, "source", null);
         if (source !== null) {
           source = this._sources.at(source);
           source = util.computeSourceURL(this.sourceRoot, source, this._sourceMapURL);
         }
 
-        var name = util.getArg(mapping, 'name', null);
+        var name = util.getArg(mapping, "name", null);
         if (name !== null) {
           name = this._names.at(name);
         }
 
         return {
-          source: source,
-          line: util.getArg(mapping, 'originalLine', null),
-          column: util.getArg(mapping, 'originalColumn', null),
-          name: name
+          source,
+          line: util.getArg(mapping, "originalLine", null),
+          column: util.getArg(mapping, "originalColumn", null),
+          name
         };
       }
     }
@@ -2049,7 +2046,7 @@ BasicSourceMapConsumer.prototype.hasContentsOfAllSources =
       return false;
     }
     return this.sourcesContent.length >= this._sources.size() &&
-      !this.sourcesContent.some(function (sc) { return sc == null; });
+      !this.sourcesContent.some(function(sc) { return sc == null; });
   };
 
 /**
@@ -2083,7 +2080,7 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
       var fileUriAbsPath = relativeSource.replace(/^file:\/\//, "");
       if (url.scheme == "file"
           && this._sources.has(fileUriAbsPath)) {
-        return this.sourcesContent[this._sources.indexOf(fileUriAbsPath)]
+        return this.sourcesContent[this._sources.indexOf(fileUriAbsPath)];
       }
 
       if ((!url.path || url.path == "/")
@@ -2099,9 +2096,9 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
     if (nullOnMissing) {
       return null;
     }
-    else {
+
       throw new Error('"' + relativeSource + '" is not in the SourceMap.');
-    }
+
   };
 
 /**
@@ -2129,7 +2126,7 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
  */
 BasicSourceMapConsumer.prototype.generatedPositionFor =
   function SourceMapConsumer_generatedPositionFor(aArgs) {
-    var source = util.getArg(aArgs, 'source');
+    var source = util.getArg(aArgs, "source");
     source = this._findSourceIndex(source);
     if (source < 0) {
       return {
@@ -2140,9 +2137,9 @@ BasicSourceMapConsumer.prototype.generatedPositionFor =
     }
 
     var needle = {
-      source: source,
-      originalLine: util.getArg(aArgs, 'line'),
-      originalColumn: util.getArg(aArgs, 'column')
+      source,
+      originalLine: util.getArg(aArgs, "line"),
+      originalColumn: util.getArg(aArgs, "column")
     };
 
     if (needle.originalLine < 1) {
@@ -2153,7 +2150,7 @@ BasicSourceMapConsumer.prototype.generatedPositionFor =
       throw new Error("Column numbers must be >= 0");
     }
 
-    var bias = util.getArg(aArgs, 'bias', SourceMapConsumer.GREATEST_LOWER_BOUND);
+    var bias = util.getArg(aArgs, "bias", SourceMapConsumer.GREATEST_LOWER_BOUND);
     if (bias == null) {
       bias = SourceMapConsumer.GREATEST_LOWER_BOUND;
     }
@@ -2176,8 +2173,8 @@ BasicSourceMapConsumer.prototype.generatedPositionFor =
           lastColumn = Infinity;
         }
         return {
-          line: util.getArg(mapping, 'generatedLine', null),
-          column: util.getArg(mapping, 'generatedColumn', null),
+          line: util.getArg(mapping, "generatedLine", null),
+          column: util.getArg(mapping, "generatedColumn", null),
           lastColumn,
         };
       }
@@ -2243,15 +2240,15 @@ exports.BasicSourceMapConsumer = BasicSourceMapConsumer;
  */
 function IndexedSourceMapConsumer(aSourceMap, aSourceMapURL) {
   var sourceMap = aSourceMap;
-  if (typeof aSourceMap === 'string') {
+  if (typeof aSourceMap === "string") {
     sourceMap = util.parseSourceMapInput(aSourceMap);
   }
 
-  var version = util.getArg(sourceMap, 'version');
-  var sections = util.getArg(sourceMap, 'sections');
+  var version = util.getArg(sourceMap, "version");
+  var sections = util.getArg(sourceMap, "sections");
 
   if (version != this._version) {
-    throw new Error('Unsupported version: ' + version);
+    throw new Error("Unsupported version: " + version);
   }
 
   this._sources = new ArraySet();
@@ -2265,20 +2262,20 @@ function IndexedSourceMapConsumer(aSourceMap, aSourceMapURL) {
     if (s.url) {
       // The url field will require support for asynchronicity.
       // See https://github.com/mozilla/source-map/issues/16
-      throw new Error('Support for url field in sections not implemented.');
+      throw new Error("Support for url field in sections not implemented.");
     }
-    var offset = util.getArg(s, 'offset');
-    var offsetLine = util.getArg(offset, 'line');
-    var offsetColumn = util.getArg(offset, 'column');
+    var offset = util.getArg(s, "offset");
+    var offsetLine = util.getArg(offset, "line");
+    var offsetColumn = util.getArg(offset, "column");
 
     if (offsetLine < lastOffset.line ||
         (offsetLine === lastOffset.line && offsetColumn < lastOffset.column)) {
-      throw new Error('Section offsets must be ordered and non-overlapping.');
+      throw new Error("Section offsets must be ordered and non-overlapping.");
     }
     lastOffset = offset;
 
-    const consumer = new SourceMapConsumer(util.getArg(s, 'map'), aSourceMapURL);
-    return consumer.then(consumer => {
+    const cons = new SourceMapConsumer(util.getArg(s, "map"), aSourceMapURL);
+    return cons.then(consumer => {
       return {
         generatedOffset: {
           // The offset fields are 0-based, but we use 1-based indices when
@@ -2286,11 +2283,11 @@ function IndexedSourceMapConsumer(aSourceMap, aSourceMapURL) {
           generatedLine: offsetLine + 1,
           generatedColumn: offsetColumn + 1
         },
-        consumer: consumer
+        consumer
       };
     });
-  })).then(sections => {
-    this._sections = sections;
+  })).then(s => {
+    this._sections = s;
     return this;
   });
 }
@@ -2329,10 +2326,10 @@ IndexedSourceMapConsumer.prototype.constructor = SourceMapConsumer;
 // `_originalMappings` is ordered by the original positions.
 
 IndexedSourceMapConsumer.prototype.__generatedMappings = null;
-Object.defineProperty(IndexedSourceMapConsumer.prototype, '_generatedMappings', {
+Object.defineProperty(IndexedSourceMapConsumer.prototype, "_generatedMappings", {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     if (!this.__generatedMappings) {
       this._sortGeneratedMappings();
     }
@@ -2342,10 +2339,10 @@ Object.defineProperty(IndexedSourceMapConsumer.prototype, '_generatedMappings', 
 });
 
 IndexedSourceMapConsumer.prototype.__originalMappings = null;
-Object.defineProperty(IndexedSourceMapConsumer.prototype, '_originalMappings', {
+Object.defineProperty(IndexedSourceMapConsumer.prototype, "_originalMappings", {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     if (!this.__originalMappings) {
       this._sortOriginalMappings();
     }
@@ -2355,10 +2352,10 @@ Object.defineProperty(IndexedSourceMapConsumer.prototype, '_originalMappings', {
 });
 
 IndexedSourceMapConsumer.prototype.__generatedMappingsUnsorted = null;
-Object.defineProperty(IndexedSourceMapConsumer.prototype, '_generatedMappingsUnsorted', {
+Object.defineProperty(IndexedSourceMapConsumer.prototype, "_generatedMappingsUnsorted", {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     if (!this.__generatedMappingsUnsorted) {
       this._parseMappings(this._mappings, this.sourceRoot);
     }
@@ -2368,10 +2365,10 @@ Object.defineProperty(IndexedSourceMapConsumer.prototype, '_generatedMappingsUns
 });
 
 IndexedSourceMapConsumer.prototype.__originalMappingsUnsorted = null;
-Object.defineProperty(IndexedSourceMapConsumer.prototype, '_originalMappingsUnsorted', {
+Object.defineProperty(IndexedSourceMapConsumer.prototype, "_originalMappingsUnsorted", {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     if (!this.__originalMappingsUnsorted) {
       this._parseMappings(this._mappings, this.sourceRoot);
     }
@@ -2402,8 +2399,8 @@ IndexedSourceMapConsumer.prototype._version = 3;
 /**
  * The list of original sources.
  */
-Object.defineProperty(IndexedSourceMapConsumer.prototype, 'sources', {
-  get: function () {
+Object.defineProperty(IndexedSourceMapConsumer.prototype, "sources", {
+  get() {
     var sources = [];
     for (var i = 0; i < this._sections.length; i++) {
       for (var j = 0; j < this._sections[i].consumer.sources.length; j++) {
@@ -2436,20 +2433,20 @@ Object.defineProperty(IndexedSourceMapConsumer.prototype, 'sources', {
 IndexedSourceMapConsumer.prototype.originalPositionFor =
   function IndexedSourceMapConsumer_originalPositionFor(aArgs) {
     var needle = {
-      generatedLine: util.getArg(aArgs, 'line'),
-      generatedColumn: util.getArg(aArgs, 'column')
+      generatedLine: util.getArg(aArgs, "line"),
+      generatedColumn: util.getArg(aArgs, "column")
     };
 
     // Find the section containing the generated position we're trying to map
     // to an original position.
     var sectionIndex = binarySearch.search(needle, this._sections,
-      function(needle, section) {
-        var cmp = needle.generatedLine - section.generatedOffset.generatedLine;
+      function(aNeedle, section) {
+        var cmp = aNeedle.generatedLine - section.generatedOffset.generatedLine;
         if (cmp) {
           return cmp;
         }
 
-        return (needle.generatedColumn -
+        return (aNeedle.generatedColumn -
                 section.generatedOffset.generatedColumn);
       });
     var section = this._sections[sectionIndex];
@@ -2480,7 +2477,7 @@ IndexedSourceMapConsumer.prototype.originalPositionFor =
  */
 IndexedSourceMapConsumer.prototype.hasContentsOfAllSources =
   function IndexedSourceMapConsumer_hasContentsOfAllSources() {
-    return this._sections.every(function (s) {
+    return this._sections.every(function(s) {
       return s.consumer.hasContentsOfAllSources();
     });
   };
@@ -2503,9 +2500,9 @@ IndexedSourceMapConsumer.prototype.sourceContentFor =
     if (nullOnMissing) {
       return null;
     }
-    else {
+
       throw new Error('"' + aSource + '" is not in the SourceMap.');
-    }
+
   };
 
 /**
@@ -2533,7 +2530,7 @@ IndexedSourceMapConsumer.prototype.generatedPositionFor =
 
       // Only consider this section if the requested source is in the list of
       // sources of the consumer.
-      if (section.consumer._findSourceIndex(util.getArg(aArgs, 'source')) === -1) {
+      if (section.consumer._findSourceIndex(util.getArg(aArgs, "source")) === -1) {
         continue;
       }
       var generatedPosition = section.consumer.generatedPositionFor(aArgs);
@@ -2589,7 +2586,7 @@ IndexedSourceMapConsumer.prototype._parseMappings =
         // need to offset them to be relative to the start of the concatenated
         // generated file.
         var adjustedMapping = {
-          source: source,
+          source,
           generatedLine: mapping.generatedLine +
             (section.generatedOffset.generatedLine - 1),
           generatedColumn: mapping.generatedColumn +
@@ -2598,11 +2595,11 @@ IndexedSourceMapConsumer.prototype._parseMappings =
             : 0),
           originalLine: mapping.originalLine,
           originalColumn: mapping.originalColumn,
-          name: name
+          name
         };
 
         generatedMappings.push(adjustedMapping);
-        if (typeof adjustedMapping.originalLine === 'number') {
+        if (typeof adjustedMapping.originalLine === "number") {
           originalMappings.push(adjustedMapping);
         }
       }
@@ -2627,14 +2624,14 @@ IndexedSourceMapConsumer.prototype.eachMapping =
     }
 
     var sourceRoot = this.sourceRoot;
-    mappings.map(function (mapping) {
+    mappings.map(function(mapping) {
       var source = null;
       if (mapping.source !== null) {
         source = this._sources.at(mapping.source);
         source = util.computeSourceURL(sourceRoot, source, this._sourceMapURL);
       }
       return {
-        source: source,
+        source,
         generatedLine: mapping.generatedLine,
         generatedColumn: mapping.generatedColumn,
         originalLine: mapping.originalLine,
@@ -2657,11 +2654,11 @@ IndexedSourceMapConsumer.prototype._findMapping =
     // find the best mapping.
 
     if (aNeedle[aLineName] <= 0) {
-      throw new TypeError('Line must be greater than or equal to 1, got '
+      throw new TypeError("Line must be greater than or equal to 1, got "
                           + aNeedle[aLineName]);
     }
     if (aNeedle[aColumnName] < 0) {
-      throw new TypeError('Column must be greater than or equal to 0, got '
+      throw new TypeError("Column must be greater than or equal to 0, got "
                           + aNeedle[aColumnName]);
     }
 
@@ -2670,16 +2667,16 @@ IndexedSourceMapConsumer.prototype._findMapping =
 
 IndexedSourceMapConsumer.prototype.allGeneratedPositionsFor =
   function IndexedSourceMapConsumer_allGeneratedPositionsFor(aArgs) {
-    var line = util.getArg(aArgs, 'line');
+    var line = util.getArg(aArgs, "line");
 
     // When there is no exact match, BasicSourceMapConsumer.prototype._findMapping
     // returns the index of the closest mapping less than the needle. By
     // setting needle.originalColumn to 0, we thus find the last mapping for
     // the given line, provided such a mapping exists.
     var needle = {
-      source: util.getArg(aArgs, 'source'),
+      source: util.getArg(aArgs, "source"),
       originalLine: line,
-      originalColumn: util.getArg(aArgs, 'column', 0)
+      originalColumn: util.getArg(aArgs, "column", 0)
     };
 
     needle.source = this._findSourceIndex(needle.source);
@@ -2719,8 +2716,8 @@ IndexedSourceMapConsumer.prototype.allGeneratedPositionsFor =
             lastColumn = Infinity;
           }
           mappings.push({
-            line: util.getArg(mapping, 'generatedLine', null),
-            column: util.getArg(mapping, 'generatedColumn', null),
+            line: util.getArg(mapping, "generatedLine", null),
+            column: util.getArg(mapping, "generatedColumn", null),
             lastColumn,
           });
 
@@ -2741,8 +2738,8 @@ IndexedSourceMapConsumer.prototype.allGeneratedPositionsFor =
             lastColumn = Infinity;
           }
           mappings.push({
-            line: util.getArg(mapping, 'generatedLine', null),
-            column: util.getArg(mapping, 'generatedColumn', null),
+            line: util.getArg(mapping, "generatedLine", null),
+            column: util.getArg(mapping, "generatedColumn", null),
             lastColumn,
           });
 
@@ -2806,8 +2803,7 @@ function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
   if (cmp === 0) {
     // Found the element we are looking for.
     return mid;
-  }
-  else if (cmp > 0) {
+  } else if (cmp > 0) {
     // Our needle is greater than aHaystack[mid].
     if (aHigh - mid > 1) {
       // The element is in the upper half.
@@ -2818,11 +2814,11 @@ function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
     // we are in termination case (3) or (2) and return the appropriate thing.
     if (aBias == exports.LEAST_UPPER_BOUND) {
       return aHigh < aHaystack.length ? aHigh : -1;
-    } else {
-      return mid;
     }
+      return mid;
+
   }
-  else {
+
     // Our needle is less than aHaystack[mid].
     if (mid - aLow > 1) {
       // The element is in the lower half.
@@ -2832,10 +2828,10 @@ function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
     // we are in termination case (3) or (2) and return the appropriate thing.
     if (aBias == exports.LEAST_UPPER_BOUND) {
       return mid;
-    } else {
-      return aLow < 0 ? -1 : aLow;
     }
-  }
+      return aLow < 0 ? -1 : aLow;
+
+
 }
 
 /**
@@ -2924,7 +2920,7 @@ module.exports = function wasm() {
   cachedWasm = readWasm().then(buffer => {
       return WebAssembly.instantiate(buffer, {
         env: {
-          mapping_callback: function (
+          mapping_callback(
             generatedLine,
             generatedColumn,
 
@@ -2939,7 +2935,7 @@ module.exports = function wasm() {
             hasName,
             name
           ) {
-            const mapping = new Mapping;
+            const mapping = new Mapping();
             // JS uses 1-based line numbers, wasm uses 0-based.
             mapping.generatedLine = generatedLine + 1;
             mapping.generatedColumn = generatedColumn;
@@ -2963,37 +2959,37 @@ module.exports = function wasm() {
             callbackStack[callbackStack.length - 1](mapping);
           },
 
-          start_all_generated_locations_for: function () { console.time("all_generated_locations_for"); },
-          end_all_generated_locations_for: function () { console.timeEnd("all_generated_locations_for"); },
+          start_all_generated_locations_for() { console.time("all_generated_locations_for"); },
+          end_all_generated_locations_for() { console.timeEnd("all_generated_locations_for"); },
 
-          start_compute_column_spans: function () { console.time("compute_column_spans"); },
-          end_compute_column_spans: function () { console.timeEnd("compute_column_spans"); },
+          start_compute_column_spans() { console.time("compute_column_spans"); },
+          end_compute_column_spans() { console.timeEnd("compute_column_spans"); },
 
-          start_generated_location_for: function () { console.time("generated_location_for"); },
-          end_generated_location_for: function () { console.timeEnd("generated_location_for"); },
+          start_generated_location_for() { console.time("generated_location_for"); },
+          end_generated_location_for() { console.timeEnd("generated_location_for"); },
 
-          start_original_location_for: function () { console.time("original_location_for"); },
-          end_original_location_for: function () { console.timeEnd("original_location_for"); },
+          start_original_location_for() { console.time("original_location_for"); },
+          end_original_location_for() { console.timeEnd("original_location_for"); },
 
-          start_parse_mappings: function () { console.time("parse_mappings"); },
-          end_parse_mappings: function () { console.timeEnd("parse_mappings"); },
+          start_parse_mappings() { console.time("parse_mappings"); },
+          end_parse_mappings() { console.timeEnd("parse_mappings"); },
 
-          start_sort_by_generated_location: function () { console.time("sort_by_generated_location"); },
-          end_sort_by_generated_location: function () { console.timeEnd("sort_by_generated_location"); },
+          start_sort_by_generated_location() { console.time("sort_by_generated_location"); },
+          end_sort_by_generated_location() { console.timeEnd("sort_by_generated_location"); },
 
-          start_sort_by_original_location: function () { console.time("sort_by_original_location"); },
-          end_sort_by_original_location: function () { console.timeEnd("sort_by_original_location"); },
+          start_sort_by_original_location() { console.time("sort_by_original_location"); },
+          end_sort_by_original_location() { console.timeEnd("sort_by_original_location"); },
         }
       });
-  }).then(wasm => {
+  }).then(Wasm => {
     return {
-      exports: wasm.instance.exports,
+      exports: Wasm.instance.exports,
       withMappingCallback: (mappingCallback, f) => {
-        callbackStack.push(mappingCallback)
+        callbackStack.push(mappingCallback);
         try {
           f();
         } finally {
-          callbackStack.pop()
+          callbackStack.pop();
         }
       }
     };
@@ -3094,8 +3090,9 @@ SourceNode.fromStringWithSourceMap =
     // To extract it current and last mapping is used.
     // Here we store the last mapping.
     var lastMapping = null;
+    var nextLine;
 
-    aSourceMapConsumer.eachMapping(function (mapping) {
+    aSourceMapConsumer.eachMapping(function(mapping) {
       if (lastMapping !== null) {
         // We add the code from "lastMapping" to "mapping":
         // First check if there is a new line in between.
@@ -3109,7 +3106,7 @@ SourceNode.fromStringWithSourceMap =
           // There is no new line in between.
           // Associate the code between "lastGeneratedColumn" and
           // "mapping.generatedColumn" with "lastMapping"
-          var nextLine = remainingLines[remainingLinesIndex] || '';
+          nextLine = remainingLines[remainingLinesIndex] || "";
           var code = nextLine.substr(0, mapping.generatedColumn -
                                         lastGeneratedColumn);
           remainingLines[remainingLinesIndex] = nextLine.substr(mapping.generatedColumn -
@@ -3129,7 +3126,7 @@ SourceNode.fromStringWithSourceMap =
         lastGeneratedLine++;
       }
       if (lastGeneratedColumn < mapping.generatedColumn) {
-        var nextLine = remainingLines[remainingLinesIndex] || '';
+        nextLine = remainingLines[remainingLinesIndex] || "";
         node.add(nextLine.substr(0, mapping.generatedColumn));
         remainingLines[remainingLinesIndex] = nextLine.substr(mapping.generatedColumn);
         lastGeneratedColumn = mapping.generatedColumn;
@@ -3147,7 +3144,7 @@ SourceNode.fromStringWithSourceMap =
     }
 
     // Copy sourcesContent into SourceNode
-    aSourceMapConsumer.sources.forEach(function (sourceFile) {
+    aSourceMapConsumer.sources.forEach(function(sourceFile) {
       var content = aSourceMapConsumer.sourceContentFor(sourceFile);
       if (content != null) {
         if (aRelativePath != null) {
@@ -3183,16 +3180,14 @@ SourceNode.fromStringWithSourceMap =
  */
 SourceNode.prototype.add = function SourceNode_add(aChunk) {
   if (Array.isArray(aChunk)) {
-    aChunk.forEach(function (chunk) {
+    aChunk.forEach(function(chunk) {
       this.add(chunk);
     }, this);
-  }
-  else if (aChunk[isSourceNode] || typeof aChunk === "string") {
+  } else if (aChunk[isSourceNode] || typeof aChunk === "string") {
     if (aChunk) {
       this.children.push(aChunk);
     }
-  }
-  else {
+  } else {
     throw new TypeError(
       "Expected a SourceNode, string, or an array of SourceNodes and strings. Got " + aChunk
     );
@@ -3208,14 +3203,12 @@ SourceNode.prototype.add = function SourceNode_add(aChunk) {
  */
 SourceNode.prototype.prepend = function SourceNode_prepend(aChunk) {
   if (Array.isArray(aChunk)) {
-    for (var i = aChunk.length-1; i >= 0; i--) {
+    for (var i = aChunk.length - 1; i >= 0; i--) {
       this.prepend(aChunk[i]);
     }
-  }
-  else if (aChunk[isSourceNode] || typeof aChunk === "string") {
+  } else if (aChunk[isSourceNode] || typeof aChunk === "string") {
     this.children.unshift(aChunk);
-  }
-  else {
+  } else {
     throw new TypeError(
       "Expected a SourceNode, string, or an array of SourceNodes and strings. Got " + aChunk
     );
@@ -3236,15 +3229,12 @@ SourceNode.prototype.walk = function SourceNode_walk(aFn) {
     chunk = this.children[i];
     if (chunk[isSourceNode]) {
       chunk.walk(aFn);
-    }
-    else {
-      if (chunk !== '') {
+    } else if (chunk !== "") {
         aFn(chunk, { source: this.source,
                      line: this.line,
                      column: this.column,
                      name: this.name });
       }
-    }
   }
 };
 
@@ -3260,7 +3250,7 @@ SourceNode.prototype.join = function SourceNode_join(aSep) {
   var len = this.children.length;
   if (len > 0) {
     newChildren = [];
-    for (i = 0; i < len-1; i++) {
+    for (i = 0; i < len - 1; i++) {
       newChildren.push(this.children[i]);
       newChildren.push(aSep);
     }
@@ -3281,12 +3271,10 @@ SourceNode.prototype.replaceRight = function SourceNode_replaceRight(aPattern, a
   var lastChild = this.children[this.children.length - 1];
   if (lastChild[isSourceNode]) {
     lastChild.replaceRight(aPattern, aReplacement);
-  }
-  else if (typeof lastChild === 'string') {
+  } else if (typeof lastChild === "string") {
     this.children[this.children.length - 1] = lastChild.replace(aPattern, aReplacement);
-  }
-  else {
-    this.children.push(''.replace(aPattern, aReplacement));
+  } else {
+    this.children.push("".replace(aPattern, aReplacement));
   }
   return this;
 };
@@ -3311,14 +3299,14 @@ SourceNode.prototype.setSourceContent =
  */
 SourceNode.prototype.walkSourceContents =
   function SourceNode_walkSourceContents(aFn) {
-    for (var i = 0, len = this.children.length; i < len; i++) {
+    for (let i = 0, len = this.children.length; i < len; i++) {
       if (this.children[i][isSourceNode]) {
         this.children[i].walkSourceContents(aFn);
       }
     }
 
     var sources = Object.keys(this.sourceContents);
-    for (var i = 0, len = sources.length; i < len; i++) {
+    for (let i = 0, len = sources.length; i < len; i++) {
       aFn(util.fromSetString(sources[i]), this.sourceContents[sources[i]]);
     }
   };
@@ -3329,7 +3317,7 @@ SourceNode.prototype.walkSourceContents =
  */
 SourceNode.prototype.toString = function SourceNode_toString() {
   var str = "";
-  this.walk(function (chunk) {
+  this.walk(function(chunk) {
     str += chunk;
   });
   return str;
@@ -3351,12 +3339,12 @@ SourceNode.prototype.toStringWithSourceMap = function SourceNode_toStringWithSou
   var lastOriginalLine = null;
   var lastOriginalColumn = null;
   var lastOriginalName = null;
-  this.walk(function (chunk, original) {
+  this.walk(function(chunk, original) {
     generated.code += chunk;
     if (original.source !== null
         && original.line !== null
         && original.column !== null) {
-      if(lastOriginalSource !== original.source
+      if (lastOriginalSource !== original.source
          || lastOriginalLine !== original.line
          || lastOriginalColumn !== original.column
          || lastOriginalName !== original.name) {
@@ -3415,11 +3403,11 @@ SourceNode.prototype.toStringWithSourceMap = function SourceNode_toStringWithSou
       }
     }
   });
-  this.walkSourceContents(function (sourceFile, sourceContent) {
+  this.walkSourceContents(function(sourceFile, sourceContent) {
     map.setSourceContent(sourceFile, sourceContent);
   });
 
-  return { code: generated.code, map: map };
+  return { code: generated.code, map };
 };
 
 exports.SourceNode = SourceNode;

--- a/lib/array-set.js
+++ b/lib/array-set.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var util = require('./util');
+var util = require("./util");
 var has = Object.prototype.hasOwnProperty;
 var hasNativeMap = typeof Map !== "undefined";
 
@@ -70,10 +70,9 @@ ArraySet.prototype.add = function ArraySet_add(aStr, aAllowDuplicates) {
 ArraySet.prototype.has = function ArraySet_has(aStr) {
   if (hasNativeMap) {
     return this._set.has(aStr);
-  } else {
-    var sStr = util.toSetString(aStr);
-    return has.call(this._set, sStr);
   }
+  var sStr = util.toSetString(aStr);
+  return has.call(this._set, sStr);
 };
 
 /**
@@ -106,7 +105,7 @@ ArraySet.prototype.at = function ArraySet_at(aIdx) {
   if (aIdx >= 0 && aIdx < this._array.length) {
     return this._array[aIdx];
   }
-  throw new Error('No element indexed by ' + aIdx);
+  throw new Error("No element indexed by " + aIdx);
 };
 
 /**

--- a/lib/base64-vlq.js
+++ b/lib/base64-vlq.js
@@ -35,7 +35,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-var base64 = require('./base64');
+var base64 = require("./base64");
 
 // A single base 64 digit can contain 6 bits of data. For the base 64 variable
 // length quantities we use in the source map spec, the first bit is the sign,
@@ -78,6 +78,7 @@ function toVLQSigned(aValue) {
  *   2 (10 binary) becomes 1, 3 (11 binary) becomes -1
  *   4 (100 binary) becomes 2, 5 (101 binary) becomes -2
  */
+// eslint-disable-next-line no-unused-vars
 function fromVLQSigned(aValue) {
   var isNegative = (aValue & 1) === 1;
   var shifted = aValue >> 1;

--- a/lib/base64.js
+++ b/lib/base64.js
@@ -5,12 +5,12 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var intToCharMap = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'.split('');
+var intToCharMap = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
 
 /**
  * Encode an integer in the range of 0 to 63 to a single base 64 digit.
  */
-exports.encode = function (number) {
+exports.encode = function(number) {
   if (0 <= number && number < intToCharMap.length) {
     return intToCharMap[number];
   }

--- a/lib/binary-search.js
+++ b/lib/binary-search.js
@@ -36,8 +36,7 @@ function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
   if (cmp === 0) {
     // Found the element we are looking for.
     return mid;
-  }
-  else if (cmp > 0) {
+  } else if (cmp > 0) {
     // Our needle is greater than aHaystack[mid].
     if (aHigh - mid > 1) {
       // The element is in the upper half.
@@ -48,24 +47,21 @@ function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
     // we are in termination case (3) or (2) and return the appropriate thing.
     if (aBias == exports.LEAST_UPPER_BOUND) {
       return aHigh < aHaystack.length ? aHigh : -1;
-    } else {
-      return mid;
     }
+    return mid;
   }
-  else {
-    // Our needle is less than aHaystack[mid].
-    if (mid - aLow > 1) {
-      // The element is in the lower half.
-      return recursiveSearch(aLow, mid, aNeedle, aHaystack, aCompare, aBias);
-    }
 
-    // we are in termination case (3) or (2) and return the appropriate thing.
-    if (aBias == exports.LEAST_UPPER_BOUND) {
-      return mid;
-    } else {
-      return aLow < 0 ? -1 : aLow;
-    }
+  // Our needle is less than aHaystack[mid].
+  if (mid - aLow > 1) {
+    // The element is in the lower half.
+    return recursiveSearch(aLow, mid, aNeedle, aHaystack, aCompare, aBias);
   }
+
+  // we are in termination case (3) or (2) and return the appropriate thing.
+  if (aBias == exports.LEAST_UPPER_BOUND) {
+    return mid;
+  }
+  return aLow < 0 ? -1 : aLow;
 }
 
 /**

--- a/lib/mapping-list.js
+++ b/lib/mapping-list.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var util = require('./util');
+var util = require("./util");
 
 /**
  * Determine whether mappingB is after mappingA with respect to generated

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -5,16 +5,16 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var util = require('./util');
-var binarySearch = require('./binary-search');
-var ArraySet = require('./array-set').ArraySet;
-var base64VLQ = require('./base64-vlq');
-var readWasm = require('../lib/read-wasm');
-var wasm = require('./wasm');
+var util = require("./util");
+var binarySearch = require("./binary-search");
+var ArraySet = require("./array-set").ArraySet;
+var base64VLQ = require("./base64-vlq"); // eslint-disable-line no-unused-vars
+var readWasm = require("../lib/read-wasm");
+var wasm = require("./wasm");
 
 function SourceMapConsumer(aSourceMap, aSourceMapURL) {
   var sourceMap = aSourceMap;
-  if (typeof aSourceMap === 'string') {
+  if (typeof aSourceMap === "string") {
     sourceMap = util.parseSourceMapInput(aSourceMap);
   }
 
@@ -31,7 +31,7 @@ SourceMapConsumer.initialize = opts => {
 
 SourceMapConsumer.fromSourceMap = function(aSourceMap, aSourceMapURL) {
   return BasicSourceMapConsumer.fromSourceMap(aSourceMap, aSourceMapURL);
-}
+};
 
 /**
  * Construct a new `SourceMapConsumer` from `rawSourceMap` and `sourceMapUrl`
@@ -201,24 +201,24 @@ exports.SourceMapConsumer = SourceMapConsumer;
  */
 function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   var sourceMap = aSourceMap;
-  if (typeof aSourceMap === 'string') {
+  if (typeof aSourceMap === "string") {
     sourceMap = util.parseSourceMapInput(aSourceMap);
   }
 
-  var version = util.getArg(sourceMap, 'version');
-  var sources = util.getArg(sourceMap, 'sources');
+  var version = util.getArg(sourceMap, "version");
+  var sources = util.getArg(sourceMap, "sources");
   // Sass 3.3 leaves out the 'names' array, so we deviate from the spec (which
   // requires the array) to play nice here.
-  var names = util.getArg(sourceMap, 'names', []);
-  var sourceRoot = util.getArg(sourceMap, 'sourceRoot', null);
-  var sourcesContent = util.getArg(sourceMap, 'sourcesContent', null);
-  var mappings = util.getArg(sourceMap, 'mappings');
-  var file = util.getArg(sourceMap, 'file', null);
+  var names = util.getArg(sourceMap, "names", []);
+  var sourceRoot = util.getArg(sourceMap, "sourceRoot", null);
+  var sourcesContent = util.getArg(sourceMap, "sourcesContent", null);
+  var mappings = util.getArg(sourceMap, "mappings");
+  var file = util.getArg(sourceMap, "file", null);
 
   // Once again, Sass deviates from the spec and supplies the version as a
   // string rather than a number, so we use loose equality checking here.
   if (version != this._version) {
-    throw new Error('Unsupported version: ' + version);
+    throw new Error("Unsupported version: " + version);
   }
 
   if (sourceRoot) {
@@ -235,7 +235,7 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
     // the source root, if the source root is absolute. Not doing this would
     // be particularly problematic when the source root is a prefix of the
     // source (valid, but why??). See github issue #199 and bugzil.la/1188982.
-    .map(function (source) {
+    .map(function(source) {
       return sourceRoot && util.isAbsolute(sourceRoot) && util.isAbsolute(source)
         ? util.relative(sourceRoot, source)
         : source;
@@ -248,7 +248,7 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   this._names = ArraySet.fromArray(names.map(String), true);
   this._sources = ArraySet.fromArray(sources, true);
 
-  this._absoluteSources = this._sources.toArray().map(function (s) {
+  this._absoluteSources = this._sources.toArray().map(function(s) {
     return util.computeSourceURL(sourceRoot, s, aSourceMapURL);
   });
 
@@ -262,8 +262,8 @@ function BasicSourceMapConsumer(aSourceMap, aSourceMapURL) {
   this._mappingsPtr = 0;
   this._wasm = null;
 
-  return wasm().then(wasm => {
-    this._wasm = wasm;
+  return wasm().then(w => {
+    this._wasm = w;
     return this;
   });
 }
@@ -319,13 +319,13 @@ BasicSourceMapConsumer.prototype._version = 3;
 /**
  * The list of original sources.
  */
-Object.defineProperty(BasicSourceMapConsumer.prototype, 'sources', {
-  get: function () {
+Object.defineProperty(BasicSourceMapConsumer.prototype, "sources", {
+  get() {
     return this._absoluteSources.slice();
   }
 });
 
-BasicSourceMapConsumer.prototype._getMappingsPtr = function () {
+BasicSourceMapConsumer.prototype._getMappingsPtr = function() {
   if (this._mappingsPtr === 0) {
     this._parseMappings(this._mappings, this.sourceRoot);
   }
@@ -367,7 +367,7 @@ BasicSourceMapConsumer.prototype._parseMappings =
           break;
         case 4:
           msg += "invalid base 64 character while parsing a VLQ";
-          break
+          break;
         default:
           msg += "unknown error code";
           break;
@@ -415,8 +415,8 @@ BasicSourceMapConsumer.prototype.eachMapping =
 
 BasicSourceMapConsumer.prototype.allGeneratedPositionsFor =
   function BasicSourceMapConsumer_allGeneratedPositionsFor(aArgs) {
-    var source = util.getArg(aArgs, 'source');
-    var originalLine = util.getArg(aArgs, 'line');
+    var source = util.getArg(aArgs, "source");
+    var originalLine = util.getArg(aArgs, "line");
     var originalColumn = aArgs.column || 0;
 
     source = this._findSourceIndex(source);
@@ -450,7 +450,7 @@ BasicSourceMapConsumer.prototype.allGeneratedPositionsFor =
           this._getMappingsPtr(),
           source,
           originalLine - 1,
-          'column' in aArgs,
+          "column" in aArgs,
           originalColumn
         );
       }
@@ -508,8 +508,8 @@ BasicSourceMapConsumer.prototype.computeColumnSpans =
 BasicSourceMapConsumer.prototype.originalPositionFor =
   function SourceMapConsumer_originalPositionFor(aArgs) {
     var needle = {
-      generatedLine: util.getArg(aArgs, 'line'),
-      generatedColumn: util.getArg(aArgs, 'column')
+      generatedLine: util.getArg(aArgs, "line"),
+      generatedColumn: util.getArg(aArgs, "column")
     };
 
     if (needle.generatedLine < 1) {
@@ -520,7 +520,7 @@ BasicSourceMapConsumer.prototype.originalPositionFor =
       throw new Error("Column numbers must be >= 0");
     }
 
-    var bias = util.getArg(aArgs, 'bias', SourceMapConsumer.GREATEST_LOWER_BOUND);
+    var bias = util.getArg(aArgs, "bias", SourceMapConsumer.GREATEST_LOWER_BOUND);
     if (bias == null) {
       bias = SourceMapConsumer.GREATEST_LOWER_BOUND;
     }
@@ -537,22 +537,22 @@ BasicSourceMapConsumer.prototype.originalPositionFor =
 
     if (mapping) {
       if (mapping.generatedLine === needle.generatedLine) {
-        var source = util.getArg(mapping, 'source', null);
+        var source = util.getArg(mapping, "source", null);
         if (source !== null) {
           source = this._sources.at(source);
           source = util.computeSourceURL(this.sourceRoot, source, this._sourceMapURL);
         }
 
-        var name = util.getArg(mapping, 'name', null);
+        var name = util.getArg(mapping, "name", null);
         if (name !== null) {
           name = this._names.at(name);
         }
 
         return {
-          source: source,
-          line: util.getArg(mapping, 'originalLine', null),
-          column: util.getArg(mapping, 'originalColumn', null),
-          name: name
+          source,
+          line: util.getArg(mapping, "originalLine", null),
+          column: util.getArg(mapping, "originalColumn", null),
+          name
         };
       }
     }
@@ -575,7 +575,7 @@ BasicSourceMapConsumer.prototype.hasContentsOfAllSources =
       return false;
     }
     return this.sourcesContent.length >= this._sources.size() &&
-      !this.sourcesContent.some(function (sc) { return sc == null; });
+      !this.sourcesContent.some(function(sc) { return sc == null; });
   };
 
 /**
@@ -609,7 +609,7 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
       var fileUriAbsPath = relativeSource.replace(/^file:\/\//, "");
       if (url.scheme == "file"
           && this._sources.has(fileUriAbsPath)) {
-        return this.sourcesContent[this._sources.indexOf(fileUriAbsPath)]
+        return this.sourcesContent[this._sources.indexOf(fileUriAbsPath)];
       }
 
       if ((!url.path || url.path == "/")
@@ -625,9 +625,8 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
     if (nullOnMissing) {
       return null;
     }
-    else {
-      throw new Error('"' + relativeSource + '" is not in the SourceMap.');
-    }
+
+    throw new Error('"' + relativeSource + '" is not in the SourceMap.');
   };
 
 /**
@@ -655,7 +654,7 @@ BasicSourceMapConsumer.prototype.sourceContentFor =
  */
 BasicSourceMapConsumer.prototype.generatedPositionFor =
   function SourceMapConsumer_generatedPositionFor(aArgs) {
-    var source = util.getArg(aArgs, 'source');
+    var source = util.getArg(aArgs, "source");
     source = this._findSourceIndex(source);
     if (source < 0) {
       return {
@@ -666,9 +665,9 @@ BasicSourceMapConsumer.prototype.generatedPositionFor =
     }
 
     var needle = {
-      source: source,
-      originalLine: util.getArg(aArgs, 'line'),
-      originalColumn: util.getArg(aArgs, 'column')
+      source,
+      originalLine: util.getArg(aArgs, "line"),
+      originalColumn: util.getArg(aArgs, "column")
     };
 
     if (needle.originalLine < 1) {
@@ -679,7 +678,7 @@ BasicSourceMapConsumer.prototype.generatedPositionFor =
       throw new Error("Column numbers must be >= 0");
     }
 
-    var bias = util.getArg(aArgs, 'bias', SourceMapConsumer.GREATEST_LOWER_BOUND);
+    var bias = util.getArg(aArgs, "bias", SourceMapConsumer.GREATEST_LOWER_BOUND);
     if (bias == null) {
       bias = SourceMapConsumer.GREATEST_LOWER_BOUND;
     }
@@ -702,8 +701,8 @@ BasicSourceMapConsumer.prototype.generatedPositionFor =
           lastColumn = Infinity;
         }
         return {
-          line: util.getArg(mapping, 'generatedLine', null),
-          column: util.getArg(mapping, 'generatedColumn', null),
+          line: util.getArg(mapping, "generatedLine", null),
+          column: util.getArg(mapping, "generatedColumn", null),
           lastColumn,
         };
       }
@@ -769,15 +768,15 @@ exports.BasicSourceMapConsumer = BasicSourceMapConsumer;
  */
 function IndexedSourceMapConsumer(aSourceMap, aSourceMapURL) {
   var sourceMap = aSourceMap;
-  if (typeof aSourceMap === 'string') {
+  if (typeof aSourceMap === "string") {
     sourceMap = util.parseSourceMapInput(aSourceMap);
   }
 
-  var version = util.getArg(sourceMap, 'version');
-  var sections = util.getArg(sourceMap, 'sections');
+  var version = util.getArg(sourceMap, "version");
+  var sections = util.getArg(sourceMap, "sections");
 
   if (version != this._version) {
-    throw new Error('Unsupported version: ' + version);
+    throw new Error("Unsupported version: " + version);
   }
 
   this._sources = new ArraySet();
@@ -791,20 +790,20 @@ function IndexedSourceMapConsumer(aSourceMap, aSourceMapURL) {
     if (s.url) {
       // The url field will require support for asynchronicity.
       // See https://github.com/mozilla/source-map/issues/16
-      throw new Error('Support for url field in sections not implemented.');
+      throw new Error("Support for url field in sections not implemented.");
     }
-    var offset = util.getArg(s, 'offset');
-    var offsetLine = util.getArg(offset, 'line');
-    var offsetColumn = util.getArg(offset, 'column');
+    var offset = util.getArg(s, "offset");
+    var offsetLine = util.getArg(offset, "line");
+    var offsetColumn = util.getArg(offset, "column");
 
     if (offsetLine < lastOffset.line ||
         (offsetLine === lastOffset.line && offsetColumn < lastOffset.column)) {
-      throw new Error('Section offsets must be ordered and non-overlapping.');
+      throw new Error("Section offsets must be ordered and non-overlapping.");
     }
     lastOffset = offset;
 
-    const consumer = new SourceMapConsumer(util.getArg(s, 'map'), aSourceMapURL);
-    return consumer.then(consumer => {
+    const cons = new SourceMapConsumer(util.getArg(s, "map"), aSourceMapURL);
+    return cons.then(consumer => {
       return {
         generatedOffset: {
           // The offset fields are 0-based, but we use 1-based indices when
@@ -812,11 +811,11 @@ function IndexedSourceMapConsumer(aSourceMap, aSourceMapURL) {
           generatedLine: offsetLine + 1,
           generatedColumn: offsetColumn + 1
         },
-        consumer: consumer
+        consumer
       };
     });
-  })).then(sections => {
-    this._sections = sections;
+  })).then(s => {
+    this._sections = s;
     return this;
   });
 }
@@ -855,10 +854,10 @@ IndexedSourceMapConsumer.prototype.constructor = SourceMapConsumer;
 // `_originalMappings` is ordered by the original positions.
 
 IndexedSourceMapConsumer.prototype.__generatedMappings = null;
-Object.defineProperty(IndexedSourceMapConsumer.prototype, '_generatedMappings', {
+Object.defineProperty(IndexedSourceMapConsumer.prototype, "_generatedMappings", {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     if (!this.__generatedMappings) {
       this._sortGeneratedMappings();
     }
@@ -868,10 +867,10 @@ Object.defineProperty(IndexedSourceMapConsumer.prototype, '_generatedMappings', 
 });
 
 IndexedSourceMapConsumer.prototype.__originalMappings = null;
-Object.defineProperty(IndexedSourceMapConsumer.prototype, '_originalMappings', {
+Object.defineProperty(IndexedSourceMapConsumer.prototype, "_originalMappings", {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     if (!this.__originalMappings) {
       this._sortOriginalMappings();
     }
@@ -881,10 +880,10 @@ Object.defineProperty(IndexedSourceMapConsumer.prototype, '_originalMappings', {
 });
 
 IndexedSourceMapConsumer.prototype.__generatedMappingsUnsorted = null;
-Object.defineProperty(IndexedSourceMapConsumer.prototype, '_generatedMappingsUnsorted', {
+Object.defineProperty(IndexedSourceMapConsumer.prototype, "_generatedMappingsUnsorted", {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     if (!this.__generatedMappingsUnsorted) {
       this._parseMappings(this._mappings, this.sourceRoot);
     }
@@ -894,10 +893,10 @@ Object.defineProperty(IndexedSourceMapConsumer.prototype, '_generatedMappingsUns
 });
 
 IndexedSourceMapConsumer.prototype.__originalMappingsUnsorted = null;
-Object.defineProperty(IndexedSourceMapConsumer.prototype, '_originalMappingsUnsorted', {
+Object.defineProperty(IndexedSourceMapConsumer.prototype, "_originalMappingsUnsorted", {
   configurable: true,
   enumerable: true,
-  get: function () {
+  get() {
     if (!this.__originalMappingsUnsorted) {
       this._parseMappings(this._mappings, this.sourceRoot);
     }
@@ -928,8 +927,8 @@ IndexedSourceMapConsumer.prototype._version = 3;
 /**
  * The list of original sources.
  */
-Object.defineProperty(IndexedSourceMapConsumer.prototype, 'sources', {
-  get: function () {
+Object.defineProperty(IndexedSourceMapConsumer.prototype, "sources", {
+  get() {
     var sources = [];
     for (var i = 0; i < this._sections.length; i++) {
       for (var j = 0; j < this._sections[i].consumer.sources.length; j++) {
@@ -962,20 +961,20 @@ Object.defineProperty(IndexedSourceMapConsumer.prototype, 'sources', {
 IndexedSourceMapConsumer.prototype.originalPositionFor =
   function IndexedSourceMapConsumer_originalPositionFor(aArgs) {
     var needle = {
-      generatedLine: util.getArg(aArgs, 'line'),
-      generatedColumn: util.getArg(aArgs, 'column')
+      generatedLine: util.getArg(aArgs, "line"),
+      generatedColumn: util.getArg(aArgs, "column")
     };
 
     // Find the section containing the generated position we're trying to map
     // to an original position.
     var sectionIndex = binarySearch.search(needle, this._sections,
-      function(needle, section) {
-        var cmp = needle.generatedLine - section.generatedOffset.generatedLine;
+      function(aNeedle, section) {
+        var cmp = aNeedle.generatedLine - section.generatedOffset.generatedLine;
         if (cmp) {
           return cmp;
         }
 
-        return (needle.generatedColumn -
+        return (aNeedle.generatedColumn -
                 section.generatedOffset.generatedColumn);
       });
     var section = this._sections[sectionIndex];
@@ -1006,7 +1005,7 @@ IndexedSourceMapConsumer.prototype.originalPositionFor =
  */
 IndexedSourceMapConsumer.prototype.hasContentsOfAllSources =
   function IndexedSourceMapConsumer_hasContentsOfAllSources() {
-    return this._sections.every(function (s) {
+    return this._sections.every(function(s) {
       return s.consumer.hasContentsOfAllSources();
     });
   };
@@ -1029,9 +1028,7 @@ IndexedSourceMapConsumer.prototype.sourceContentFor =
     if (nullOnMissing) {
       return null;
     }
-    else {
-      throw new Error('"' + aSource + '" is not in the SourceMap.');
-    }
+    throw new Error('"' + aSource + '" is not in the SourceMap.');
   };
 
 /**
@@ -1059,7 +1056,7 @@ IndexedSourceMapConsumer.prototype.generatedPositionFor =
 
       // Only consider this section if the requested source is in the list of
       // sources of the consumer.
-      if (section.consumer._findSourceIndex(util.getArg(aArgs, 'source')) === -1) {
+      if (section.consumer._findSourceIndex(util.getArg(aArgs, "source")) === -1) {
         continue;
       }
       var generatedPosition = section.consumer.generatedPositionFor(aArgs);
@@ -1115,7 +1112,7 @@ IndexedSourceMapConsumer.prototype._parseMappings =
         // need to offset them to be relative to the start of the concatenated
         // generated file.
         var adjustedMapping = {
-          source: source,
+          source,
           generatedLine: mapping.generatedLine +
             (section.generatedOffset.generatedLine - 1),
           generatedColumn: mapping.generatedColumn +
@@ -1124,11 +1121,11 @@ IndexedSourceMapConsumer.prototype._parseMappings =
             : 0),
           originalLine: mapping.originalLine,
           originalColumn: mapping.originalColumn,
-          name: name
+          name
         };
 
         generatedMappings.push(adjustedMapping);
-        if (typeof adjustedMapping.originalLine === 'number') {
+        if (typeof adjustedMapping.originalLine === "number") {
           originalMappings.push(adjustedMapping);
         }
       }
@@ -1153,14 +1150,14 @@ IndexedSourceMapConsumer.prototype.eachMapping =
     }
 
     var sourceRoot = this.sourceRoot;
-    mappings.map(function (mapping) {
+    mappings.map(function(mapping) {
       var source = null;
       if (mapping.source !== null) {
         source = this._sources.at(mapping.source);
         source = util.computeSourceURL(sourceRoot, source, this._sourceMapURL);
       }
       return {
-        source: source,
+        source,
         generatedLine: mapping.generatedLine,
         generatedColumn: mapping.generatedColumn,
         originalLine: mapping.originalLine,
@@ -1183,11 +1180,11 @@ IndexedSourceMapConsumer.prototype._findMapping =
     // find the best mapping.
 
     if (aNeedle[aLineName] <= 0) {
-      throw new TypeError('Line must be greater than or equal to 1, got '
+      throw new TypeError("Line must be greater than or equal to 1, got "
                           + aNeedle[aLineName]);
     }
     if (aNeedle[aColumnName] < 0) {
-      throw new TypeError('Column must be greater than or equal to 0, got '
+      throw new TypeError("Column must be greater than or equal to 0, got "
                           + aNeedle[aColumnName]);
     }
 
@@ -1196,16 +1193,16 @@ IndexedSourceMapConsumer.prototype._findMapping =
 
 IndexedSourceMapConsumer.prototype.allGeneratedPositionsFor =
   function IndexedSourceMapConsumer_allGeneratedPositionsFor(aArgs) {
-    var line = util.getArg(aArgs, 'line');
+    var line = util.getArg(aArgs, "line");
 
     // When there is no exact match, BasicSourceMapConsumer.prototype._findMapping
     // returns the index of the closest mapping less than the needle. By
     // setting needle.originalColumn to 0, we thus find the last mapping for
     // the given line, provided such a mapping exists.
     var needle = {
-      source: util.getArg(aArgs, 'source'),
+      source: util.getArg(aArgs, "source"),
       originalLine: line,
-      originalColumn: util.getArg(aArgs, 'column', 0)
+      originalColumn: util.getArg(aArgs, "column", 0)
     };
 
     needle.source = this._findSourceIndex(needle.source);
@@ -1245,8 +1242,8 @@ IndexedSourceMapConsumer.prototype.allGeneratedPositionsFor =
             lastColumn = Infinity;
           }
           mappings.push({
-            line: util.getArg(mapping, 'generatedLine', null),
-            column: util.getArg(mapping, 'generatedColumn', null),
+            line: util.getArg(mapping, "generatedLine", null),
+            column: util.getArg(mapping, "generatedColumn", null),
             lastColumn,
           });
 
@@ -1267,8 +1264,8 @@ IndexedSourceMapConsumer.prototype.allGeneratedPositionsFor =
             lastColumn = Infinity;
           }
           mappings.push({
-            line: util.getArg(mapping, 'generatedLine', null),
-            column: util.getArg(mapping, 'generatedColumn', null),
+            line: util.getArg(mapping, "generatedLine", null),
+            column: util.getArg(mapping, "generatedColumn", null),
             lastColumn,
           });
 

--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -5,10 +5,10 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var base64VLQ = require('./base64-vlq');
-var util = require('./util');
-var ArraySet = require('./array-set').ArraySet;
-var MappingList = require('./mapping-list').MappingList;
+var base64VLQ = require("./base64-vlq");
+var util = require("./util");
+var ArraySet = require("./array-set").ArraySet;
+var MappingList = require("./mapping-list").MappingList;
 
 /**
  * An instance of the SourceMapGenerator represents a source map which is
@@ -22,9 +22,9 @@ function SourceMapGenerator(aArgs) {
   if (!aArgs) {
     aArgs = {};
   }
-  this._file = util.getArg(aArgs, 'file', null);
-  this._sourceRoot = util.getArg(aArgs, 'sourceRoot', null);
-  this._skipValidation = util.getArg(aArgs, 'skipValidation', false);
+  this._file = util.getArg(aArgs, "file", null);
+  this._sourceRoot = util.getArg(aArgs, "sourceRoot", null);
+  this._skipValidation = util.getArg(aArgs, "skipValidation", false);
   this._sources = new ArraySet();
   this._names = new ArraySet();
   this._mappings = new MappingList();
@@ -43,9 +43,9 @@ SourceMapGenerator.fromSourceMap =
     var sourceRoot = aSourceMapConsumer.sourceRoot;
     var generator = new SourceMapGenerator({
       file: aSourceMapConsumer.file,
-      sourceRoot: sourceRoot
+      sourceRoot
     });
-    aSourceMapConsumer.eachMapping(function (mapping) {
+    aSourceMapConsumer.eachMapping(function(mapping) {
       var newMapping = {
         generated: {
           line: mapping.generatedLine,
@@ -71,7 +71,7 @@ SourceMapGenerator.fromSourceMap =
 
       generator.addMapping(newMapping);
     });
-    aSourceMapConsumer.sources.forEach(function (sourceFile) {
+    aSourceMapConsumer.sources.forEach(function(sourceFile) {
       var sourceRelative = sourceFile;
       if (sourceRoot !== null) {
         sourceRelative = util.relative(sourceRoot, sourceFile);
@@ -101,10 +101,10 @@ SourceMapGenerator.fromSourceMap =
  */
 SourceMapGenerator.prototype.addMapping =
   function SourceMapGenerator_addMapping(aArgs) {
-    var generated = util.getArg(aArgs, 'generated');
-    var original = util.getArg(aArgs, 'original', null);
-    var source = util.getArg(aArgs, 'source', null);
-    var name = util.getArg(aArgs, 'name', null);
+    var generated = util.getArg(aArgs, "generated");
+    var original = util.getArg(aArgs, "original", null);
+    var source = util.getArg(aArgs, "source", null);
+    var name = util.getArg(aArgs, "name", null);
 
     if (!this._skipValidation) {
       this._validateMapping(generated, original, source, name);
@@ -129,8 +129,8 @@ SourceMapGenerator.prototype.addMapping =
       generatedColumn: generated.column,
       originalLine: original != null && original.line,
       originalColumn: original != null && original.column,
-      source: source,
-      name: name
+      source,
+      name
     });
   };
 
@@ -184,7 +184,7 @@ SourceMapGenerator.prototype.applySourceMap =
     if (aSourceFile == null) {
       if (aSourceMapConsumer.file == null) {
         throw new Error(
-          'SourceMapGenerator.prototype.applySourceMap requires either an explicit source file, ' +
+          "SourceMapGenerator.prototype.applySourceMap requires either an explicit source file, " +
           'or the source map\'s "file" property. Both were omitted.'
         );
       }
@@ -203,7 +203,7 @@ SourceMapGenerator.prototype.applySourceMap =
     var newNames = new ArraySet();
 
     // Find mappings for the "sourceFile"
-    this._mappings.unsortedForEach(function (mapping) {
+    this._mappings.unsortedForEach(function(mapping) {
       if (mapping.source === sourceFile && mapping.originalLine != null) {
         // Check if it can be mapped by the source map, then update the mapping.
         var original = aSourceMapConsumer.originalPositionFor({
@@ -214,7 +214,7 @@ SourceMapGenerator.prototype.applySourceMap =
           // Copy mapping
           mapping.source = original.source;
           if (aSourceMapPath != null) {
-            mapping.source = util.join(aSourceMapPath, mapping.source)
+            mapping.source = util.join(aSourceMapPath, mapping.source);
           }
           if (sourceRoot != null) {
             mapping.source = util.relative(sourceRoot, mapping.source);
@@ -242,16 +242,16 @@ SourceMapGenerator.prototype.applySourceMap =
     this._names = newNames;
 
     // Copy sourcesContents of applied map.
-    aSourceMapConsumer.sources.forEach(function (sourceFile) {
-      var content = aSourceMapConsumer.sourceContentFor(sourceFile);
+    aSourceMapConsumer.sources.forEach(function(srcFile) {
+      var content = aSourceMapConsumer.sourceContentFor(srcFile);
       if (content != null) {
         if (aSourceMapPath != null) {
-          sourceFile = util.join(aSourceMapPath, sourceFile);
+          srcFile = util.join(aSourceMapPath, srcFile);
         }
         if (sourceRoot != null) {
-          sourceFile = util.relative(sourceRoot, sourceFile);
+          srcFile = util.relative(sourceRoot, srcFile);
         }
-        this.setSourceContent(sourceFile, content);
+        this.setSourceContent(srcFile, content);
       }
     }, this);
   };
@@ -274,30 +274,28 @@ SourceMapGenerator.prototype._validateMapping =
     // it is most likely a programmer error. In this case we throw a very
     // specific error message to try to guide them the right way.
     // For example: https://github.com/Polymer/polymer-bundler/pull/519
-    if (aOriginal && typeof aOriginal.line !== 'number' && typeof aOriginal.column !== 'number') {
+    if (aOriginal && typeof aOriginal.line !== "number" && typeof aOriginal.column !== "number") {
         throw new Error(
-            'original.line and original.column are not numbers -- you probably meant to omit ' +
-            'the original mapping entirely and only map the generated position. If so, pass ' +
-            'null for the original mapping instead of an object with empty or null values.'
+            "original.line and original.column are not numbers -- you probably meant to omit " +
+            "the original mapping entirely and only map the generated position. If so, pass " +
+            "null for the original mapping instead of an object with empty or null values."
         );
     }
 
-    if (aGenerated && 'line' in aGenerated && 'column' in aGenerated
+    if (aGenerated && "line" in aGenerated && "column" in aGenerated
         && aGenerated.line > 0 && aGenerated.column >= 0
         && !aOriginal && !aSource && !aName) {
       // Case 1.
-      return;
-    }
-    else if (aGenerated && 'line' in aGenerated && 'column' in aGenerated
-             && aOriginal && 'line' in aOriginal && 'column' in aOriginal
+
+    } else if (aGenerated && "line" in aGenerated && "column" in aGenerated
+             && aOriginal && "line" in aOriginal && "column" in aOriginal
              && aGenerated.line > 0 && aGenerated.column >= 0
              && aOriginal.line > 0 && aOriginal.column >= 0
              && aSource) {
       // Cases 2 and 3.
-      return;
-    }
-    else {
-      throw new Error('Invalid mapping: ' + JSON.stringify({
+
+    } else {
+      throw new Error("Invalid mapping: " + JSON.stringify({
         generated: aGenerated,
         source: aSource,
         original: aOriginal,
@@ -318,7 +316,7 @@ SourceMapGenerator.prototype._serializeMappings =
     var previousOriginalLine = 0;
     var previousName = 0;
     var previousSource = 0;
-    var result = '';
+    var result = "";
     var next;
     var mapping;
     var nameIdx;
@@ -327,22 +325,19 @@ SourceMapGenerator.prototype._serializeMappings =
     var mappings = this._mappings.toArray();
     for (var i = 0, len = mappings.length; i < len; i++) {
       mapping = mappings[i];
-      next = ''
+      next = "";
 
       if (mapping.generatedLine !== previousGeneratedLine) {
         previousGeneratedColumn = 0;
         while (mapping.generatedLine !== previousGeneratedLine) {
-          next += ';';
+          next += ";";
           previousGeneratedLine++;
         }
-      }
-      else {
-        if (i > 0) {
-          if (!util.compareByGeneratedPositionsInflated(mapping, mappings[i - 1])) {
-            continue;
-          }
-          next += ',';
+      } else if (i > 0) {
+        if (!util.compareByGeneratedPositionsInflated(mapping, mappings[i - 1])) {
+          continue;
         }
+        next += ",";
       }
 
       next += base64VLQ.encode(mapping.generatedColumn
@@ -378,7 +373,7 @@ SourceMapGenerator.prototype._serializeMappings =
 
 SourceMapGenerator.prototype._generateSourcesContent =
   function SourceMapGenerator_generateSourcesContent(aSources, aSourceRoot) {
-    return aSources.map(function (source) {
+    return aSources.map(function(source) {
       if (!this._sourcesContents) {
         return null;
       }

--- a/lib/source-node.js
+++ b/lib/source-node.js
@@ -5,8 +5,8 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var SourceMapGenerator = require('./source-map-generator').SourceMapGenerator;
-var util = require('./util');
+var SourceMapGenerator = require("./source-map-generator").SourceMapGenerator;
+var util = require("./util");
 
 // Matches a Windows-style `\r\n` newline or a `\n` newline used by all other
 // operating systems these days (capturing the result).
@@ -82,8 +82,9 @@ SourceNode.fromStringWithSourceMap =
     // To extract it current and last mapping is used.
     // Here we store the last mapping.
     var lastMapping = null;
+    var nextLine;
 
-    aSourceMapConsumer.eachMapping(function (mapping) {
+    aSourceMapConsumer.eachMapping(function(mapping) {
       if (lastMapping !== null) {
         // We add the code from "lastMapping" to "mapping":
         // First check if there is a new line in between.
@@ -97,7 +98,7 @@ SourceNode.fromStringWithSourceMap =
           // There is no new line in between.
           // Associate the code between "lastGeneratedColumn" and
           // "mapping.generatedColumn" with "lastMapping"
-          var nextLine = remainingLines[remainingLinesIndex] || '';
+          nextLine = remainingLines[remainingLinesIndex] || "";
           var code = nextLine.substr(0, mapping.generatedColumn -
                                         lastGeneratedColumn);
           remainingLines[remainingLinesIndex] = nextLine.substr(mapping.generatedColumn -
@@ -117,7 +118,7 @@ SourceNode.fromStringWithSourceMap =
         lastGeneratedLine++;
       }
       if (lastGeneratedColumn < mapping.generatedColumn) {
-        var nextLine = remainingLines[remainingLinesIndex] || '';
+        nextLine = remainingLines[remainingLinesIndex] || "";
         node.add(nextLine.substr(0, mapping.generatedColumn));
         remainingLines[remainingLinesIndex] = nextLine.substr(mapping.generatedColumn);
         lastGeneratedColumn = mapping.generatedColumn;
@@ -135,7 +136,7 @@ SourceNode.fromStringWithSourceMap =
     }
 
     // Copy sourcesContent into SourceNode
-    aSourceMapConsumer.sources.forEach(function (sourceFile) {
+    aSourceMapConsumer.sources.forEach(function(sourceFile) {
       var content = aSourceMapConsumer.sourceContentFor(sourceFile);
       if (content != null) {
         if (aRelativePath != null) {
@@ -171,16 +172,14 @@ SourceNode.fromStringWithSourceMap =
  */
 SourceNode.prototype.add = function SourceNode_add(aChunk) {
   if (Array.isArray(aChunk)) {
-    aChunk.forEach(function (chunk) {
+    aChunk.forEach(function(chunk) {
       this.add(chunk);
     }, this);
-  }
-  else if (aChunk[isSourceNode] || typeof aChunk === "string") {
+  } else if (aChunk[isSourceNode] || typeof aChunk === "string") {
     if (aChunk) {
       this.children.push(aChunk);
     }
-  }
-  else {
+  } else {
     throw new TypeError(
       "Expected a SourceNode, string, or an array of SourceNodes and strings. Got " + aChunk
     );
@@ -196,14 +195,12 @@ SourceNode.prototype.add = function SourceNode_add(aChunk) {
  */
 SourceNode.prototype.prepend = function SourceNode_prepend(aChunk) {
   if (Array.isArray(aChunk)) {
-    for (var i = aChunk.length-1; i >= 0; i--) {
+    for (var i = aChunk.length - 1; i >= 0; i--) {
       this.prepend(aChunk[i]);
     }
-  }
-  else if (aChunk[isSourceNode] || typeof aChunk === "string") {
+  } else if (aChunk[isSourceNode] || typeof aChunk === "string") {
     this.children.unshift(aChunk);
-  }
-  else {
+  } else {
     throw new TypeError(
       "Expected a SourceNode, string, or an array of SourceNodes and strings. Got " + aChunk
     );
@@ -224,14 +221,11 @@ SourceNode.prototype.walk = function SourceNode_walk(aFn) {
     chunk = this.children[i];
     if (chunk[isSourceNode]) {
       chunk.walk(aFn);
-    }
-    else {
-      if (chunk !== '') {
-        aFn(chunk, { source: this.source,
-                     line: this.line,
-                     column: this.column,
-                     name: this.name });
-      }
+    } else if (chunk !== "") {
+      aFn(chunk, { source: this.source,
+                    line: this.line,
+                    column: this.column,
+                    name: this.name });
     }
   }
 };
@@ -248,7 +242,7 @@ SourceNode.prototype.join = function SourceNode_join(aSep) {
   var len = this.children.length;
   if (len > 0) {
     newChildren = [];
-    for (i = 0; i < len-1; i++) {
+    for (i = 0; i < len - 1; i++) {
       newChildren.push(this.children[i]);
       newChildren.push(aSep);
     }
@@ -269,12 +263,10 @@ SourceNode.prototype.replaceRight = function SourceNode_replaceRight(aPattern, a
   var lastChild = this.children[this.children.length - 1];
   if (lastChild[isSourceNode]) {
     lastChild.replaceRight(aPattern, aReplacement);
-  }
-  else if (typeof lastChild === 'string') {
+  } else if (typeof lastChild === "string") {
     this.children[this.children.length - 1] = lastChild.replace(aPattern, aReplacement);
-  }
-  else {
-    this.children.push(''.replace(aPattern, aReplacement));
+  } else {
+    this.children.push("".replace(aPattern, aReplacement));
   }
   return this;
 };
@@ -299,14 +291,14 @@ SourceNode.prototype.setSourceContent =
  */
 SourceNode.prototype.walkSourceContents =
   function SourceNode_walkSourceContents(aFn) {
-    for (var i = 0, len = this.children.length; i < len; i++) {
+    for (let i = 0, len = this.children.length; i < len; i++) {
       if (this.children[i][isSourceNode]) {
         this.children[i].walkSourceContents(aFn);
       }
     }
 
     var sources = Object.keys(this.sourceContents);
-    for (var i = 0, len = sources.length; i < len; i++) {
+    for (let i = 0, len = sources.length; i < len; i++) {
       aFn(util.fromSetString(sources[i]), this.sourceContents[sources[i]]);
     }
   };
@@ -317,7 +309,7 @@ SourceNode.prototype.walkSourceContents =
  */
 SourceNode.prototype.toString = function SourceNode_toString() {
   var str = "";
-  this.walk(function (chunk) {
+  this.walk(function(chunk) {
     str += chunk;
   });
   return str;
@@ -339,12 +331,12 @@ SourceNode.prototype.toStringWithSourceMap = function SourceNode_toStringWithSou
   var lastOriginalLine = null;
   var lastOriginalColumn = null;
   var lastOriginalName = null;
-  this.walk(function (chunk, original) {
+  this.walk(function(chunk, original) {
     generated.code += chunk;
     if (original.source !== null
         && original.line !== null
         && original.column !== null) {
-      if(lastOriginalSource !== original.source
+      if (lastOriginalSource !== original.source
          || lastOriginalLine !== original.line
          || lastOriginalColumn !== original.column
          || lastOriginalName !== original.name) {
@@ -403,11 +395,11 @@ SourceNode.prototype.toStringWithSourceMap = function SourceNode_toStringWithSou
       }
     }
   });
-  this.walkSourceContents(function (sourceFile, sourceContent) {
+  this.walkSourceContents(function(sourceFile, sourceContent) {
     map.setSourceContent(sourceFile, sourceContent);
   });
 
-  return { code: generated.code, map: map };
+  return { code: generated.code, map };
 };
 
 exports.SourceNode = SourceNode;

--- a/lib/util.js
+++ b/lib/util.js
@@ -20,9 +20,9 @@ function getArg(aArgs, aName, aDefaultValue) {
     return aArgs[aName];
   } else if (arguments.length === 3) {
     return aDefaultValue;
-  } else {
-    throw new Error('"' + aName + '" is a required argument.');
   }
+    throw new Error('"' + aName + '" is a required argument.');
+
 }
 exports.getArg = getArg;
 
@@ -45,19 +45,19 @@ function urlParse(aUrl) {
 exports.urlParse = urlParse;
 
 function urlGenerate(aParsedUrl) {
-  var url = '';
+  var url = "";
   if (aParsedUrl.scheme) {
-    url += aParsedUrl.scheme + ':';
+    url += aParsedUrl.scheme + ":";
   }
-  url += '//';
+  url += "//";
   if (aParsedUrl.auth) {
-    url += aParsedUrl.auth + '@';
+    url += aParsedUrl.auth + "@";
   }
   if (aParsedUrl.host) {
     url += aParsedUrl.host;
   }
   if (aParsedUrl.port) {
-    url += ":" + aParsedUrl.port
+    url += ":" + aParsedUrl.port;
   }
   if (aParsedUrl.path) {
     url += aParsedUrl.path;
@@ -78,7 +78,7 @@ const MAX_CACHED_INPUTS = 32;
 function lruMemoize(f) {
   const cache = [];
 
-  return function (input) {
+  return function(input) {
     for (var i = 0; i < cache.length; i++) {
       if (cache[i].input === input) {
         var temp = cache[0];
@@ -144,14 +144,15 @@ var normalize = lruMemoize(function normalize(aPath) {
     }
   }
 
-  for (var part, up = 0, i = parts.length - 1; i >= 0; i--) {
-    part = parts[i];
-    if (part === '.') {
+  var up = 0;
+  for (i = parts.length - 1; i >= 0; i--) {
+    var part = parts[i];
+    if (part === ".") {
       parts.splice(i, 1);
-    } else if (part === '..') {
+    } else if (part === "..") {
       up++;
     } else if (up > 0) {
-      if (part === '') {
+      if (part === "") {
         // The first part is blank if the path is absolute. Trying to go
         // above the root is a no-op. Therefore we can remove all '..' parts
         // directly after the root.
@@ -163,10 +164,10 @@ var normalize = lruMemoize(function normalize(aPath) {
       }
     }
   }
-  path = parts.join('/');
+  path = parts.join("/");
 
-  if (path === '') {
-    path = isAbsolute ? '/' : '.';
+  if (path === "") {
+    path = isAbsolute ? "/" : ".";
   }
 
   if (url) {
@@ -203,7 +204,7 @@ function join(aRoot, aPath) {
   var aPathUrl = urlParse(aPath);
   var aRootUrl = urlParse(aRoot);
   if (aRootUrl) {
-    aRoot = aRootUrl.path || '/';
+    aRoot = aRootUrl.path || "/";
   }
 
   // `join(foo, '//www.example.org')`
@@ -224,9 +225,9 @@ function join(aRoot, aPath) {
     return urlGenerate(aRootUrl);
   }
 
-  var joined = aPath.charAt(0) === '/'
+  var joined = aPath.charAt(0) === "/"
     ? aPath
-    : normalize(aRoot.replace(/\/+$/, '') + '/' + aPath);
+    : normalize(aRoot.replace(/\/+$/, "") + "/" + aPath);
 
   if (aRootUrl) {
     aRootUrl.path = joined;
@@ -236,8 +237,8 @@ function join(aRoot, aPath) {
 }
 exports.join = join;
 
-exports.isAbsolute = function (aPath) {
-  return aPath.charAt(0) === '/' || urlRegexp.test(aPath);
+exports.isAbsolute = function(aPath) {
+  return aPath.charAt(0) === "/" || urlRegexp.test(aPath);
 };
 
 /**
@@ -251,14 +252,14 @@ function relative(aRoot, aPath) {
     aRoot = ".";
   }
 
-  aRoot = aRoot.replace(/\/$/, '');
+  aRoot = aRoot.replace(/\/$/, "");
 
   // It is possible for the path to be above the root. In this case, simply
   // checking whether the root is a prefix of the path won't work. Instead, we
   // need to remove components from the root one by one, until either we find
   // a prefix that fits, or we run out of components to remove.
   var level = 0;
-  while (aPath.indexOf(aRoot + '/') !== 0) {
+  while (aPath.indexOf(aRoot + "/") !== 0) {
     var index = aRoot.lastIndexOf("/");
     if (index < 0) {
       return aPath;
@@ -280,12 +281,12 @@ function relative(aRoot, aPath) {
 }
 exports.relative = relative;
 
-var supportsNullProto = (function () {
+var supportsNullProto = (function() {
   var obj = Object.create(null);
-  return !('__proto__' in obj);
+  return !("__proto__" in obj);
 }());
 
-function identity (s) {
+function identity(s) {
   return s;
 }
 
@@ -300,7 +301,7 @@ function identity (s) {
  */
 function toSetString(aStr) {
   if (isProtoString(aStr)) {
-    return '$' + aStr;
+    return "$" + aStr;
   }
 
   return aStr;
@@ -327,6 +328,7 @@ function isProtoString(s) {
     return false;
   }
 
+  /* eslint-disable no-multi-spaces */
   if (s.charCodeAt(length - 1) !== 95  /* '_' */ ||
       s.charCodeAt(length - 2) !== 95  /* '_' */ ||
       s.charCodeAt(length - 3) !== 111 /* 'o' */ ||
@@ -338,6 +340,7 @@ function isProtoString(s) {
       s.charCodeAt(length - 9) !== 95  /* '_' */) {
     return false;
   }
+  /* eslint-enable no-multi-spaces */
 
   for (var i = length - 10; i >= 0; i--) {
     if (s.charCodeAt(i) !== 36 /* '$' */) {
@@ -485,7 +488,7 @@ exports.compareByGeneratedPositionsInflated = compareByGeneratedPositionsInflate
  * JSON.
  */
 function parseSourceMapInput(str) {
-  return JSON.parse(str.replace(/^\)]}'[^\n]*\n/, ''));
+  return JSON.parse(str.replace(/^\)]}'[^\n]*\n/, ""));
 }
 exports.parseSourceMapInput = parseSourceMapInput;
 
@@ -494,12 +497,12 @@ exports.parseSourceMapInput = parseSourceMapInput;
  * URL, and the source map's URL.
  */
 function computeSourceURL(sourceRoot, sourceURL, sourceMapURL) {
-  sourceURL = sourceURL || '';
+  sourceURL = sourceURL || "";
 
   if (sourceRoot) {
     // This follows what Chrome does.
-    if (sourceRoot[sourceRoot.length - 1] !== '/' && sourceURL[0] !== '/') {
-      sourceRoot += '/';
+    if (sourceRoot[sourceRoot.length - 1] !== "/" && sourceURL[0] !== "/") {
+      sourceRoot += "/";
     }
     // The spec says:
     //   Line 4: An optional source root, useful for relocating source
@@ -530,7 +533,7 @@ function computeSourceURL(sourceRoot, sourceURL, sourceMapURL) {
     }
     if (parsed.path) {
       // Strip the last path component, but keep the "/".
-      var index = parsed.path.lastIndexOf('/');
+      var index = parsed.path.lastIndexOf("/");
       if (index >= 0) {
         parsed.path = parsed.path.substring(0, index + 1);
       }

--- a/lib/wasm.js
+++ b/lib/wasm.js
@@ -25,7 +25,7 @@ module.exports = function wasm() {
   cachedWasm = readWasm().then(buffer => {
       return WebAssembly.instantiate(buffer, {
         env: {
-          mapping_callback: function (
+          mapping_callback(
             generatedLine,
             generatedColumn,
 
@@ -40,7 +40,7 @@ module.exports = function wasm() {
             hasName,
             name
           ) {
-            const mapping = new Mapping;
+            const mapping = new Mapping();
             // JS uses 1-based line numbers, wasm uses 0-based.
             mapping.generatedLine = generatedLine + 1;
             mapping.generatedColumn = generatedColumn;
@@ -64,37 +64,37 @@ module.exports = function wasm() {
             callbackStack[callbackStack.length - 1](mapping);
           },
 
-          start_all_generated_locations_for: function () { console.time("all_generated_locations_for"); },
-          end_all_generated_locations_for: function () { console.timeEnd("all_generated_locations_for"); },
+          start_all_generated_locations_for() { console.time("all_generated_locations_for"); },
+          end_all_generated_locations_for() { console.timeEnd("all_generated_locations_for"); },
 
-          start_compute_column_spans: function () { console.time("compute_column_spans"); },
-          end_compute_column_spans: function () { console.timeEnd("compute_column_spans"); },
+          start_compute_column_spans() { console.time("compute_column_spans"); },
+          end_compute_column_spans() { console.timeEnd("compute_column_spans"); },
 
-          start_generated_location_for: function () { console.time("generated_location_for"); },
-          end_generated_location_for: function () { console.timeEnd("generated_location_for"); },
+          start_generated_location_for() { console.time("generated_location_for"); },
+          end_generated_location_for() { console.timeEnd("generated_location_for"); },
 
-          start_original_location_for: function () { console.time("original_location_for"); },
-          end_original_location_for: function () { console.timeEnd("original_location_for"); },
+          start_original_location_for() { console.time("original_location_for"); },
+          end_original_location_for() { console.timeEnd("original_location_for"); },
 
-          start_parse_mappings: function () { console.time("parse_mappings"); },
-          end_parse_mappings: function () { console.timeEnd("parse_mappings"); },
+          start_parse_mappings() { console.time("parse_mappings"); },
+          end_parse_mappings() { console.timeEnd("parse_mappings"); },
 
-          start_sort_by_generated_location: function () { console.time("sort_by_generated_location"); },
-          end_sort_by_generated_location: function () { console.timeEnd("sort_by_generated_location"); },
+          start_sort_by_generated_location() { console.time("sort_by_generated_location"); },
+          end_sort_by_generated_location() { console.timeEnd("sort_by_generated_location"); },
 
-          start_sort_by_original_location: function () { console.time("sort_by_original_location"); },
-          end_sort_by_original_location: function () { console.timeEnd("sort_by_original_location"); },
+          start_sort_by_original_location() { console.time("sort_by_original_location"); },
+          end_sort_by_original_location() { console.timeEnd("sort_by_original_location"); },
         }
       });
-  }).then(wasm => {
+  }).then(Wasm => {
     return {
-      exports: wasm.instance.exports,
+      exports: Wasm.instance.exports,
       withMappingCallback: (mappingCallback, f) => {
-        callbackStack.push(mappingCallback)
+        callbackStack.push(mappingCallback);
         try {
           f();
         } finally {
-          callbackStack.pop()
+          callbackStack.pop();
         }
       }
     };

--- a/package.json
+++ b/package.json
@@ -59,13 +59,15 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "test": "npm run build && node test/run-tests.js",
+    "test": "npm run lint && npm run build && node test/run-tests.js",
     "build": "webpack --color",
+    "lint": "eslint lib/ test/",
     "toc": "doctoc --title '## Table of Contents' README.md && doctoc --title '## Table of Contents' CONTRIBUTING.md"
   },
   "devDependencies": {
     "doctoc": "^0.15.0",
-    "webpack": "^3.10"
+    "webpack": "^3.10",
+    "eslint": "^4.19.1"
   },
   "typings": "source-map"
 }

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -5,9 +5,9 @@
  * Licensed under the New BSD license. See LICENSE or:
  * http://opensource.org/licenses/BSD-3-Clause
  */
-var assert = require('assert');
-var fs = require('fs');
-var path = require('path');
+var assert = require("assert");
+var fs = require("fs");
+var path = require("path");
 
 async function run(tests) {
   var total = 0;
@@ -20,18 +20,17 @@ async function run(tests) {
         try {
           await tests[i].testCase[k](assert);
           passed++;
-        }
-        catch (e) {
-          console.log('FAILED ' + tests[i].name + ': ' + k + '!');
+        } catch (e) {
+          console.log("FAILED " + tests[i].name + ": " + k + "!");
           console.log(e.stack);
         }
       }
     }
   }
 
-  console.log('');
-  console.log(passed + ' / ' + total + ' tests passed.');
-  console.log('');
+  console.log("");
+  console.log(passed + " / " + total + " tests passed.");
+  console.log("");
 
   return total - passed;
 }
@@ -44,14 +43,14 @@ function isTestFile(f) {
 }
 
 function toRelativeModule(f) {
-  return './' + f.replace(/\.js$/, '');
+  return "./" + f.replace(/\.js$/, "");
 }
 
 var requires = fs.readdirSync(__dirname)
   .filter(isTestFile)
   .map(toRelativeModule);
 
-run(requires.map(require).map(function (mod, i) {
+run(requires.map(require).map(function(mod, i) {
   return {
     name: requires[i],
     testCase: mod

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -5,9 +5,9 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var sourceMap = require('../source-map');
+var sourceMap = require("../source-map");
 
-exports['test that the api is properly exposed in the top level'] = function (assert) {
+exports["test that the api is properly exposed in the top level"] = function(assert) {
   assert.equal(typeof sourceMap.SourceMapGenerator, "function");
   assert.equal(typeof sourceMap.SourceMapConsumer, "function");
   assert.equal(typeof sourceMap.SourceNode, "function");

--- a/test/test-array-set.js
+++ b/test/test-array-set.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var ArraySet = require('../lib/array-set').ArraySet;
+var ArraySet = require("../lib/array-set").ArraySet;
 
 function makeTestSet() {
   var set = new ArraySet();
@@ -15,122 +15,122 @@ function makeTestSet() {
   return set;
 }
 
-exports['test .has() membership'] = function (assert) {
+exports["test .has() membership"] = function(assert) {
   var set = makeTestSet();
   for (var i = 0; i < 100; i++) {
     assert.ok(set.has(String(i)));
   }
 };
 
-exports['test .indexOf() elements'] = function (assert) {
+exports["test .indexOf() elements"] = function(assert) {
   var set = makeTestSet();
   for (var i = 0; i < 100; i++) {
     assert.strictEqual(set.indexOf(String(i)), i);
   }
 };
 
-exports['test .at() indexing'] = function (assert) {
+exports["test .at() indexing"] = function(assert) {
   var set = makeTestSet();
   for (var i = 0; i < 100; i++) {
     assert.strictEqual(set.at(i), String(i));
   }
 };
 
-exports['test creating from an array'] = function (assert) {
-  var set = ArraySet.fromArray(['foo', 'bar', 'baz', 'quux', 'hasOwnProperty']);
+exports["test creating from an array"] = function(assert) {
+  var set = ArraySet.fromArray(["foo", "bar", "baz", "quux", "hasOwnProperty"]);
 
-  assert.ok(set.has('foo'));
-  assert.ok(set.has('bar'));
-  assert.ok(set.has('baz'));
-  assert.ok(set.has('quux'));
-  assert.ok(set.has('hasOwnProperty'));
+  assert.ok(set.has("foo"));
+  assert.ok(set.has("bar"));
+  assert.ok(set.has("baz"));
+  assert.ok(set.has("quux"));
+  assert.ok(set.has("hasOwnProperty"));
 
-  assert.strictEqual(set.indexOf('foo'), 0);
-  assert.strictEqual(set.indexOf('bar'), 1);
-  assert.strictEqual(set.indexOf('baz'), 2);
-  assert.strictEqual(set.indexOf('quux'), 3);
+  assert.strictEqual(set.indexOf("foo"), 0);
+  assert.strictEqual(set.indexOf("bar"), 1);
+  assert.strictEqual(set.indexOf("baz"), 2);
+  assert.strictEqual(set.indexOf("quux"), 3);
 
-  assert.strictEqual(set.at(0), 'foo');
-  assert.strictEqual(set.at(1), 'bar');
-  assert.strictEqual(set.at(2), 'baz');
-  assert.strictEqual(set.at(3), 'quux');
+  assert.strictEqual(set.at(0), "foo");
+  assert.strictEqual(set.at(1), "bar");
+  assert.strictEqual(set.at(2), "baz");
+  assert.strictEqual(set.at(3), "quux");
 };
 
-exports['test that you can add __proto__; see github issue #30'] = function (assert) {
+exports["test that you can add __proto__; see github issue #30"] = function(assert) {
   var set = new ArraySet();
-  set.add('__proto__');
-  assert.ok(set.has('__proto__'));
-  assert.strictEqual(set.at(0), '__proto__');
-  assert.strictEqual(set.indexOf('__proto__'), 0);
+  set.add("__proto__");
+  assert.ok(set.has("__proto__"));
+  assert.strictEqual(set.at(0), "__proto__");
+  assert.strictEqual(set.indexOf("__proto__"), 0);
 };
 
-exports['test .fromArray() with duplicates'] = function (assert) {
-  var set = ArraySet.fromArray(['foo', 'foo']);
-  assert.ok(set.has('foo'));
-  assert.strictEqual(set.at(0), 'foo');
-  assert.strictEqual(set.indexOf('foo'), 0);
+exports["test .fromArray() with duplicates"] = function(assert) {
+  var set = ArraySet.fromArray(["foo", "foo"]);
+  assert.ok(set.has("foo"));
+  assert.strictEqual(set.at(0), "foo");
+  assert.strictEqual(set.indexOf("foo"), 0);
   assert.strictEqual(set.toArray().length, 1);
 
-  set = ArraySet.fromArray(['foo', 'foo'], true);
-  assert.ok(set.has('foo'));
-  assert.strictEqual(set.at(0), 'foo');
-  assert.strictEqual(set.at(1), 'foo');
-  assert.strictEqual(set.indexOf('foo'), 0);
+  set = ArraySet.fromArray(["foo", "foo"], true);
+  assert.ok(set.has("foo"));
+  assert.strictEqual(set.at(0), "foo");
+  assert.strictEqual(set.at(1), "foo");
+  assert.strictEqual(set.indexOf("foo"), 0);
   assert.strictEqual(set.toArray().length, 2);
 };
 
-exports['test .add() with duplicates'] = function (assert) {
+exports["test .add() with duplicates"] = function(assert) {
   var set = new ArraySet();
-  set.add('foo');
+  set.add("foo");
 
-  set.add('foo');
-  assert.ok(set.has('foo'));
-  assert.strictEqual(set.at(0), 'foo');
-  assert.strictEqual(set.indexOf('foo'), 0);
+  set.add("foo");
+  assert.ok(set.has("foo"));
+  assert.strictEqual(set.at(0), "foo");
+  assert.strictEqual(set.indexOf("foo"), 0);
   assert.strictEqual(set.toArray().length, 1);
 
-  set.add('foo', true);
-  assert.ok(set.has('foo'));
-  assert.strictEqual(set.at(0), 'foo');
-  assert.strictEqual(set.at(1), 'foo');
-  assert.strictEqual(set.indexOf('foo'), 0);
+  set.add("foo", true);
+  assert.ok(set.has("foo"));
+  assert.strictEqual(set.at(0), "foo");
+  assert.strictEqual(set.at(1), "foo");
+  assert.strictEqual(set.indexOf("foo"), 0);
   assert.strictEqual(set.toArray().length, 2);
 };
 
-exports['test .size()'] = function (assert) {
+exports["test .size()"] = function(assert) {
   var set = new ArraySet();
-  set.add('foo');
-  set.add('bar');
-  set.add('baz');
+  set.add("foo");
+  set.add("bar");
+  set.add("baz");
   assert.strictEqual(set.size(), 3);
 };
 
-exports['test .size() with disallowed duplicates'] = function (assert) {
+exports["test .size() with disallowed duplicates"] = function(assert) {
   var set = new ArraySet();
 
-  set.add('foo');
-  set.add('foo');
+  set.add("foo");
+  set.add("foo");
 
-  set.add('bar');
-  set.add('bar');
+  set.add("bar");
+  set.add("bar");
 
-  set.add('baz');
-  set.add('baz');
+  set.add("baz");
+  set.add("baz");
 
   assert.strictEqual(set.size(), 3);
 };
 
-exports['test .size() with allowed duplicates'] = function (assert) {
+exports["test .size() with allowed duplicates"] = function(assert) {
   var set = new ArraySet();
 
-  set.add('foo');
-  set.add('foo', true);
+  set.add("foo");
+  set.add("foo", true);
 
-  set.add('bar');
-  set.add('bar', true);
+  set.add("bar");
+  set.add("bar", true);
 
-  set.add('baz');
-  set.add('baz', true);
+  set.add("baz");
+  set.add("baz", true);
 
   assert.strictEqual(set.size(), 3);
 };

--- a/test/test-base64-vlq.js
+++ b/test/test-base64-vlq.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var base64VLQ = require('../lib/base64-vlq');
+var base64VLQ = require("../lib/base64-vlq");
 
 var vlqs = [
   { number: -255, encoded: "/P" },
@@ -517,7 +517,7 @@ var vlqs = [
   { number: 255, encoded: "+P" },
 ];
 
-exports['test normal encoding and decoding'] = function (assert) {
+exports["test normal encoding and decoding"] = function(assert) {
   for (var i = 0; i < vlqs.length; i++) {
     var str = base64VLQ.encode(vlqs[i].number);
     assert.equal(

--- a/test/test-base64.js
+++ b/test/test-base64.js
@@ -5,18 +5,18 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var base64 = require('../lib/base64');
+var base64 = require("../lib/base64");
 
-exports['test out of range encoding'] = function (assert) {
-  assert.throws(function () {
+exports["test out of range encoding"] = function(assert) {
+  assert.throws(function() {
     base64.encode(-1);
   });
-  assert.throws(function () {
+  assert.throws(function() {
     base64.encode(64);
   });
 };
 
-exports['test normal encoding and decoding'] = function (assert) {
+exports["test normal encoding and decoding"] = function(assert) {
   for (var i = 0; i < 64; i++) {
     base64.encode(i);
   }

--- a/test/test-binary-search.js
+++ b/test/test-binary-search.js
@@ -5,39 +5,39 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var binarySearch = require('../lib/binary-search');
+var binarySearch = require("../lib/binary-search");
 
 function numberCompare(a, b) {
   return a - b;
 }
 
-exports['test too high with default (glb) bias'] = function (assert) {
+exports["test too high with default (glb) bias"] = function(assert) {
   var needle = 30;
-  var haystack = [2,4,6,8,10,12,14,16,18,20];
+  var haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
-  assert.doesNotThrow(function () {
+  assert.doesNotThrow(function() {
     binarySearch.search(needle, haystack, numberCompare);
   });
 
   assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare)], 20);
 };
 
-exports['test too low with default (glb) bias'] = function (assert) {
+exports["test too low with default (glb) bias"] = function(assert) {
   var needle = 1;
-  var haystack = [2,4,6,8,10,12,14,16,18,20];
+  var haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
-  assert.doesNotThrow(function () {
+  assert.doesNotThrow(function() {
     binarySearch.search(needle, haystack, numberCompare);
   });
 
   assert.equal(binarySearch.search(needle, haystack, numberCompare), -1);
 };
 
-exports['test too high with lub bias'] = function (assert) {
+exports["test too high with lub bias"] = function(assert) {
   var needle = 30;
-  var haystack = [2,4,6,8,10,12,14,16,18,20];
+  var haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
-  assert.doesNotThrow(function () {
+  assert.doesNotThrow(function() {
     binarySearch.search(needle, haystack, numberCompare);
   });
 
@@ -45,11 +45,11 @@ exports['test too high with lub bias'] = function (assert) {
                                    binarySearch.LEAST_UPPER_BOUND), -1);
 };
 
-exports['test too low with lub bias'] = function (assert) {
+exports["test too low with lub bias"] = function(assert) {
   var needle = 1;
-  var haystack = [2,4,6,8,10,12,14,16,18,20];
+  var haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
-  assert.doesNotThrow(function () {
+  assert.doesNotThrow(function() {
     binarySearch.search(needle, haystack, numberCompare);
   });
 
@@ -57,29 +57,29 @@ exports['test too low with lub bias'] = function (assert) {
                                             binarySearch.LEAST_UPPER_BOUND)], 2);
 };
 
-exports['test exact search'] = function (assert) {
+exports["test exact search"] = function(assert) {
   var needle = 4;
-  var haystack = [2,4,6,8,10,12,14,16,18,20];
+  var haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
   assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare)], 4);
 };
 
-exports['test fuzzy search with default (glb) bias'] = function (assert) {
+exports["test fuzzy search with default (glb) bias"] = function(assert) {
   var needle = 19;
-  var haystack = [2,4,6,8,10,12,14,16,18,20];
+  var haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
   assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare)], 18);
 };
 
-exports['test fuzzy search with lub bias'] = function (assert) {
+exports["test fuzzy search with lub bias"] = function(assert) {
   var needle = 19;
-  var haystack = [2,4,6,8,10,12,14,16,18,20];
+  var haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
   assert.equal(haystack[binarySearch.search(needle, haystack, numberCompare,
                                             binarySearch.LEAST_UPPER_BOUND)], 20);
 };
 
-exports['test multiple matches'] = function (assert) {
+exports["test multiple matches"] = function(assert) {
   var needle = 5;
   var haystack = [1, 1, 2, 5, 5, 5, 13, 21];
 
@@ -87,7 +87,7 @@ exports['test multiple matches'] = function (assert) {
                                    binarySearch.LEAST_UPPER_BOUND), 3);
 };
 
-exports['test multiple matches at the beginning'] = function (assert) {
+exports["test multiple matches at the beginning"] = function(assert) {
   var needle = 1;
   var haystack = [1, 1, 2, 5, 5, 5, 13, 21];
 

--- a/test/test-dog-fooding.js
+++ b/test/test-dog-fooding.js
@@ -6,41 +6,41 @@
  */
 
 var util = require("./util");
-var SourceMapConsumer = require('../lib/source-map-consumer').SourceMapConsumer;
-var SourceMapGenerator = require('../lib/source-map-generator').SourceMapGenerator;
+var SourceMapConsumer = require("../lib/source-map-consumer").SourceMapConsumer;
+var SourceMapGenerator = require("../lib/source-map-generator").SourceMapGenerator;
 
-exports['test eating our own dog food'] = async function (assert) {
+exports["test eating our own dog food"] = async function(assert) {
   var smg = new SourceMapGenerator({
-    file: 'testing.js',
-    sourceRoot: '/wu/tang'
+    file: "testing.js",
+    sourceRoot: "/wu/tang"
   });
 
   smg.addMapping({
-    source: 'gza.coffee',
+    source: "gza.coffee",
     original: { line: 1, column: 0 },
     generated: { line: 2, column: 2 }
   });
 
   smg.addMapping({
-    source: 'gza.coffee',
+    source: "gza.coffee",
     original: { line: 2, column: 0 },
     generated: { line: 3, column: 2 }
   });
 
   smg.addMapping({
-    source: 'gza.coffee',
+    source: "gza.coffee",
     original: { line: 3, column: 0 },
     generated: { line: 4, column: 2 }
   });
 
   smg.addMapping({
-    source: 'gza.coffee',
+    source: "gza.coffee",
     original: { line: 4, column: 0 },
     generated: { line: 5, column: 2 }
   });
 
   smg.addMapping({
-    source: 'gza.coffee',
+    source: "gza.coffee",
     original: { line: 5, column: 10 },
     generated: { line: 6, column: 12 }
   });
@@ -48,55 +48,55 @@ exports['test eating our own dog food'] = async function (assert) {
   var smc = await new SourceMapConsumer(smg.toString());
 
   // Exact
-  util.assertMapping(2, 2, '/wu/tang/gza.coffee', 1, 0, null, null, smc, assert);
-  util.assertMapping(3, 2, '/wu/tang/gza.coffee', 2, 0, null, null, smc, assert);
-  util.assertMapping(4, 2, '/wu/tang/gza.coffee', 3, 0, null, null, smc, assert);
-  util.assertMapping(5, 2, '/wu/tang/gza.coffee', 4, 0, null, null, smc, assert);
-  util.assertMapping(6, 12, '/wu/tang/gza.coffee', 5, 10, null, null, smc, assert);
+  util.assertMapping(2, 2, "/wu/tang/gza.coffee", 1, 0, null, null, smc, assert);
+  util.assertMapping(3, 2, "/wu/tang/gza.coffee", 2, 0, null, null, smc, assert);
+  util.assertMapping(4, 2, "/wu/tang/gza.coffee", 3, 0, null, null, smc, assert);
+  util.assertMapping(5, 2, "/wu/tang/gza.coffee", 4, 0, null, null, smc, assert);
+  util.assertMapping(6, 12, "/wu/tang/gza.coffee", 5, 10, null, null, smc, assert);
 
   // Fuzzy
 
   // Generated to original with default (glb) bias.
   util.assertMapping(2, 0, null, null, null, null, null, smc, assert, true);
-  util.assertMapping(2, 9, '/wu/tang/gza.coffee', 1, 0, null, null, smc, assert, true);
+  util.assertMapping(2, 9, "/wu/tang/gza.coffee", 1, 0, null, null, smc, assert, true);
   util.assertMapping(3, 0, null, null, null, null, null, smc, assert, true);
-  util.assertMapping(3, 9, '/wu/tang/gza.coffee', 2, 0, null, null, smc, assert, true);
+  util.assertMapping(3, 9, "/wu/tang/gza.coffee", 2, 0, null, null, smc, assert, true);
   util.assertMapping(4, 0, null, null, null, null, null, smc, assert, true);
-  util.assertMapping(4, 9, '/wu/tang/gza.coffee', 3, 0, null, null, smc, assert, true);
+  util.assertMapping(4, 9, "/wu/tang/gza.coffee", 3, 0, null, null, smc, assert, true);
   util.assertMapping(5, 0, null, null, null, null, null, smc, assert, true);
-  util.assertMapping(5, 9, '/wu/tang/gza.coffee', 4, 0, null, null, smc, assert, true);
+  util.assertMapping(5, 9, "/wu/tang/gza.coffee", 4, 0, null, null, smc, assert, true);
   util.assertMapping(6, 0, null, null, null, null, null, smc, assert, true);
   util.assertMapping(6, 9, null, null, null, null, null, smc, assert, true);
-  util.assertMapping(6, 13, '/wu/tang/gza.coffee', 5, 10, null, null, smc, assert, true);
+  util.assertMapping(6, 13, "/wu/tang/gza.coffee", 5, 10, null, null, smc, assert, true);
 
   // Generated to original with lub bias.
-  util.assertMapping(2, 0, '/wu/tang/gza.coffee', 1, 0, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
+  util.assertMapping(2, 0, "/wu/tang/gza.coffee", 1, 0, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
   util.assertMapping(2, 9, null, null, null, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
-  util.assertMapping(3, 0, '/wu/tang/gza.coffee', 2, 0, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
+  util.assertMapping(3, 0, "/wu/tang/gza.coffee", 2, 0, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
   util.assertMapping(3, 9, null, null, null, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
-  util.assertMapping(4, 0, '/wu/tang/gza.coffee', 3, 0, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
+  util.assertMapping(4, 0, "/wu/tang/gza.coffee", 3, 0, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
   util.assertMapping(4, 9, null, null, null, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
-  util.assertMapping(5, 0, '/wu/tang/gza.coffee', 4, 0, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
+  util.assertMapping(5, 0, "/wu/tang/gza.coffee", 4, 0, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
   util.assertMapping(5, 9, null, null, null, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
-  util.assertMapping(6, 0, '/wu/tang/gza.coffee', 5, 10, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
-  util.assertMapping(6, 9, '/wu/tang/gza.coffee', 5, 10, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
+  util.assertMapping(6, 0, "/wu/tang/gza.coffee", 5, 10, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
+  util.assertMapping(6, 9, "/wu/tang/gza.coffee", 5, 10, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
   util.assertMapping(6, 13, null, null, null, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, true);
 
   // Original to generated with default (glb) bias
-  util.assertMapping(2, 2, '/wu/tang/gza.coffee', 1, 1, null, null, smc, assert, null, true);
-  util.assertMapping(3, 2, '/wu/tang/gza.coffee', 2, 3, null, null, smc, assert, null, true);
-  util.assertMapping(4, 2, '/wu/tang/gza.coffee', 3, 6, null, null, smc, assert, null, true);
-  util.assertMapping(5, 2, '/wu/tang/gza.coffee', 4, 9, null, null, smc, assert, null, true);
-  util.assertMapping(5, 2, '/wu/tang/gza.coffee', 5, 9, null, null, smc, assert, null, true);
-  util.assertMapping(6, 12, '/wu/tang/gza.coffee', 6, 19, null, null, smc, assert, null, true);
+  util.assertMapping(2, 2, "/wu/tang/gza.coffee", 1, 1, null, null, smc, assert, null, true);
+  util.assertMapping(3, 2, "/wu/tang/gza.coffee", 2, 3, null, null, smc, assert, null, true);
+  util.assertMapping(4, 2, "/wu/tang/gza.coffee", 3, 6, null, null, smc, assert, null, true);
+  util.assertMapping(5, 2, "/wu/tang/gza.coffee", 4, 9, null, null, smc, assert, null, true);
+  util.assertMapping(5, 2, "/wu/tang/gza.coffee", 5, 9, null, null, smc, assert, null, true);
+  util.assertMapping(6, 12, "/wu/tang/gza.coffee", 6, 19, null, null, smc, assert, null, true);
 
   // Original to generated with lub bias.
-  util.assertMapping(3, 2, '/wu/tang/gza.coffee', 1, 1, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
-  util.assertMapping(4, 2, '/wu/tang/gza.coffee', 2, 3, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
-  util.assertMapping(5, 2, '/wu/tang/gza.coffee', 3, 6, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
-  util.assertMapping(6, 12, '/wu/tang/gza.coffee', 4, 9, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
-  util.assertMapping(6, 12, '/wu/tang/gza.coffee', 5, 9, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
-  util.assertMapping(null, null, '/wu/tang/gza.coffee', 6, 19, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
+  util.assertMapping(3, 2, "/wu/tang/gza.coffee", 1, 1, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
+  util.assertMapping(4, 2, "/wu/tang/gza.coffee", 2, 3, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
+  util.assertMapping(5, 2, "/wu/tang/gza.coffee", 3, 6, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
+  util.assertMapping(6, 12, "/wu/tang/gza.coffee", 4, 9, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
+  util.assertMapping(6, 12, "/wu/tang/gza.coffee", 5, 9, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
+  util.assertMapping(null, null, "/wu/tang/gza.coffee", 6, 19, null, SourceMapConsumer.LEAST_UPPER_BOUND, smc, assert, null, true);
 
   smc.destroy();
 };

--- a/test/test-nested-consumer-usage.js
+++ b/test/test-nested-consumer-usage.js
@@ -1,6 +1,6 @@
-const {SourceMapConsumer, SourceMapGenerator} = require('../')
+const {SourceMapConsumer, SourceMapGenerator} = require("../");
 
-const tsMap = {
+const TS_MAP = {
   version: 3,
   file: "blah.js",
   sourceRoot: "",
@@ -13,7 +13,7 @@ const tsMap = {
   ]
 };
 
-const babelMap = {
+const BABEL_MAP = {
   version: 3,
   sources: ["blah.tsx"],
   names: [
@@ -38,9 +38,9 @@ async function composeSourceMaps(
   babelMap,
   tsFileName,
 ) {
-  const tsConsumer = await new SourceMapConsumer(tsMap)
-  const babelConsumer = await new SourceMapConsumer(babelMap)
-  const map = new SourceMapGenerator()
+  const tsConsumer = await new SourceMapConsumer(tsMap);
+  const babelConsumer = await new SourceMapConsumer(babelMap);
+  const map = new SourceMapGenerator();
   babelConsumer.eachMapping(
     ({
       source,
@@ -54,7 +54,7 @@ async function composeSourceMaps(
         const original = tsConsumer.originalPositionFor({
           line: originalLine,
           column: originalColumn,
-        })
+        });
         if (original.line) {
           map.addMapping({
             generated: {
@@ -66,15 +66,15 @@ async function composeSourceMaps(
               column: original.column,
             },
             source: tsFileName,
-            name: name,
-          })
+            name,
+          });
         }
       }
     }
-  )
-  return map.toJSON()
+  );
+  return map.toJSON();
 }
 
-exports["test nested consumer usage"] = async function (assert) {
-  await composeSourceMaps(tsMap, babelMap, 'blah.tsx')
+exports["test nested consumer usage"] = async function(assert) {
+  await composeSourceMaps(TS_MAP, BABEL_MAP, "blah.tsx");
 };

--- a/test/test-source-map-consumer.js
+++ b/test/test-source-map-consumer.js
@@ -6,77 +6,77 @@
  */
 
 var util = require("./util");
-var SourceMapConsumer = require('../lib/source-map-consumer').SourceMapConsumer;
-var IndexedSourceMapConsumer = require('../lib/source-map-consumer').IndexedSourceMapConsumer;
-var BasicSourceMapConsumer = require('../lib/source-map-consumer').BasicSourceMapConsumer;
-var SourceMapGenerator = require('../lib/source-map-generator').SourceMapGenerator;
+var SourceMapConsumer = require("../lib/source-map-consumer").SourceMapConsumer;
+var IndexedSourceMapConsumer = require("../lib/source-map-consumer").IndexedSourceMapConsumer;
+var BasicSourceMapConsumer = require("../lib/source-map-consumer").BasicSourceMapConsumer;
+var SourceMapGenerator = require("../lib/source-map-generator").SourceMapGenerator;
 
-exports['test that we can instantiate with a string or an object'] = async function (assert) {
+exports["test that we can instantiate with a string or an object"] = async function(assert) {
   var map = await new SourceMapConsumer(util.testMap);
   map = await new SourceMapConsumer(JSON.stringify(util.testMap));
   assert.ok(true);
   map.destroy();
 };
 
-exports['test that the object returned from await new SourceMapConsumer inherits from SourceMapConsumer'] = async function (assert) {
+exports["test that the object returned from await new SourceMapConsumer inherits from SourceMapConsumer"] = async function(assert) {
   var map = await new SourceMapConsumer(util.testMap);
   assert.ok(map instanceof SourceMapConsumer);
   map.destroy();
-}
+};
 
-exports['test that a BasicSourceMapConsumer is returned for sourcemaps without sections'] = async function(assert) {
+exports["test that a BasicSourceMapConsumer is returned for sourcemaps without sections"] = async function(assert) {
   var map = await new SourceMapConsumer(util.testMap);
   assert.ok(map instanceof BasicSourceMapConsumer);
   map.destroy();
 };
 
-exports['test that an IndexedSourceMapConsumer is returned for sourcemaps with sections'] = async function(assert) {
+exports["test that an IndexedSourceMapConsumer is returned for sourcemaps with sections"] = async function(assert) {
   var map = await new SourceMapConsumer(util.indexedTestMap);
   assert.ok(map instanceof IndexedSourceMapConsumer);
   map.destroy();
 };
 
-exports['test that the `sources` field has the original sources'] = async function (assert) {
+exports["test that the `sources` field has the original sources"] = async function(assert) {
   var map;
   var sources;
 
   map = await new SourceMapConsumer(util.testMap);
   sources = map.sources;
-  assert.equal(sources[0], '/the/root/one.js');
-  assert.equal(sources[1], '/the/root/two.js');
+  assert.equal(sources[0], "/the/root/one.js");
+  assert.equal(sources[1], "/the/root/two.js");
   assert.equal(sources.length, 2);
   map.destroy();
 
   map = await new SourceMapConsumer(util.indexedTestMap);
   sources = map.sources;
-  assert.equal(sources[0], '/the/root/one.js');
-  assert.equal(sources[1], '/the/root/two.js');
+  assert.equal(sources[0], "/the/root/one.js");
+  assert.equal(sources[1], "/the/root/two.js");
   assert.equal(sources.length, 2);
   map.destroy();
 
   map = await new SourceMapConsumer(util.indexedTestMapDifferentSourceRoots);
   sources = map.sources;
-  assert.equal(sources[0], '/the/root/one.js');
-  assert.equal(sources[1], '/different/root/two.js');
+  assert.equal(sources[0], "/the/root/one.js");
+  assert.equal(sources[1], "/different/root/two.js");
   assert.equal(sources.length, 2);
   map.destroy();
 
   map = await new SourceMapConsumer(util.testMapNoSourceRoot);
   sources = map.sources;
-  assert.equal(sources[0], 'one.js');
-  assert.equal(sources[1], 'two.js');
+  assert.equal(sources[0], "one.js");
+  assert.equal(sources[1], "two.js");
   assert.equal(sources.length, 2);
   map.destroy();
 
   map = await new SourceMapConsumer(util.testMapEmptySourceRoot);
   sources = map.sources;
-  assert.equal(sources[0], 'one.js');
-  assert.equal(sources[1], 'two.js');
+  assert.equal(sources[0], "one.js");
+  assert.equal(sources[1], "two.js");
   assert.equal(sources.length, 2);
   map.destroy();
 };
 
-exports['test that the source root is reflected in a mapping\'s source field'] = async function (assert) {
+exports["test that the source root is reflected in a mapping's source field"] = async function(assert) {
   var map;
   var mapping;
 
@@ -86,13 +86,13 @@ exports['test that the source root is reflected in a mapping\'s source field'] =
     line: 2,
     column: 1
   });
-  assert.equal(mapping.source, '/the/root/two.js');
+  assert.equal(mapping.source, "/the/root/two.js");
 
   mapping = map.originalPositionFor({
     line: 1,
     column: 1
   });
-  assert.equal(mapping.source, '/the/root/one.js');
+  assert.equal(mapping.source, "/the/root/one.js");
   map.destroy();
 
 
@@ -102,13 +102,13 @@ exports['test that the source root is reflected in a mapping\'s source field'] =
     line: 2,
     column: 1
   });
-  assert.equal(mapping.source, 'two.js');
+  assert.equal(mapping.source, "two.js");
 
   mapping = map.originalPositionFor({
     line: 1,
     column: 1
   });
-  assert.equal(mapping.source, 'one.js');
+  assert.equal(mapping.source, "one.js");
   map.destroy();
 
 
@@ -118,166 +118,165 @@ exports['test that the source root is reflected in a mapping\'s source field'] =
     line: 2,
     column: 1
   });
-  assert.equal(mapping.source, 'two.js');
+  assert.equal(mapping.source, "two.js");
 
   mapping = map.originalPositionFor({
     line: 1,
     column: 1
   });
-  assert.equal(mapping.source, 'one.js');
+  assert.equal(mapping.source, "one.js");
   map.destroy();
 };
 
-exports['test mapping tokens back exactly'] = async function (assert) {
+exports["test mapping tokens back exactly"] = async function(assert) {
   var map = await new SourceMapConsumer(util.testMap);
 
-  util.assertMapping(1, 1, '/the/root/one.js', 1, 1, null, null, map, assert);
-  util.assertMapping(1, 5, '/the/root/one.js', 1, 5, null, null, map, assert);
-  util.assertMapping(1, 9, '/the/root/one.js', 1, 11, null, null, map, assert);
-  util.assertMapping(1, 18, '/the/root/one.js', 1, 21, 'bar', null, map, assert);
-  util.assertMapping(1, 21, '/the/root/one.js', 2, 3, null, null, map, assert);
-  util.assertMapping(1, 28, '/the/root/one.js', 2, 10, 'baz', null, map, assert);
-  util.assertMapping(1, 32, '/the/root/one.js', 2, 14, 'bar', null, map, assert);
+  util.assertMapping(1, 1, "/the/root/one.js", 1, 1, null, null, map, assert);
+  util.assertMapping(1, 5, "/the/root/one.js", 1, 5, null, null, map, assert);
+  util.assertMapping(1, 9, "/the/root/one.js", 1, 11, null, null, map, assert);
+  util.assertMapping(1, 18, "/the/root/one.js", 1, 21, "bar", null, map, assert);
+  util.assertMapping(1, 21, "/the/root/one.js", 2, 3, null, null, map, assert);
+  util.assertMapping(1, 28, "/the/root/one.js", 2, 10, "baz", null, map, assert);
+  util.assertMapping(1, 32, "/the/root/one.js", 2, 14, "bar", null, map, assert);
 
-  util.assertMapping(2, 1, '/the/root/two.js', 1, 1, null, null, map, assert);
-  util.assertMapping(2, 5, '/the/root/two.js', 1, 5, null, null, map, assert);
-  util.assertMapping(2, 9, '/the/root/two.js', 1, 11, null, null, map, assert);
-  util.assertMapping(2, 18, '/the/root/two.js', 1, 21, 'n', null, map, assert);
-  util.assertMapping(2, 21, '/the/root/two.js', 2, 3, null, null, map, assert);
-  util.assertMapping(2, 28, '/the/root/two.js', 2, 10, 'n', null, map, assert);
+  util.assertMapping(2, 1, "/the/root/two.js", 1, 1, null, null, map, assert);
+  util.assertMapping(2, 5, "/the/root/two.js", 1, 5, null, null, map, assert);
+  util.assertMapping(2, 9, "/the/root/two.js", 1, 11, null, null, map, assert);
+  util.assertMapping(2, 18, "/the/root/two.js", 1, 21, "n", null, map, assert);
+  util.assertMapping(2, 21, "/the/root/two.js", 2, 3, null, null, map, assert);
+  util.assertMapping(2, 28, "/the/root/two.js", 2, 10, "n", null, map, assert);
 
   map.destroy();
 };
 
-exports['test mapping tokens back exactly in indexed source map'] = async function (assert) {
+exports["test mapping tokens back exactly in indexed source map"] = async function(assert) {
   var map = await new SourceMapConsumer(util.indexedTestMap);
 
-  util.assertMapping(1, 1, '/the/root/one.js', 1, 1, null, null, map, assert);
-  util.assertMapping(1, 5, '/the/root/one.js', 1, 5, null, null, map, assert);
-  util.assertMapping(1, 9, '/the/root/one.js', 1, 11, null, null, map, assert);
-  util.assertMapping(1, 18, '/the/root/one.js', 1, 21, 'bar', null, map, assert);
-  util.assertMapping(1, 21, '/the/root/one.js', 2, 3, null, null, map, assert);
-  util.assertMapping(1, 28, '/the/root/one.js', 2, 10, 'baz', null, map, assert);
-  util.assertMapping(1, 32, '/the/root/one.js', 2, 14, 'bar', null, map, assert);
+  util.assertMapping(1, 1, "/the/root/one.js", 1, 1, null, null, map, assert);
+  util.assertMapping(1, 5, "/the/root/one.js", 1, 5, null, null, map, assert);
+  util.assertMapping(1, 9, "/the/root/one.js", 1, 11, null, null, map, assert);
+  util.assertMapping(1, 18, "/the/root/one.js", 1, 21, "bar", null, map, assert);
+  util.assertMapping(1, 21, "/the/root/one.js", 2, 3, null, null, map, assert);
+  util.assertMapping(1, 28, "/the/root/one.js", 2, 10, "baz", null, map, assert);
+  util.assertMapping(1, 32, "/the/root/one.js", 2, 14, "bar", null, map, assert);
 
-  util.assertMapping(2, 1, '/the/root/two.js', 1, 1, null, null, map, assert);
-  util.assertMapping(2, 5, '/the/root/two.js', 1, 5, null, null, map, assert);
-  util.assertMapping(2, 9, '/the/root/two.js', 1, 11, null, null, map, assert);
-  util.assertMapping(2, 18, '/the/root/two.js', 1, 21, 'n', null, map, assert);
-  util.assertMapping(2, 21, '/the/root/two.js', 2, 3, null, null, map, assert);
-  util.assertMapping(2, 28, '/the/root/two.js', 2, 10, 'n', null, map, assert);
+  util.assertMapping(2, 1, "/the/root/two.js", 1, 1, null, null, map, assert);
+  util.assertMapping(2, 5, "/the/root/two.js", 1, 5, null, null, map, assert);
+  util.assertMapping(2, 9, "/the/root/two.js", 1, 11, null, null, map, assert);
+  util.assertMapping(2, 18, "/the/root/two.js", 1, 21, "n", null, map, assert);
+  util.assertMapping(2, 21, "/the/root/two.js", 2, 3, null, null, map, assert);
+  util.assertMapping(2, 28, "/the/root/two.js", 2, 10, "n", null, map, assert);
 
   map.destroy();
 };
 
-exports['test mapping tokens fuzzy'] = async function (assert) {
+exports["test mapping tokens fuzzy"] = async function(assert) {
   var map = await new SourceMapConsumer(util.testMap);
 
   // Finding original positions with default (glb) bias.
-  util.assertMapping(1, 20, '/the/root/one.js', 1, 21, 'bar', null, map, assert, true);
-  util.assertMapping(1, 30, '/the/root/one.js', 2, 10, 'baz', null, map, assert, true);
-  util.assertMapping(2, 12, '/the/root/two.js', 1, 11, null, null, map, assert, true);
+  util.assertMapping(1, 20, "/the/root/one.js", 1, 21, "bar", null, map, assert, true);
+  util.assertMapping(1, 30, "/the/root/one.js", 2, 10, "baz", null, map, assert, true);
+  util.assertMapping(2, 12, "/the/root/two.js", 1, 11, null, null, map, assert, true);
 
   // Finding original positions with lub bias.
-  util.assertMapping(1, 16, '/the/root/one.js', 1, 21, 'bar', SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
-  util.assertMapping(1, 26, '/the/root/one.js', 2, 10, 'baz', SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
-  util.assertMapping(2, 6, '/the/root/two.js', 1, 11, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
+  util.assertMapping(1, 16, "/the/root/one.js", 1, 21, "bar", SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
+  util.assertMapping(1, 26, "/the/root/one.js", 2, 10, "baz", SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
+  util.assertMapping(2, 6, "/the/root/two.js", 1, 11, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
 
   // Finding generated positions with default (glb) bias.
-  util.assertMapping(1, 18, '/the/root/one.js', 1, 22, 'bar', null, map, assert, null, true);
-  util.assertMapping(1, 28, '/the/root/one.js', 2, 13, 'baz', null, map, assert, null, true);
-  util.assertMapping(2, 9, '/the/root/two.js', 1, 16, null, null, map, assert, null, true);
+  util.assertMapping(1, 18, "/the/root/one.js", 1, 22, "bar", null, map, assert, null, true);
+  util.assertMapping(1, 28, "/the/root/one.js", 2, 13, "baz", null, map, assert, null, true);
+  util.assertMapping(2, 9, "/the/root/two.js", 1, 16, null, null, map, assert, null, true);
 
   // Finding generated positions with lub bias.
-  util.assertMapping(1, 18, '/the/root/one.js', 1, 20, 'bar', SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
-  util.assertMapping(1, 28, '/the/root/one.js', 2, 7, 'baz', SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
-  util.assertMapping(2, 9, '/the/root/two.js', 1, 6, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
+  util.assertMapping(1, 18, "/the/root/one.js", 1, 20, "bar", SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
+  util.assertMapping(1, 28, "/the/root/one.js", 2, 7, "baz", SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
+  util.assertMapping(2, 9, "/the/root/two.js", 1, 6, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
 
   map.destroy();
 };
 
-exports['test mapping tokens fuzzy in indexed source map'] = async function (assert) {
+exports["test mapping tokens fuzzy in indexed source map"] = async function(assert) {
   var map = await new SourceMapConsumer(util.indexedTestMap);
 
   // Finding original positions with default (glb) bias.
-  util.assertMapping(1, 20, '/the/root/one.js', 1, 21, 'bar', null, map, assert, true);
-  util.assertMapping(1, 30, '/the/root/one.js', 2, 10, 'baz', null, map, assert, true);
-  util.assertMapping(2, 12, '/the/root/two.js', 1, 11, null, null, map, assert, true);
+  util.assertMapping(1, 20, "/the/root/one.js", 1, 21, "bar", null, map, assert, true);
+  util.assertMapping(1, 30, "/the/root/one.js", 2, 10, "baz", null, map, assert, true);
+  util.assertMapping(2, 12, "/the/root/two.js", 1, 11, null, null, map, assert, true);
 
   // Finding original positions with lub bias.
-  util.assertMapping(1, 16, '/the/root/one.js', 1, 21, 'bar', SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
-  util.assertMapping(1, 26, '/the/root/one.js', 2, 10, 'baz', SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
-  util.assertMapping(2, 6, '/the/root/two.js', 1, 11, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
+  util.assertMapping(1, 16, "/the/root/one.js", 1, 21, "bar", SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
+  util.assertMapping(1, 26, "/the/root/one.js", 2, 10, "baz", SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
+  util.assertMapping(2, 6, "/the/root/two.js", 1, 11, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, true);
 
   // Finding generated positions with default (glb) bias.
-  util.assertMapping(1, 18, '/the/root/one.js', 1, 22, 'bar', null, map, assert, null, true);
-  util.assertMapping(1, 28, '/the/root/one.js', 2, 13, 'baz', null, map, assert, null, true);
-  util.assertMapping(2, 9, '/the/root/two.js', 1, 16, null, null, map, assert, null, true);
+  util.assertMapping(1, 18, "/the/root/one.js", 1, 22, "bar", null, map, assert, null, true);
+  util.assertMapping(1, 28, "/the/root/one.js", 2, 13, "baz", null, map, assert, null, true);
+  util.assertMapping(2, 9, "/the/root/two.js", 1, 16, null, null, map, assert, null, true);
 
   // Finding generated positions with lub bias.
-  util.assertMapping(1, 18, '/the/root/one.js', 1, 20, 'bar', SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
-  util.assertMapping(1, 28, '/the/root/one.js', 2, 7, 'baz', SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
-  util.assertMapping(2, 9, '/the/root/two.js', 1, 6, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
+  util.assertMapping(1, 18, "/the/root/one.js", 1, 20, "bar", SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
+  util.assertMapping(1, 28, "/the/root/one.js", 2, 7, "baz", SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
+  util.assertMapping(2, 9, "/the/root/two.js", 1, 6, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
 
   map.destroy();
 };
 
-exports['test mappings and end of lines'] = async function (assert) {
+exports["test mappings and end of lines"] = async function(assert) {
   var smg = new SourceMapGenerator({
-    file: 'foo.js'
+    file: "foo.js"
   });
   smg.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 1 },
-    source: 'bar.js'
+    source: "bar.js"
   });
   smg.addMapping({
     original: { line: 2, column: 2 },
     generated: { line: 2, column: 2 },
-    source: 'bar.js'
+    source: "bar.js"
   });
   smg.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 1 },
-    source: 'baz.js'
+    source: "baz.js"
   });
 
   var map = await SourceMapConsumer.fromSourceMap(smg);
 
   // When finding original positions, mappings end at the end of the line.
-  util.assertMapping(2, 1, null, null, null, null, null, map, assert, true)
+  util.assertMapping(2, 1, null, null, null, null, null, map, assert, true);
 
   // When finding generated positions, mappings do not end at the end of the line.
-  util.assertMapping(1, 1, 'bar.js', 2, 1, null, null, map, assert, null, true);
+  util.assertMapping(1, 1, "bar.js", 2, 1, null, null, map, assert, null, true);
 
   // When finding generated positions with, mappings end at the end of the source.
-  util.assertMapping(null, null, 'bar.js', 3, 1, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
+  util.assertMapping(null, null, "bar.js", 3, 1, null, SourceMapConsumer.LEAST_UPPER_BOUND, map, assert, null, true);
 
   map.destroy();
 };
 
-exports['test creating source map consumers with )]}\' prefix'] = async function (assert) {
+exports["test creating source map consumers with )]}' prefix"] = async function(assert) {
   var map = await new SourceMapConsumer(")]}'\n" + JSON.stringify(util.testMap));
   assert.ok(true);
   map.destroy();
 };
 
-exports['test eachMapping'] = async function (assert) {
+exports["test eachMapping"] = async function(assert) {
   var map;
 
   map = await new SourceMapConsumer(util.testMap);
   var previousLine = -Infinity;
   var previousColumn = -Infinity;
-  map.eachMapping(function (mapping) {
+  map.eachMapping(function(mapping) {
     assert.ok(mapping.generatedLine >= previousLine);
 
-    assert.ok(mapping.source === '/the/root/one.js' || mapping.source === '/the/root/two.js');
+    assert.ok(mapping.source === "/the/root/one.js" || mapping.source === "/the/root/two.js");
 
     if (mapping.generatedLine === previousLine) {
       assert.ok(mapping.generatedColumn >= previousColumn);
       previousColumn = mapping.generatedColumn;
-    }
-    else {
+    } else {
       previousLine = mapping.generatedLine;
       previousColumn = -Infinity;
     }
@@ -285,30 +284,30 @@ exports['test eachMapping'] = async function (assert) {
   map.destroy();
 
   map = await new SourceMapConsumer(util.testMapNoSourceRoot);
-  map.eachMapping(function (mapping) {
-    assert.ok(mapping.source === 'one.js' || mapping.source === 'two.js');
+  map.eachMapping(function(mapping) {
+    assert.ok(mapping.source === "one.js" || mapping.source === "two.js");
   });
   map.destroy();
 
   map = await new SourceMapConsumer(util.testMapEmptySourceRoot);
-  map.eachMapping(function (mapping) {
-    assert.ok(mapping.source === 'one.js' || mapping.source === 'two.js');
+  map.eachMapping(function(mapping) {
+    assert.ok(mapping.source === "one.js" || mapping.source === "two.js");
   });
   map.destroy();
 
   map = await new SourceMapConsumer(util.mapWithSourcelessMapping);
-  map.eachMapping(function (mapping) {
-    assert.ok(mapping.source === null || (typeof mapping.originalColumn === 'number' && typeof mapping.originalLine === 'number'));
+  map.eachMapping(function(mapping) {
+    assert.ok(mapping.source === null || (typeof mapping.originalColumn === "number" && typeof mapping.originalLine === "number"));
   });
   map.destroy();
 };
 
-exports['test eachMapping for indexed source maps'] = async function(assert) {
+exports["test eachMapping for indexed source maps"] = async function(assert) {
   var map = await new SourceMapConsumer(util.indexedTestMap);
   var previousLine = -Infinity;
   var previousColumn = -Infinity;
 
-  map.eachMapping(function (mapping) {
+  map.eachMapping(function(mapping) {
     assert.ok(mapping.generatedLine >= previousLine);
 
     if (mapping.source) {
@@ -318,8 +317,7 @@ exports['test eachMapping for indexed source maps'] = async function(assert) {
     if (mapping.generatedLine === previousLine) {
       assert.ok(mapping.generatedColumn >= previousColumn);
       previousColumn = mapping.generatedColumn;
-    }
-    else {
+    } else {
       previousLine = mapping.generatedLine;
       previousColumn = -Infinity;
     }
@@ -328,13 +326,13 @@ exports['test eachMapping for indexed source maps'] = async function(assert) {
   map.destroy();
 };
 
-exports['test iterating over mappings in a different order'] = async function (assert) {
+exports["test iterating over mappings in a different order"] = async function(assert) {
   var map = await new SourceMapConsumer(util.testMap);
   var previousLine = -Infinity;
   var previousColumn = -Infinity;
   var previousSource = "";
 
-  map.eachMapping(function (mapping) {
+  map.eachMapping(function(mapping) {
     assert.ok(mapping.source >= previousSource);
 
     if (mapping.source === previousSource) {
@@ -343,13 +341,11 @@ exports['test iterating over mappings in a different order'] = async function (a
       if (mapping.originalLine === previousLine) {
         assert.ok(mapping.originalColumn >= previousColumn);
         previousColumn = mapping.originalColumn;
-      }
-      else {
+      } else {
         previousLine = mapping.originalLine;
         previousColumn = -Infinity;
       }
-    }
-    else {
+    } else {
       previousSource = mapping.source;
       previousLine = -Infinity;
       previousColumn = -Infinity;
@@ -359,12 +355,12 @@ exports['test iterating over mappings in a different order'] = async function (a
   map.destroy();
 };
 
-exports['test iterating over mappings in a different order in indexed source maps'] = async function (assert) {
+exports["test iterating over mappings in a different order in indexed source maps"] = async function(assert) {
   var map = await new SourceMapConsumer(util.indexedTestMap);
   var previousLine = -Infinity;
   var previousColumn = -Infinity;
   var previousSource = "";
-  map.eachMapping(function (mapping) {
+  map.eachMapping(function(mapping) {
     assert.ok(mapping.source >= previousSource);
 
     if (mapping.source === previousSource) {
@@ -373,13 +369,11 @@ exports['test iterating over mappings in a different order in indexed source map
       if (mapping.originalLine === previousLine) {
         assert.ok(mapping.originalColumn >= previousColumn);
         previousColumn = mapping.originalColumn;
-      }
-      else {
+      } else {
         previousLine = mapping.originalLine;
         previousColumn = -Infinity;
       }
-    }
-    else {
+    } else {
       previousSource = mapping.source;
       previousLine = -Infinity;
       previousColumn = -Infinity;
@@ -388,115 +382,115 @@ exports['test iterating over mappings in a different order in indexed source map
   map.destroy();
 };
 
-exports['test that we can set the context for `this` in eachMapping'] = async function (assert) {
+exports["test that we can set the context for `this` in eachMapping"] = async function(assert) {
   var map = await new SourceMapConsumer(util.testMap);
   var context = {};
-  map.eachMapping(function () {
+  map.eachMapping(function() {
     assert.equal(this, context);
   }, context);
   map.destroy();
 };
 
-exports['test that we can set the context for `this` in eachMapping in indexed source maps'] = async function (assert) {
+exports["test that we can set the context for `this` in eachMapping in indexed source maps"] = async function(assert) {
   var map = await new SourceMapConsumer(util.indexedTestMap);
   var context = {};
-  map.eachMapping(function () {
+  map.eachMapping(function() {
     assert.equal(this, context);
   }, context);
   map.destroy();
 };
 
-exports['test that the `sourcesContent` field has the original sources'] = async function (assert) {
+exports["test that the `sourcesContent` field has the original sources"] = async function(assert) {
   var map = await new SourceMapConsumer(util.testMapWithSourcesContent);
   var sourcesContent = map.sourcesContent;
 
-  assert.equal(sourcesContent[0], ' ONE.foo = function (bar) {\n   return baz(bar);\n };');
-  assert.equal(sourcesContent[1], ' TWO.inc = function (n) {\n   return n + 1;\n };');
+  assert.equal(sourcesContent[0], " ONE.foo = function (bar) {\n   return baz(bar);\n };");
+  assert.equal(sourcesContent[1], " TWO.inc = function (n) {\n   return n + 1;\n };");
   assert.equal(sourcesContent.length, 2);
 
   map.destroy();
 };
 
-exports['test that we can get the original sources for the sources'] = async function (assert) {
+exports["test that we can get the original sources for the sources"] = async function(assert) {
   var map = await new SourceMapConsumer(util.testMapWithSourcesContent);
   var sources = map.sources;
 
-  assert.equal(map.sourceContentFor(sources[0]), ' ONE.foo = function (bar) {\n   return baz(bar);\n };');
-  assert.equal(map.sourceContentFor(sources[1]), ' TWO.inc = function (n) {\n   return n + 1;\n };');
-  assert.equal(map.sourceContentFor("one.js"), ' ONE.foo = function (bar) {\n   return baz(bar);\n };');
-  assert.equal(map.sourceContentFor("two.js"), ' TWO.inc = function (n) {\n   return n + 1;\n };');
-  assert.throws(function () {
+  assert.equal(map.sourceContentFor(sources[0]), " ONE.foo = function (bar) {\n   return baz(bar);\n };");
+  assert.equal(map.sourceContentFor(sources[1]), " TWO.inc = function (n) {\n   return n + 1;\n };");
+  assert.equal(map.sourceContentFor("one.js"), " ONE.foo = function (bar) {\n   return baz(bar);\n };");
+  assert.equal(map.sourceContentFor("two.js"), " TWO.inc = function (n) {\n   return n + 1;\n };");
+  assert.throws(function() {
     map.sourceContentFor("");
   }, Error);
-  assert.throws(function () {
+  assert.throws(function() {
     map.sourceContentFor("/the/root/three.js");
   }, Error);
-  assert.throws(function () {
+  assert.throws(function() {
     map.sourceContentFor("three.js");
   }, Error);
 
   map.destroy();
 };
 
-exports['test that we can get the original source content with relative source paths'] = async function (assert) {
+exports["test that we can get the original source content with relative source paths"] = async function(assert) {
   var map = await new SourceMapConsumer(util.testMapRelativeSources);
   var sources = map.sources;
 
-  assert.equal(map.sourceContentFor(sources[0]), ' ONE.foo = function (bar) {\n   return baz(bar);\n };');
-  assert.equal(map.sourceContentFor(sources[1]), ' TWO.inc = function (n) {\n   return n + 1;\n };');
-  assert.equal(map.sourceContentFor("one.js"), ' ONE.foo = function (bar) {\n   return baz(bar);\n };');
-  assert.equal(map.sourceContentFor("two.js"), ' TWO.inc = function (n) {\n   return n + 1;\n };');
-  assert.throws(function () {
+  assert.equal(map.sourceContentFor(sources[0]), " ONE.foo = function (bar) {\n   return baz(bar);\n };");
+  assert.equal(map.sourceContentFor(sources[1]), " TWO.inc = function (n) {\n   return n + 1;\n };");
+  assert.equal(map.sourceContentFor("one.js"), " ONE.foo = function (bar) {\n   return baz(bar);\n };");
+  assert.equal(map.sourceContentFor("two.js"), " TWO.inc = function (n) {\n   return n + 1;\n };");
+  assert.throws(function() {
     map.sourceContentFor("");
   }, Error);
-  assert.throws(function () {
+  assert.throws(function() {
     map.sourceContentFor("/the/root/three.js");
   }, Error);
-  assert.throws(function () {
+  assert.throws(function() {
     map.sourceContentFor("three.js");
   }, Error);
 
   map.destroy();
 };
 
-exports['test that we can get the original source content for the sources on an indexed source map'] = async function (assert) {
+exports["test that we can get the original source content for the sources on an indexed source map"] = async function(assert) {
   var map = await new SourceMapConsumer(util.indexedTestMap);
   var sources = map.sources;
 
-  assert.equal(map.sourceContentFor(sources[0]), ' ONE.foo = function (bar) {\n   return baz(bar);\n };');
-  assert.equal(map.sourceContentFor(sources[1]), ' TWO.inc = function (n) {\n   return n + 1;\n };');
-  assert.equal(map.sourceContentFor("one.js"), ' ONE.foo = function (bar) {\n   return baz(bar);\n };');
-  assert.equal(map.sourceContentFor("two.js"), ' TWO.inc = function (n) {\n   return n + 1;\n };');
-  assert.throws(function () {
+  assert.equal(map.sourceContentFor(sources[0]), " ONE.foo = function (bar) {\n   return baz(bar);\n };");
+  assert.equal(map.sourceContentFor(sources[1]), " TWO.inc = function (n) {\n   return n + 1;\n };");
+  assert.equal(map.sourceContentFor("one.js"), " ONE.foo = function (bar) {\n   return baz(bar);\n };");
+  assert.equal(map.sourceContentFor("two.js"), " TWO.inc = function (n) {\n   return n + 1;\n };");
+  assert.throws(function() {
     map.sourceContentFor("");
   }, Error);
-  assert.throws(function () {
+  assert.throws(function() {
     map.sourceContentFor("/the/root/three.js");
   }, Error);
-  assert.throws(function () {
+  assert.throws(function() {
     map.sourceContentFor("three.js");
   }, Error);
 
   map.destroy();
 };
 
-exports['test hasContentsOfAllSources, single source with contents'] = async function (assert) {
+exports["test hasContentsOfAllSources, single source with contents"] = async function(assert) {
   // Has one source: foo.js (with contents).
   var mapWithContents = new SourceMapGenerator();
-  mapWithContents.addMapping({ source: 'foo.js',
+  mapWithContents.addMapping({ source: "foo.js",
                                original: { line: 1, column: 10 },
                                generated: { line: 1, column: 10 } });
-  mapWithContents.setSourceContent('foo.js', 'content of foo.js');
+  mapWithContents.setSourceContent("foo.js", "content of foo.js");
 
   var consumer = await new SourceMapConsumer(mapWithContents.toJSON());
   assert.ok(consumer.hasContentsOfAllSources());
   consumer.destroy();
 };
 
-exports['test hasContentsOfAllSources, single source without contents'] = async function (assert) {
+exports["test hasContentsOfAllSources, single source without contents"] = async function(assert) {
   // Has one source: foo.js (without contents).
   var mapWithoutContents = new SourceMapGenerator();
-  mapWithoutContents.addMapping({ source: 'foo.js',
+  mapWithoutContents.addMapping({ source: "foo.js",
                                   original: { line: 1, column: 10 },
                                   generated: { line: 1, column: 10 } });
   var consumer = await new SourceMapConsumer(mapWithoutContents.toJSON());
@@ -504,81 +498,81 @@ exports['test hasContentsOfAllSources, single source without contents'] = async 
   consumer.destroy();
 };
 
-exports['test hasContentsOfAllSources, two sources with contents'] = async function (assert) {
+exports["test hasContentsOfAllSources, two sources with contents"] = async function(assert) {
   // Has two sources: foo.js (with contents) and bar.js (with contents).
   var mapWithBothContents = new SourceMapGenerator();
-  mapWithBothContents.addMapping({ source: 'foo.js',
+  mapWithBothContents.addMapping({ source: "foo.js",
                                    original: { line: 1, column: 10 },
                                    generated: { line: 1, column: 10 } });
-  mapWithBothContents.addMapping({ source: 'bar.js',
+  mapWithBothContents.addMapping({ source: "bar.js",
                                    original: { line: 1, column: 10 },
                                    generated: { line: 1, column: 10 } });
-  mapWithBothContents.setSourceContent('foo.js', 'content of foo.js');
-  mapWithBothContents.setSourceContent('bar.js', 'content of bar.js');
+  mapWithBothContents.setSourceContent("foo.js", "content of foo.js");
+  mapWithBothContents.setSourceContent("bar.js", "content of bar.js");
   var consumer = await new SourceMapConsumer(mapWithBothContents.toJSON());
   assert.ok(consumer.hasContentsOfAllSources());
   consumer.destroy();
 };
 
-exports['test hasContentsOfAllSources, two sources one with and one without contents'] = async function (assert) {
+exports["test hasContentsOfAllSources, two sources one with and one without contents"] = async function(assert) {
   // Has two sources: foo.js (with contents) and bar.js (without contents).
   var mapWithoutSomeContents = new SourceMapGenerator();
-  mapWithoutSomeContents.addMapping({ source: 'foo.js',
+  mapWithoutSomeContents.addMapping({ source: "foo.js",
                                       original: { line: 1, column: 10 },
                                       generated: { line: 1, column: 10 } });
-  mapWithoutSomeContents.addMapping({ source: 'bar.js',
+  mapWithoutSomeContents.addMapping({ source: "bar.js",
                                       original: { line: 1, column: 10 },
                                       generated: { line: 1, column: 10 } });
-  mapWithoutSomeContents.setSourceContent('foo.js', 'content of foo.js');
+  mapWithoutSomeContents.setSourceContent("foo.js", "content of foo.js");
   var consumer = await new SourceMapConsumer(mapWithoutSomeContents.toJSON());
   assert.ok(!consumer.hasContentsOfAllSources());
   consumer.destroy();
 };
 
-exports['test sourceRoot + generatedPositionFor'] = async function (assert) {
+exports["test sourceRoot + generatedPositionFor"] = async function(assert) {
   var map = new SourceMapGenerator({
-    sourceRoot: 'foo/bar',
-    file: 'baz.js'
+    sourceRoot: "foo/bar",
+    file: "baz.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: 'bang.coffee'
+    source: "bang.coffee"
   });
   map.addMapping({
     original: { line: 5, column: 5 },
     generated: { line: 6, column: 6 },
-    source: 'bang.coffee'
+    source: "bang.coffee"
   });
 
 
-  map = await new SourceMapConsumer(map.toString(), 'http://example.com/');
+  map = await new SourceMapConsumer(map.toString(), "http://example.com/");
 
   // Should handle without sourceRoot.
   var pos = map.generatedPositionFor({
     line: 1,
     column: 1,
-    source: 'bang.coffee'
+    source: "bang.coffee"
   });
 
   assert.equal(pos.line, 2);
   assert.equal(pos.column, 2);
 
   // Should handle with sourceRoot.
-  var pos = map.generatedPositionFor({
+  pos = map.generatedPositionFor({
     line: 1,
     column: 1,
-    source: 'foo/bar/bang.coffee'
+    source: "foo/bar/bang.coffee"
   });
 
   assert.equal(pos.line, 2);
   assert.equal(pos.column, 2);
 
   // Should handle absolute case.
-  var pos = map.generatedPositionFor({
+  pos = map.generatedPositionFor({
     line: 1,
     column: 1,
-    source: 'http://example.com/foo/bar/bang.coffee'
+    source: "http://example.com/foo/bar/bang.coffee"
   });
 
   assert.equal(pos.line, 2);
@@ -587,15 +581,15 @@ exports['test sourceRoot + generatedPositionFor'] = async function (assert) {
   map.destroy();
 };
 
-exports['test sourceRoot + generatedPositionFor for path above the root'] = async function (assert) {
+exports["test sourceRoot + generatedPositionFor for path above the root"] = async function(assert) {
   var map = new SourceMapGenerator({
-    sourceRoot: 'foo/bar',
-    file: 'baz.js'
+    sourceRoot: "foo/bar",
+    file: "baz.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: '../bang.coffee'
+    source: "../bang.coffee"
   });
 
   map = await new SourceMapConsumer(map.toString());
@@ -604,7 +598,7 @@ exports['test sourceRoot + generatedPositionFor for path above the root'] = asyn
   var pos = map.generatedPositionFor({
     line: 1,
     column: 1,
-    source: 'foo/bang.coffee'
+    source: "foo/bang.coffee"
   });
 
   assert.equal(pos.line, 2);
@@ -613,41 +607,41 @@ exports['test sourceRoot + generatedPositionFor for path above the root'] = asyn
   map.destroy();
 };
 
-exports['test allGeneratedPositionsFor for line'] = async function (assert) {
+exports["test allGeneratedPositionsFor for line"] = async function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated.js'
+    file: "generated.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: 'bar.coffee'
+    source: "bar.coffee"
   });
   map.addMapping({
     original: { line: 2, column: 1 },
     generated: { line: 3, column: 2 },
-    source: 'bar.coffee'
+    source: "bar.coffee"
   });
   map.addMapping({
     original: { line: 2, column: 2 },
     generated: { line: 3, column: 3 },
-    source: 'bar.coffee'
+    source: "bar.coffee"
   });
   map.addMapping({
     original: { line: 3, column: 1 },
     generated: { line: 4, column: 2 },
-    source: 'bar.coffee'
+    source: "bar.coffee"
   });
 
-  map = await new SourceMapConsumer(map.toString(), 'http://example.com/');
+  map = await new SourceMapConsumer(map.toString(), "http://example.com/");
 
   var mappings = map.allGeneratedPositionsFor({
     line: 2,
-    source: 'bar.coffee'
+    source: "bar.coffee"
   });
 
   assert.equal(mappings.length, 2);
@@ -658,7 +652,7 @@ exports['test allGeneratedPositionsFor for line'] = async function (assert) {
 
   mappings = map.allGeneratedPositionsFor({
     line: 2,
-    source: 'http://example.com/bar.coffee'
+    source: "http://example.com/bar.coffee"
   });
 
   assert.equal(mappings.length, 2);
@@ -670,31 +664,31 @@ exports['test allGeneratedPositionsFor for line'] = async function (assert) {
   map.destroy();
 };
 
-exports['test allGeneratedPositionsFor for line fuzzy'] = async function (assert) {
+exports["test allGeneratedPositionsFor for line fuzzy"] = async function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated.js'
+    file: "generated.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: 'bar.coffee'
+    source: "bar.coffee"
   });
   map.addMapping({
     original: { line: 3, column: 1 },
     generated: { line: 4, column: 2 },
-    source: 'bar.coffee'
+    source: "bar.coffee"
   });
 
   map = await new SourceMapConsumer(map.toString());
 
   var mappings = map.allGeneratedPositionsFor({
     line: 2,
-    source: 'bar.coffee'
+    source: "bar.coffee"
   });
 
   assert.equal(mappings.length, 1);
@@ -704,15 +698,15 @@ exports['test allGeneratedPositionsFor for line fuzzy'] = async function (assert
   map.destroy();
 };
 
-exports['test allGeneratedPositionsFor for empty source map'] = async function (assert) {
+exports["test allGeneratedPositionsFor for empty source map"] = async function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated.js'
+    file: "generated.js"
   });
   map = await new SourceMapConsumer(map.toString());
 
   var mappings = map.allGeneratedPositionsFor({
     line: 2,
-    source: 'bar.coffee'
+    source: "bar.coffee"
   });
 
   assert.equal(mappings.length, 0);
@@ -720,19 +714,19 @@ exports['test allGeneratedPositionsFor for empty source map'] = async function (
   map.destroy();
 };
 
-exports['test allGeneratedPositionsFor for column'] = async function (assert) {
+exports["test allGeneratedPositionsFor for column"] = async function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated.js'
+    file: "generated.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 2 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 3 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
 
   map = await new SourceMapConsumer(map.toString());
@@ -740,7 +734,7 @@ exports['test allGeneratedPositionsFor for column'] = async function (assert) {
   var mappings = map.allGeneratedPositionsFor({
     line: 1,
     column: 1,
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
 
   assert.equal(mappings.length, 2);
@@ -752,19 +746,19 @@ exports['test allGeneratedPositionsFor for column'] = async function (assert) {
   map.destroy();
 };
 
-exports['test allGeneratedPositionsFor for column fuzzy'] = async function (assert) {
+exports["test allGeneratedPositionsFor for column fuzzy"] = async function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated.js'
+    file: "generated.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 2 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 3 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
 
   map = await new SourceMapConsumer(map.toString());
@@ -772,7 +766,7 @@ exports['test allGeneratedPositionsFor for column fuzzy'] = async function (asse
   var mappings = map.allGeneratedPositionsFor({
     line: 1,
     column: 0,
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
 
   assert.equal(mappings.length, 2);
@@ -784,19 +778,19 @@ exports['test allGeneratedPositionsFor for column fuzzy'] = async function (asse
   map.destroy();
 };
 
-exports['test allGeneratedPositionsFor for column on different line fuzzy'] = async function (assert) {
+exports["test allGeneratedPositionsFor for column on different line fuzzy"] = async function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated.js'
+    file: "generated.js"
   });
   map.addMapping({
     original: { line: 2, column: 1 },
     generated: { line: 2, column: 2 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
   map.addMapping({
     original: { line: 2, column: 1 },
     generated: { line: 2, column: 3 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
 
   map = await new SourceMapConsumer(map.toString());
@@ -804,7 +798,7 @@ exports['test allGeneratedPositionsFor for column on different line fuzzy'] = as
   var mappings = map.allGeneratedPositionsFor({
     line: 1,
     column: 0,
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
 
   assert.equal(mappings.length, 0);
@@ -812,39 +806,39 @@ exports['test allGeneratedPositionsFor for column on different line fuzzy'] = as
   map.destroy();
 };
 
-exports['test computeColumnSpans'] = async function (assert) {
+exports["test computeColumnSpans"] = async function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated.js'
+    file: "generated.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 1 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
   map.addMapping({
     original: { line: 2, column: 1 },
     generated: { line: 2, column: 1 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
   map.addMapping({
     original: { line: 2, column: 2 },
     generated: { line: 2, column: 10 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
   map.addMapping({
     original: { line: 2, column: 3 },
     generated: { line: 2, column: 20 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
   map.addMapping({
     original: { line: 3, column: 1 },
     generated: { line: 3, column: 1 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
   map.addMapping({
     original: { line: 3, column: 2 },
     generated: { line: 3, column: 2 },
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
 
   map = await new SourceMapConsumer(map.toString());
@@ -853,15 +847,15 @@ exports['test computeColumnSpans'] = async function (assert) {
 
   var mappings = map.allGeneratedPositionsFor({
     line: 1,
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
 
   assert.equal(mappings.length, 1);
   assert.equal(mappings[0].lastColumn, Infinity);
 
-  var mappings = map.allGeneratedPositionsFor({
+  mappings = map.allGeneratedPositionsFor({
     line: 2,
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
 
   assert.equal(mappings.length, 3);
@@ -869,9 +863,9 @@ exports['test computeColumnSpans'] = async function (assert) {
   assert.equal(mappings[1].lastColumn, 19);
   assert.equal(mappings[2].lastColumn, Infinity);
 
-  var mappings = map.allGeneratedPositionsFor({
+  mappings = map.allGeneratedPositionsFor({
     line: 3,
-    source: 'foo.coffee'
+    source: "foo.coffee"
   });
 
   assert.equal(mappings.length, 2);
@@ -881,15 +875,15 @@ exports['test computeColumnSpans'] = async function (assert) {
   map.destroy();
 };
 
-exports['test sourceRoot + originalPositionFor'] = async function (assert) {
+exports["test sourceRoot + originalPositionFor"] = async function(assert) {
   var map = new SourceMapGenerator({
-    sourceRoot: 'foo/bar',
-    file: 'baz.js'
+    sourceRoot: "foo/bar",
+    file: "baz.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: 'bang.coffee'
+    source: "bang.coffee"
   });
 
   map = await new SourceMapConsumer(map.toString());
@@ -900,79 +894,79 @@ exports['test sourceRoot + originalPositionFor'] = async function (assert) {
   });
 
   // Should always have the prepended source root
-  assert.equal(pos.source, 'foo/bar/bang.coffee');
+  assert.equal(pos.source, "foo/bar/bang.coffee");
   assert.equal(pos.line, 1);
   assert.equal(pos.column, 1);
 
   map.destroy();
 };
 
-exports['test github issue #56'] = async function (assert) {
+exports["test github issue #56"] = async function(assert) {
   var map = new SourceMapGenerator({
-    sourceRoot: 'http://',
-    file: 'www.example.com/foo.js'
+    sourceRoot: "http://",
+    file: "www.example.com/foo.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: 'www.example.com/original.js'
+    source: "www.example.com/original.js"
   });
 
   map = await new SourceMapConsumer(map.toString());
 
   var sources = map.sources;
   assert.equal(sources.length, 1);
-  assert.equal(sources[0], 'http://www.example.com/original.js');
+  assert.equal(sources[0], "http://www.example.com/original.js");
 
   map.destroy();
 };
 
 // Was github issue #43, but that's no longer valid.
-exports['test source resolution with sourceMapURL'] = async function (assert) {
+exports["test source resolution with sourceMapURL"] = async function(assert) {
   var map = new SourceMapGenerator({
-    sourceRoot: '',
-    file: 'foo.js'
+    sourceRoot: "",
+    file: "foo.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: 'original.js',
+    source: "original.js",
   });
 
-  map = await new SourceMapConsumer(map.toString(), 'http://cdn.example.com');
+  map = await new SourceMapConsumer(map.toString(), "http://cdn.example.com");
 
   var sources = map.sources;
   assert.equal(sources.length, 1,
-               'Should only be one source.');
-  assert.equal(sources[0], 'http://cdn.example.com/original.js',
-               'Should be joined with the source map URL.');
+               "Should only be one source.");
+  assert.equal(sources[0], "http://cdn.example.com/original.js",
+               "Should be joined with the source map URL.");
 
   map.destroy();
 };
 
-exports['test sourceRoot prepending'] = async function (assert) {
+exports["test sourceRoot prepending"] = async function(assert) {
   var map = new SourceMapGenerator({
-    sourceRoot: 'http://example.com/foo/bar',
-    file: 'foo.js'
+    sourceRoot: "http://example.com/foo/bar",
+    file: "foo.js"
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: '/original.js'
+    source: "/original.js"
   });
 
   map = await new SourceMapConsumer(map.toString());
 
   var sources = map.sources;
   assert.equal(sources.length, 1,
-               'Should only be one source.');
-  assert.equal(sources[0], 'http://example.com/foo/bar/original.js',
-               'Source include the source root.');
+               "Should only be one source.");
+  assert.equal(sources[0], "http://example.com/foo/bar/original.js",
+               "Source include the source root.");
 
   map.destroy();
 };
 
-exports['test indexed source map errors when sections are out of order by line'] = async function(assert) {
+exports["test indexed source map errors when sections are out of order by line"] = async function(assert) {
   // Make a deep copy of the indexedTestMap
   var misorderedIndexedTestMap = JSON.parse(JSON.stringify(util.indexedTestMap));
 
@@ -990,7 +984,7 @@ exports['test indexed source map errors when sections are out of order by line']
   assert.ok(error instanceof Error);
 };
 
-exports['test github issue #64'] = async function (assert) {
+exports["test github issue #64"] = async function(assert) {
   var map = await new SourceMapConsumer({
     "version": 3,
     "file": "foo.js",
@@ -1007,25 +1001,24 @@ exports['test github issue #64'] = async function (assert) {
   map.destroy();
 };
 
-exports['test full source content with sourceMapURL'] = async function (assert) {
+exports["test full source content with sourceMapURL"] = async function(assert) {
   var map = await new SourceMapConsumer({
-    'version': 3,
-    'file': 'foo.js',
-    'sourceRoot': '',
-    'sources': ['original.js'],
-    'names': [],
-    'mappings': 'AACA',
-    'sourcesContent': ['yellow warbler']
-  }, 'http://cdn.example.com');
+    "version": 3,
+    "file": "foo.js",
+    "sourceRoot": "",
+    "sources": ["original.js"],
+    "names": [],
+    "mappings": "AACA",
+    "sourcesContent": ["yellow warbler"]
+  }, "http://cdn.example.com");
 
-  var sources = map.sources;
-  assert.equal(map.sourceContentFor('http://cdn.example.com/original.js'), 'yellow warbler',
-               'Source content should be found using full URL');
+  assert.equal(map.sourceContentFor("http://cdn.example.com/original.js"), "yellow warbler",
+               "Source content should be found using full URL");
 
   map.destroy();
 };
 
-exports['test bug 885597'] = async function (assert) {
+exports["test bug 885597"] = async function(assert) {
   var map = await new SourceMapConsumer({
     "version": 3,
     "file": "foo.js",
@@ -1042,7 +1035,7 @@ exports['test bug 885597'] = async function (assert) {
   map.destroy();
 };
 
-exports['test github issue #72, duplicate sources'] = async function (assert) {
+exports["test github issue #72, duplicate sources"] = async function(assert) {
   var map = await new SourceMapConsumer({
     "version": 3,
     "file": "foo.js",
@@ -1056,30 +1049,30 @@ exports['test github issue #72, duplicate sources'] = async function (assert) {
     line: 2,
     column: 2
   });
-  assert.equal(pos.source, 'http://example.com/source1.js');
+  assert.equal(pos.source, "http://example.com/source1.js");
   assert.equal(pos.line, 1);
   assert.equal(pos.column, 1);
 
-  var pos = map.originalPositionFor({
+  pos = map.originalPositionFor({
     line: 4,
     column: 4
   });
-  assert.equal(pos.source, 'http://example.com/source1.js');
+  assert.equal(pos.source, "http://example.com/source1.js");
   assert.equal(pos.line, 3);
   assert.equal(pos.column, 3);
 
-  var pos = map.originalPositionFor({
+  pos = map.originalPositionFor({
     line: 6,
     column: 6
   });
-  assert.equal(pos.source, 'http://example.com/source3.js');
+  assert.equal(pos.source, "http://example.com/source3.js");
   assert.equal(pos.line, 5);
   assert.equal(pos.column, 5);
 
   map.destroy();
 };
 
-exports['test github issue #72, duplicate names'] = async function (assert) {
+exports["test github issue #72, duplicate names"] = async function(assert) {
   var map = await new SourceMapConsumer({
     "version": 3,
     "file": "foo.js",
@@ -1093,54 +1086,54 @@ exports['test github issue #72, duplicate names'] = async function (assert) {
     line: 2,
     column: 2
   });
-  assert.equal(pos.name, 'name1');
+  assert.equal(pos.name, "name1");
   assert.equal(pos.line, 1);
   assert.equal(pos.column, 1);
 
-  var pos = map.originalPositionFor({
+  pos = map.originalPositionFor({
     line: 4,
     column: 4
   });
-  assert.equal(pos.name, 'name1');
+  assert.equal(pos.name, "name1");
   assert.equal(pos.line, 3);
   assert.equal(pos.column, 3);
 
-  var pos = map.originalPositionFor({
+  pos = map.originalPositionFor({
     line: 6,
     column: 6
   });
-  assert.equal(pos.name, 'name3');
+  assert.equal(pos.name, "name3");
   assert.equal(pos.line, 5);
   assert.equal(pos.column, 5);
 
   map.destroy();
 };
 
-exports['test SourceMapConsumer.fromSourceMap'] = async function (assert) {
+exports["test SourceMapConsumer.fromSourceMap"] = async function(assert) {
   var smg = new SourceMapGenerator({
-    sourceRoot: 'http://example.com/',
-    file: 'foo.js'
+    sourceRoot: "http://example.com/",
+    file: "foo.js"
   });
   smg.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: 'bar.js'
+    source: "bar.js"
   });
   smg.addMapping({
     original: { line: 2, column: 2 },
     generated: { line: 4, column: 4 },
-    source: 'baz.js',
-    name: 'dirtMcGirt'
+    source: "baz.js",
+    name: "dirtMcGirt"
   });
-  smg.setSourceContent('baz.js', 'baz.js content');
+  smg.setSourceContent("baz.js", "baz.js content");
 
   var smc = await SourceMapConsumer.fromSourceMap(smg);
-  assert.equal(smc.file, 'foo.js');
-  assert.equal(smc.sourceRoot, 'http://example.com/');
+  assert.equal(smc.file, "foo.js");
+  assert.equal(smc.sourceRoot, "http://example.com/");
   assert.equal(smc.sources.length, 2);
-  assert.equal(smc.sources[0], 'http://example.com/bar.js');
-  assert.equal(smc.sources[1], 'http://example.com/baz.js');
-  assert.equal(smc.sourceContentFor('baz.js'), 'baz.js content');
+  assert.equal(smc.sources[0], "http://example.com/bar.js");
+  assert.equal(smc.sources[1], "http://example.com/baz.js");
+  assert.equal(smc.sourceContentFor("baz.js"), "baz.js content");
 
   var pos = smc.originalPositionFor({
     line: 2,
@@ -1148,13 +1141,13 @@ exports['test SourceMapConsumer.fromSourceMap'] = async function (assert) {
   });
   assert.equal(pos.line, 1);
   assert.equal(pos.column, 1);
-  assert.equal(pos.source, 'http://example.com/bar.js');
+  assert.equal(pos.source, "http://example.com/bar.js");
   assert.equal(pos.name, null);
 
   pos = smc.generatedPositionFor({
     line: 1,
     column: 1,
-    source: 'http://example.com/bar.js'
+    source: "http://example.com/bar.js"
   });
   assert.equal(pos.line, 2);
   assert.equal(pos.column, 2);
@@ -1165,13 +1158,13 @@ exports['test SourceMapConsumer.fromSourceMap'] = async function (assert) {
   });
   assert.equal(pos.line, 2);
   assert.equal(pos.column, 2);
-  assert.equal(pos.source, 'http://example.com/baz.js');
-  assert.equal(pos.name, 'dirtMcGirt');
+  assert.equal(pos.source, "http://example.com/baz.js");
+  assert.equal(pos.name, "dirtMcGirt");
 
   pos = smc.generatedPositionFor({
     line: 2,
     column: 2,
-    source: 'http://example.com/baz.js'
+    source: "http://example.com/baz.js"
   });
   assert.equal(pos.line, 4);
   assert.equal(pos.column, 4);
@@ -1179,10 +1172,10 @@ exports['test SourceMapConsumer.fromSourceMap'] = async function (assert) {
   smc.destroy();
 };
 
-exports['test issue #191'] = async function (assert) {
-  var generator = new SourceMapGenerator({ file: 'a.css' });
+exports["test issue #191"] = async function(assert) {
+  var generator = new SourceMapGenerator({ file: "a.css" });
   generator.addMapping({
-    source:   'b.css',
+    source:   "b.css",
     original: {
       line:   1,
       column: 0
@@ -1205,7 +1198,7 @@ exports['test issue #191'] = async function (assert) {
   consumer.destroy();
 };
 
-exports['test sources where their prefix is the source root: issue #199'] = async function (assert) {
+exports["test sources where their prefix is the source root: issue #199"] = async function(assert) {
   var testSourceMap = {
     "version": 3,
     "sources": ["/source/app/app/app.js"],
@@ -1213,7 +1206,7 @@ exports['test sources where their prefix is the source root: issue #199'] = asyn
     "mappings": "AAAAA",
     "file": "app/app.js",
     "sourcesContent": ["'use strict';"],
-    "sourceRoot":"/source/"
+    "sourceRoot": "/source/"
   };
 
   var consumer = await new SourceMapConsumer(testSourceMap);
@@ -1228,14 +1221,14 @@ exports['test sources where their prefix is the source root: issue #199'] = asyn
   consumer.destroy();
 };
 
-exports['test sources where their prefix is the source root and the source root is a url: issue #199'] = async function (assert) {
+exports["test sources where their prefix is the source root and the source root is a url: issue #199"] = async function(assert) {
   var testSourceMap = {
     "version": 3,
     "sources": ["http://example.com/source/app/app/app.js"],
     "names": ["System"],
     "mappings": "AAAAA",
     "sourcesContent": ["'use strict';"],
-    "sourceRoot":"http://example.com/source/"
+    "sourceRoot": "http://example.com/source/"
   };
 
   var consumer = await new SourceMapConsumer(testSourceMap);
@@ -1250,7 +1243,7 @@ exports['test sources where their prefix is the source root and the source root 
   consumer.destroy();
 };
 
-exports['test consuming names and sources that are numbers'] = async function (assert) {
+exports["test consuming names and sources that are numbers"] = async function(assert) {
   var testSourceMap = {
     "version": 3,
     "sources": [0],
@@ -1264,7 +1257,7 @@ exports['test consuming names and sources that are numbers'] = async function (a
   assert.equal(consumer.sources[0], "0");
 
   var i = 0;
-  consumer.eachMapping(function (m) {
+  consumer.eachMapping(function(m) {
     i++;
     assert.equal(m.name, "1");
   });
@@ -1273,24 +1266,24 @@ exports['test consuming names and sources that are numbers'] = async function (a
   consumer.destroy();
 };
 
-exports['test non-normalized sourceRoot (from issue #227)'] = async function (assert) {
+exports["test non-normalized sourceRoot (from issue #227)"] = async function(assert) {
   var consumer = await new SourceMapConsumer({
     version: 3,
-    sources: [ 'index.js' ],
+    sources: [ "index.js" ],
     names: [],
-    mappings: ';;AAAA,IAAI,OAAO,MAAP',
-    file: 'index.js',
-    sourceRoot: './src/',
+    mappings: ";;AAAA,IAAI,OAAO,MAAP",
+    file: "index.js",
+    sourceRoot: "./src/",
     sourcesContent: [ 'var name = "Mark"\n' ]
   });
-  assert.equal(consumer.sourceRoot, 'src/', 'sourceRoot was normalized');
+  assert.equal(consumer.sourceRoot, "src/", "sourceRoot was normalized");
   // Before the fix, this threw an exception.
   consumer.sourceContentFor(consumer.sources[0]);
 
   consumer.destroy();
 };
 
-exports['test webpack URL resolution'] = async function (assert) {
+exports["test webpack URL resolution"] = async function(assert) {
   var map = {
     version: 3,
     sources:  ["webpack:///webpack/bootstrap 67e184f9679733298d44"],
@@ -1307,7 +1300,7 @@ exports['test webpack URL resolution'] = async function (assert) {
   consumer.destroy();
 };
 
-exports['test webpack URL resolution with sourceMapURL'] = async function (assert) {
+exports["test webpack URL resolution with sourceMapURL"] = async function(assert) {
   var map = {
     version: 3,
     sources:  ["webpack:///webpack/bootstrap 67e184f9679733298d44"],
@@ -1316,7 +1309,7 @@ exports['test webpack URL resolution with sourceMapURL'] = async function (asser
     file: "static/js/manifest.b7cf97680f7a50fa150f.js",
     sourceRoot: ""
   };
-  var consumer = await new SourceMapConsumer(map, 'http://www.example.com/q.js.map');
+  var consumer = await new SourceMapConsumer(map, "http://www.example.com/q.js.map");
 
   assert.equal(consumer.sources.length, 1);
   assert.equal(consumer.sources[0], "webpack:///webpack/bootstrap 67e184f9679733298d44");
@@ -1324,7 +1317,7 @@ exports['test webpack URL resolution with sourceMapURL'] = async function (asser
   consumer.destroy();
 };
 
-exports['test relative webpack URL resolution with sourceMapURL'] = async function (assert) {
+exports["test relative webpack URL resolution with sourceMapURL"] = async function(assert) {
   var map = {
     version: 3,
     sources:  ["webpack/bootstrap.js"],
@@ -1333,7 +1326,7 @@ exports['test relative webpack URL resolution with sourceMapURL'] = async functi
     file: "static/js/manifest.b7cf97680f7a50fa150f.js",
     sourceRoot: "webpack:///"
   };
-  var consumer = await new SourceMapConsumer(map, 'http://www.example.com/q.js.map');
+  var consumer = await new SourceMapConsumer(map, "http://www.example.com/q.js.map");
 
   assert.equal(consumer.sources.length, 1);
   assert.equal(consumer.sources[0], "webpack:///webpack/bootstrap.js");
@@ -1341,7 +1334,7 @@ exports['test relative webpack URL resolution with sourceMapURL'] = async functi
   consumer.destroy();
 };
 
-exports['test basic URL resolution with sourceMapURL'] = async function (assert) {
+exports["test basic URL resolution with sourceMapURL"] = async function(assert) {
   var map = {
     version: 3,
     sources:  ["something.js"],
@@ -1350,15 +1343,15 @@ exports['test basic URL resolution with sourceMapURL'] = async function (assert)
     file: "static/js/manifest.b7cf97680f7a50fa150f.js",
     sourceRoot: "src"
   };
-  var consumer = await new SourceMapConsumer(map, 'http://www.example.com/x/q.js.map');
+  var consumer = await new SourceMapConsumer(map, "http://www.example.com/x/q.js.map");
 
   assert.equal(consumer.sources.length, 1);
-  assert.equal(consumer.sources[0], 'http://www.example.com/x/src/something.js');
+  assert.equal(consumer.sources[0], "http://www.example.com/x/src/something.js");
 
   consumer.destroy();
 };
 
-exports['test absolute sourceURL resolution with sourceMapURL'] = async function (assert) {
+exports["test absolute sourceURL resolution with sourceMapURL"] = async function(assert) {
   var map = {
     version: 3,
     sources:  ["something.js"],
@@ -1367,15 +1360,15 @@ exports['test absolute sourceURL resolution with sourceMapURL'] = async function
     file: "static/js/manifest.b7cf97680f7a50fa150f.js",
     sourceRoot: "http://www.example.com/src"
   };
-  var consumer = await new SourceMapConsumer(map, 'http://www.example.com/x/q.js.map');
+  var consumer = await new SourceMapConsumer(map, "http://www.example.com/x/q.js.map");
 
   assert.equal(consumer.sources.length, 1);
-  assert.equal(consumer.sources[0], 'http://www.example.com/src/something.js');
+  assert.equal(consumer.sources[0], "http://www.example.com/src/something.js");
 
   consumer.destroy();
 };
 
-exports['test line numbers > 2**32'] = async function (assert) {
+exports["test line numbers > 2**32"] = async function(assert) {
   let map = await new SourceMapConsumer({
     version: 3,
     sources:  ["something.js"],
@@ -1396,7 +1389,7 @@ exports['test line numbers > 2**32'] = async function (assert) {
   map.destroy();
 };
 
-exports['test line numbers < 0'] = async function (assert) {
+exports["test line numbers < 0"] = async function(assert) {
   let map = await new SourceMapConsumer({
     version: 3,
     sources:  ["something.js"],
@@ -1417,9 +1410,9 @@ exports['test line numbers < 0'] = async function (assert) {
   map.destroy();
 };
 
-exports['test SourceMapConsumer.with'] = async function (assert) {
+exports["test SourceMapConsumer.with"] = async function(assert) {
   let consumer = null;
-  const six = await SourceMapConsumer.with(util.testMap, null, async function (c) {
+  const six = await SourceMapConsumer.with(util.testMap, null, async function(c) {
     // Don't keep references to the consumer around at home, kids.
     consumer = c;
 
@@ -1443,12 +1436,12 @@ exports['test SourceMapConsumer.with'] = async function (assert) {
   assert.equal(consumer._mappingsPtr, 0);
 };
 
-exports['test SourceMapConsumer.with and exceptions'] = async function (assert) {
+exports["test SourceMapConsumer.with and exceptions"] = async function(assert) {
   let consumer = null;
   let error = null;
 
   try {
-    await SourceMapConsumer.with(util.testMap, null, async function (c) {
+    await SourceMapConsumer.with(util.testMap, null, async function(c) {
       consumer = c;
       assert.equal(c._mappingsPtr, 0);
 

--- a/test/test-source-map-generator.js
+++ b/test/test-source-map-generator.js
@@ -5,89 +5,89 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var SourceMapGenerator = require('../lib/source-map-generator').SourceMapGenerator;
-var SourceMapConsumer = require('../lib/source-map-consumer').SourceMapConsumer;
-var SourceNode = require('../lib/source-node').SourceNode;
-var util = require('./util');
+var SourceMapGenerator = require("../lib/source-map-generator").SourceMapGenerator;
+var SourceMapConsumer = require("../lib/source-map-consumer").SourceMapConsumer;
+var SourceNode = require("../lib/source-node").SourceNode;
+var util = require("./util");
 
-exports['test some simple stuff'] = function (assert) {
+exports["test some simple stuff"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'foo.js',
-    sourceRoot: '.'
+    file: "foo.js",
+    sourceRoot: "."
   }).toJSON();
-  assert.ok('file' in map);
-  assert.ok('sourceRoot' in map);
+  assert.ok("file" in map);
+  assert.ok("sourceRoot" in map);
 
-  var map = new SourceMapGenerator().toJSON();
-  assert.ok(!('file' in map));
-  assert.ok(!('sourceRoot' in map));
+  map = new SourceMapGenerator().toJSON();
+  assert.ok(!("file" in map));
+  assert.ok(!("sourceRoot" in map));
 };
 
-exports['test JSON serialization'] = function (assert) {
+exports["test JSON serialization"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'foo.js',
-    sourceRoot: '.'
+    file: "foo.js",
+    sourceRoot: "."
   });
   assert.equal(map.toString(), JSON.stringify(map));
 };
 
-exports['test adding mappings (case 1)'] = function (assert) {
+exports["test adding mappings (case 1)"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated-foo.js',
-    sourceRoot: '.'
+    file: "generated-foo.js",
+    sourceRoot: "."
   });
 
-  assert.doesNotThrow(function () {
+  assert.doesNotThrow(function() {
     map.addMapping({
       generated: { line: 1, column: 1 }
     });
   });
 };
 
-exports['test adding mappings (case 2)'] = function (assert) {
+exports["test adding mappings (case 2)"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated-foo.js',
-    sourceRoot: '.'
+    file: "generated-foo.js",
+    sourceRoot: "."
   });
 
-  assert.doesNotThrow(function () {
+  assert.doesNotThrow(function() {
     map.addMapping({
       generated: { line: 1, column: 1 },
-      source: 'bar.js',
+      source: "bar.js",
       original: { line: 1, column: 1 }
     });
   });
 };
 
-exports['test adding mappings (case 3)'] = function (assert) {
+exports["test adding mappings (case 3)"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated-foo.js',
-    sourceRoot: '.'
+    file: "generated-foo.js",
+    sourceRoot: "."
   });
 
-  assert.doesNotThrow(function () {
+  assert.doesNotThrow(function() {
     map.addMapping({
       generated: { line: 1, column: 1 },
-      source: 'bar.js',
+      source: "bar.js",
       original: { line: 1, column: 1 },
-      name: 'someToken'
+      name: "someToken"
     });
   });
 };
 
-exports['test adding mappings (invalid)'] = function (assert) {
+exports["test adding mappings (invalid)"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated-foo.js',
-    sourceRoot: '.'
+    file: "generated-foo.js",
+    sourceRoot: "."
   });
 
   // Not enough info.
-  assert.throws(function () {
+  assert.throws(function() {
     map.addMapping({});
   });
 
   // Original file position, but no source.
-  assert.throws(function () {
+  assert.throws(function() {
     map.addMapping({
       generated: { line: 1, column: 1 },
       original: { line: 1, column: 1 }
@@ -95,20 +95,20 @@ exports['test adding mappings (invalid)'] = function (assert) {
   });
 };
 
-exports['test adding mappings with skipValidation'] = function (assert) {
+exports["test adding mappings with skipValidation"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated-foo.js',
-    sourceRoot: '.',
+    file: "generated-foo.js",
+    sourceRoot: ".",
     skipValidation: true
   });
 
   // Not enough info, caught by `util.getArgs`
-  assert.throws(function () {
+  assert.throws(function() {
     map.addMapping({});
   });
 
   // Original file position, but no source. Not checked.
-  assert.doesNotThrow(function () {
+  assert.doesNotThrow(function() {
     map.addMapping({
       generated: { line: 1, column: 1 },
       original: { line: 1, column: 1 }
@@ -116,82 +116,82 @@ exports['test adding mappings with skipValidation'] = function (assert) {
   });
 };
 
-exports['test that the correct mappings are being generated'] = function (assert) {
+exports["test that the correct mappings are being generated"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'min.js',
-    sourceRoot: '/the/root'
+    file: "min.js",
+    sourceRoot: "/the/root"
   });
 
   map.addMapping({
     generated: { line: 1, column: 1 },
     original: { line: 1, column: 1 },
-    source: 'one.js'
+    source: "one.js"
   });
   map.addMapping({
     generated: { line: 1, column: 5 },
     original: { line: 1, column: 5 },
-    source: 'one.js'
+    source: "one.js"
   });
   map.addMapping({
     generated: { line: 1, column: 9 },
     original: { line: 1, column: 11 },
-    source: 'one.js'
+    source: "one.js"
   });
   map.addMapping({
     generated: { line: 1, column: 18 },
     original: { line: 1, column: 21 },
-    source: 'one.js',
-    name: 'bar'
+    source: "one.js",
+    name: "bar"
   });
   map.addMapping({
     generated: { line: 1, column: 21 },
     original: { line: 2, column: 3 },
-    source: 'one.js'
+    source: "one.js"
   });
   map.addMapping({
     generated: { line: 1, column: 28 },
     original: { line: 2, column: 10 },
-    source: 'one.js',
-    name: 'baz'
+    source: "one.js",
+    name: "baz"
   });
   map.addMapping({
     generated: { line: 1, column: 32 },
     original: { line: 2, column: 14 },
-    source: 'one.js',
-    name: 'bar'
+    source: "one.js",
+    name: "bar"
   });
 
   map.addMapping({
     generated: { line: 2, column: 1 },
     original: { line: 1, column: 1 },
-    source: 'two.js'
+    source: "two.js"
   });
   map.addMapping({
     generated: { line: 2, column: 5 },
     original: { line: 1, column: 5 },
-    source: 'two.js'
+    source: "two.js"
   });
   map.addMapping({
     generated: { line: 2, column: 9 },
     original: { line: 1, column: 11 },
-    source: 'two.js'
+    source: "two.js"
   });
   map.addMapping({
     generated: { line: 2, column: 18 },
     original: { line: 1, column: 21 },
-    source: 'two.js',
-    name: 'n'
+    source: "two.js",
+    name: "n"
   });
   map.addMapping({
     generated: { line: 2, column: 21 },
     original: { line: 2, column: 3 },
-    source: 'two.js'
+    source: "two.js"
   });
   map.addMapping({
     generated: { line: 2, column: 28 },
     original: { line: 2, column: 10 },
-    source: 'two.js',
-    name: 'n'
+    source: "two.js",
+    name: "n"
   });
 
   map = JSON.parse(map.toString());
@@ -199,137 +199,137 @@ exports['test that the correct mappings are being generated'] = function (assert
   util.assertEqualMaps(assert, map, util.testMap);
 };
 
-exports['test that adding a mapping with an empty string name does not break generation'] = function (assert) {
+exports["test that adding a mapping with an empty string name does not break generation"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'generated-foo.js',
-    sourceRoot: '.'
+    file: "generated-foo.js",
+    sourceRoot: "."
   });
 
   map.addMapping({
     generated: { line: 1, column: 1 },
-    source: 'bar.js',
+    source: "bar.js",
     original: { line: 1, column: 1 },
-    name: ''
+    name: ""
   });
 
-  assert.doesNotThrow(function () {
+  assert.doesNotThrow(function() {
     JSON.parse(map.toString());
   });
 };
 
-exports['test that source content can be set'] = function (assert) {
+exports["test that source content can be set"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'min.js',
-    sourceRoot: '/the/root'
+    file: "min.js",
+    sourceRoot: "/the/root"
   });
   map.addMapping({
     generated: { line: 1, column: 1 },
     original: { line: 1, column: 1 },
-    source: 'one.js'
+    source: "one.js"
   });
   map.addMapping({
     generated: { line: 2, column: 1 },
     original: { line: 1, column: 1 },
-    source: 'two.js'
+    source: "two.js"
   });
-  map.setSourceContent('one.js', 'one file content');
+  map.setSourceContent("one.js", "one file content");
 
   map = JSON.parse(map.toString());
-  assert.equal(map.sources[0], 'one.js');
-  assert.equal(map.sources[1], 'two.js');
-  assert.equal(map.sourcesContent[0], 'one file content');
+  assert.equal(map.sources[0], "one.js");
+  assert.equal(map.sources[1], "two.js");
+  assert.equal(map.sourcesContent[0], "one file content");
   assert.equal(map.sourcesContent[1], null);
 };
 
-exports['test .fromSourceMap'] = async function (assert) {
+exports["test .fromSourceMap"] = async function(assert) {
   var smc = await new SourceMapConsumer(util.testMap);
   var map = SourceMapGenerator.fromSourceMap(smc);
   smc.destroy();
   util.assertEqualMaps(assert, map.toJSON(), util.testMap);
 };
 
-exports['test .fromSourceMap with sourcesContent'] = async function (assert) {
-  var smc = await new SourceMapConsumer(util.testMapWithSourcesContent)
+exports["test .fromSourceMap with sourcesContent"] = async function(assert) {
+  var smc = await new SourceMapConsumer(util.testMapWithSourcesContent);
   var map = SourceMapGenerator.fromSourceMap(smc);
   smc.destroy();
   util.assertEqualMaps(assert, map.toJSON(), util.testMapWithSourcesContent);
 };
 
-exports['test .fromSourceMap with single source'] = async function (assert) {
+exports["test .fromSourceMap with single source"] = async function(assert) {
   var smc = await new SourceMapConsumer(util.testMapSingleSource);
   var map = SourceMapGenerator.fromSourceMap(smc);
   smc.destroy();
   util.assertEqualMaps(assert, map.toJSON(), util.testMapSingleSource);
 };
 
-exports['test .fromSourceMap with empty mappings'] = async function (assert) {
+exports["test .fromSourceMap with empty mappings"] = async function(assert) {
   var smc = await new SourceMapConsumer(util.testMapEmptyMappings);
   var map = SourceMapGenerator.fromSourceMap(smc);
   smc.destroy();
   util.assertEqualMaps(assert, map.toJSON(), util.testMapEmptyMappings);
 };
 
-exports['test .fromSourceMap with empty mappings and relative sources'] = async function (assert) {
+exports["test .fromSourceMap with empty mappings and relative sources"] = async function(assert) {
   var smc = await new SourceMapConsumer(util.testMapEmptyMappingsRelativeSources);
   var map = SourceMapGenerator.fromSourceMap(smc);
   smc.destroy();
   util.assertEqualMaps(assert, map.toJSON(), util.testMapEmptyMappingsRelativeSources_generatedExpected);
 };
 
-exports['test .fromSourceMap with multiple sources where mappings refers only to single source'] = async function (assert) {
+exports["test .fromSourceMap with multiple sources where mappings refers only to single source"] = async function(assert) {
   var smc = await new SourceMapConsumer(util.testMapMultiSourcesMappingRefersSingleSourceOnly);
   var map = SourceMapGenerator.fromSourceMap(smc);
   smc.destroy();
   util.assertEqualMaps(assert, map.toJSON(), util.testMapMultiSourcesMappingRefersSingleSourceOnly);
 };
 
-exports['test applySourceMap'] = async function (assert) {
+exports["test applySourceMap"] = async function(assert) {
   var node = new SourceNode(null, null, null, [
-    new SourceNode(2, 0, 'fileX', 'lineX2\n'),
-    'genA1\n',
-    new SourceNode(2, 0, 'fileY', 'lineY2\n'),
-    'genA2\n',
-    new SourceNode(1, 0, 'fileX', 'lineX1\n'),
-    'genA3\n',
-    new SourceNode(1, 0, 'fileY', 'lineY1\n')
+    new SourceNode(2, 0, "fileX", "lineX2\n"),
+    "genA1\n",
+    new SourceNode(2, 0, "fileY", "lineY2\n"),
+    "genA2\n",
+    new SourceNode(1, 0, "fileX", "lineX1\n"),
+    "genA3\n",
+    new SourceNode(1, 0, "fileY", "lineY1\n")
   ]);
   var mapStep1 = node.toStringWithSourceMap({
-    file: 'fileA'
+    file: "fileA"
   }).map;
-  mapStep1.setSourceContent('fileX', 'lineX1\nlineX2\n');
+  mapStep1.setSourceContent("fileX", "lineX1\nlineX2\n");
   mapStep1 = mapStep1.toJSON();
 
   node = new SourceNode(null, null, null, [
-    'gen1\n',
-    new SourceNode(1, 0, 'fileA', 'lineA1\n'),
-    new SourceNode(2, 0, 'fileA', 'lineA2\n'),
-    new SourceNode(3, 0, 'fileA', 'lineA3\n'),
-    new SourceNode(4, 0, 'fileA', 'lineA4\n'),
-    new SourceNode(1, 0, 'fileB', 'lineB1\n'),
-    new SourceNode(2, 0, 'fileB', 'lineB2\n'),
-    'gen2\n'
+    "gen1\n",
+    new SourceNode(1, 0, "fileA", "lineA1\n"),
+    new SourceNode(2, 0, "fileA", "lineA2\n"),
+    new SourceNode(3, 0, "fileA", "lineA3\n"),
+    new SourceNode(4, 0, "fileA", "lineA4\n"),
+    new SourceNode(1, 0, "fileB", "lineB1\n"),
+    new SourceNode(2, 0, "fileB", "lineB2\n"),
+    "gen2\n"
   ]);
   var mapStep2 = node.toStringWithSourceMap({
-    file: 'fileGen'
+    file: "fileGen"
   }).map;
-  mapStep2.setSourceContent('fileB', 'lineB1\nlineB2\n');
+  mapStep2.setSourceContent("fileB", "lineB1\nlineB2\n");
   mapStep2 = mapStep2.toJSON();
 
   node = new SourceNode(null, null, null, [
-    'gen1\n',
-    new SourceNode(2, 0, 'fileX', 'lineA1\n'),
-    new SourceNode(2, 0, 'fileA', 'lineA2\n'),
-    new SourceNode(2, 0, 'fileY', 'lineA3\n'),
-    new SourceNode(4, 0, 'fileA', 'lineA4\n'),
-    new SourceNode(1, 0, 'fileB', 'lineB1\n'),
-    new SourceNode(2, 0, 'fileB', 'lineB2\n'),
-    'gen2\n'
+    "gen1\n",
+    new SourceNode(2, 0, "fileX", "lineA1\n"),
+    new SourceNode(2, 0, "fileA", "lineA2\n"),
+    new SourceNode(2, 0, "fileY", "lineA3\n"),
+    new SourceNode(4, 0, "fileA", "lineA4\n"),
+    new SourceNode(1, 0, "fileB", "lineB1\n"),
+    new SourceNode(2, 0, "fileB", "lineB2\n"),
+    "gen2\n"
   ]);
   var expectedMap = node.toStringWithSourceMap({
-    file: 'fileGen'
+    file: "fileGen"
   }).map;
-  expectedMap.setSourceContent('fileX', 'lineX1\nlineX2\n');
-  expectedMap.setSourceContent('fileB', 'lineB1\nlineB2\n');
+  expectedMap.setSourceContent("fileX", "lineX1\nlineX2\n");
+  expectedMap.setSourceContent("fileB", "lineB1\nlineB2\n");
   expectedMap = expectedMap.toJSON();
 
   // apply source map "mapStep1" to "mapStep2"
@@ -345,9 +345,9 @@ exports['test applySourceMap'] = async function (assert) {
   util.assertEqualMaps(assert, actualMap, expectedMap);
 };
 
-exports['test applySourceMap throws when file is missing'] = async function (assert) {
+exports["test applySourceMap throws when file is missing"] = async function(assert) {
   var map = new SourceMapGenerator({
-    file: 'test.js'
+    file: "test.js"
   });
   var map2 = new SourceMapGenerator();
 
@@ -363,7 +363,7 @@ exports['test applySourceMap throws when file is missing'] = async function (ass
   assert.ok(error instanceof Error);
 };
 
-exports['test the two additional parameters of applySourceMap'] = async function (assert) {
+exports["test the two additional parameters of applySourceMap"] = async function(assert) {
   // Assume the following directory structure:
   //
   // http://foo.org/
@@ -383,157 +383,157 @@ exports['test the two additional parameters of applySourceMap'] = async function
   //   baz.coffee
 
   var bundleMap = new SourceMapGenerator({
-    file: 'bundle.js'
+    file: "bundle.js"
   });
   bundleMap.addMapping({
     generated: { line: 3, column: 3 },
     original: { line: 2, column: 2 },
-    source: '../../coffee/foo.coffee'
+    source: "../../coffee/foo.coffee"
   });
-  bundleMap.setSourceContent('../../coffee/foo.coffee', 'foo coffee');
+  bundleMap.setSourceContent("../../coffee/foo.coffee", "foo coffee");
   bundleMap.addMapping({
     generated: { line: 13, column: 13 },
     original: { line: 12, column: 12 },
-    source: '/bar.coffee'
+    source: "/bar.coffee"
   });
-  bundleMap.setSourceContent('/bar.coffee', 'bar coffee');
+  bundleMap.setSourceContent("/bar.coffee", "bar coffee");
   bundleMap.addMapping({
     generated: { line: 23, column: 23 },
     original: { line: 22, column: 22 },
-    source: 'http://www.example.com/baz.coffee'
+    source: "http://www.example.com/baz.coffee"
   });
   bundleMap.setSourceContent(
-    'http://www.example.com/baz.coffee',
-    'baz coffee'
+    "http://www.example.com/baz.coffee",
+    "baz coffee"
   );
   bundleMap = await new SourceMapConsumer(bundleMap.toJSON());
 
   var minifiedMap = new SourceMapGenerator({
-    file: 'bundle.min.js',
-    sourceRoot: '..'
+    file: "bundle.min.js",
+    sourceRoot: ".."
   });
   minifiedMap.addMapping({
     generated: { line: 1, column: 1 },
     original: { line: 3, column: 3 },
-    source: 'temp/bundle.js'
+    source: "temp/bundle.js"
   });
   minifiedMap.addMapping({
     generated: { line: 11, column: 11 },
     original: { line: 13, column: 13 },
-    source: 'temp/bundle.js'
+    source: "temp/bundle.js"
   });
   minifiedMap.addMapping({
     generated: { line: 21, column: 21 },
     original: { line: 23, column: 23 },
-    source: 'temp/bundle.js'
+    source: "temp/bundle.js"
   });
   minifiedMap = await new SourceMapConsumer(minifiedMap.toJSON());
 
-  var expectedMap = function (sources) {
+  var expectedMap = function(sources) {
     var map = new SourceMapGenerator({
-      file: 'bundle.min.js',
-      sourceRoot: '..'
+      file: "bundle.min.js",
+      sourceRoot: ".."
     });
     map.addMapping({
       generated: { line: 1, column: 1 },
       original: { line: 2, column: 2 },
       source: sources[0]
     });
-    map.setSourceContent(sources[0], 'foo coffee');
+    map.setSourceContent(sources[0], "foo coffee");
     map.addMapping({
       generated: { line: 11, column: 11 },
       original: { line: 12, column: 12 },
       source: sources[1]
     });
-    map.setSourceContent(sources[1], 'bar coffee');
+    map.setSourceContent(sources[1], "bar coffee");
     map.addMapping({
       generated: { line: 21, column: 21 },
       original: { line: 22, column: 22 },
       source: sources[2]
     });
-    map.setSourceContent(sources[2], 'baz coffee');
+    map.setSourceContent(sources[2], "baz coffee");
     return map.toJSON();
-  }
+  };
 
-  var actualMap = function (aSourceMapPath) {
+  var actualMap = function(aSourceMapPath) {
     var map = SourceMapGenerator.fromSourceMap(minifiedMap);
     // Note that relying on `bundleMap.file` (which is simply 'bundle.js')
     // instead of supplying the second parameter wouldn't work here.
-    map.applySourceMap(bundleMap, '../temp/bundle.js', aSourceMapPath);
+    map.applySourceMap(bundleMap, "../temp/bundle.js", aSourceMapPath);
     return map.toJSON();
-  }
+  };
 
-  util.assertEqualMaps(assert, actualMap('../temp/temp_maps'), expectedMap([
-    'coffee/foo.coffee',
-    '/bar.coffee',
-    'http://www.example.com/baz.coffee'
+  util.assertEqualMaps(assert, actualMap("../temp/temp_maps"), expectedMap([
+    "coffee/foo.coffee",
+    "/bar.coffee",
+    "http://www.example.com/baz.coffee"
   ]));
 
-  util.assertEqualMaps(assert, actualMap('/app/temp/temp_maps'), expectedMap([
-    '/app/coffee/foo.coffee',
-    '/bar.coffee',
-    'http://www.example.com/baz.coffee'
+  util.assertEqualMaps(assert, actualMap("/app/temp/temp_maps"), expectedMap([
+    "/app/coffee/foo.coffee",
+    "/bar.coffee",
+    "http://www.example.com/baz.coffee"
   ]));
 
-  util.assertEqualMaps(assert, actualMap('http://foo.org/app/temp/temp_maps'), expectedMap([
-    'http://foo.org/app/coffee/foo.coffee',
-    'http://foo.org/bar.coffee',
-    'http://www.example.com/baz.coffee'
+  util.assertEqualMaps(assert, actualMap("http://foo.org/app/temp/temp_maps"), expectedMap([
+    "http://foo.org/app/coffee/foo.coffee",
+    "http://foo.org/bar.coffee",
+    "http://www.example.com/baz.coffee"
   ]));
 
   // If the third parameter is omitted or set to the current working
   // directory we get incorrect source paths:
 
   util.assertEqualMaps(assert, actualMap(), expectedMap([
-    '../coffee/foo.coffee',
-    '/bar.coffee',
-    'http://www.example.com/baz.coffee'
+    "../coffee/foo.coffee",
+    "/bar.coffee",
+    "http://www.example.com/baz.coffee"
   ]));
 
-  util.assertEqualMaps(assert, actualMap(''), expectedMap([
-    '../coffee/foo.coffee',
-    '/bar.coffee',
-    'http://www.example.com/baz.coffee'
+  util.assertEqualMaps(assert, actualMap(""), expectedMap([
+    "../coffee/foo.coffee",
+    "/bar.coffee",
+    "http://www.example.com/baz.coffee"
   ]));
 
-  util.assertEqualMaps(assert, actualMap('.'), expectedMap([
-    '../coffee/foo.coffee',
-    '/bar.coffee',
-    'http://www.example.com/baz.coffee'
+  util.assertEqualMaps(assert, actualMap("."), expectedMap([
+    "../coffee/foo.coffee",
+    "/bar.coffee",
+    "http://www.example.com/baz.coffee"
   ]));
 
-  util.assertEqualMaps(assert, actualMap('./'), expectedMap([
-    '../coffee/foo.coffee',
-    '/bar.coffee',
-    'http://www.example.com/baz.coffee'
+  util.assertEqualMaps(assert, actualMap("./"), expectedMap([
+    "../coffee/foo.coffee",
+    "/bar.coffee",
+    "http://www.example.com/baz.coffee"
   ]));
 
   bundleMap.destroy();
   minifiedMap.destroy();
 };
 
-exports['test applySourceMap name handling'] = async function (assert) {
+exports["test applySourceMap name handling"] = async function(assert) {
   // Imagine some CoffeeScript code being compiled into JavaScript and then
   // minified.
 
   var assertName = async function(coffeeName, jsName, expectedName) {
     var minifiedMap = new SourceMapGenerator({
-      file: 'test.js.min'
+      file: "test.js.min"
     });
     minifiedMap.addMapping({
       generated: { line: 1, column: 4 },
       original: { line: 1, column: 4 },
-      source: 'test.js',
+      source: "test.js",
       name: jsName
     });
 
     var coffeeMap = new SourceMapGenerator({
-      file: 'test.js'
+      file: "test.js"
     });
     coffeeMap.addMapping({
       generated: { line: 1, column: 4 },
       original: { line: 1, column: 0 },
-      source: 'test.coffee',
+      source: "test.coffee",
       name: coffeeName
     });
 
@@ -553,33 +553,33 @@ exports['test applySourceMap name handling'] = async function (assert) {
   // provide names in its source maps. Minifiers do rename variables and
   // therefore do provide names in their source maps. So that name should be
   // retained if the original map lacks names.
-  await assertName(null, 'foo', 'foo');
+  await assertName(null, "foo", "foo");
 
   // `foo = 1` -> `var coffee$foo = 1;` -> `var a=1`
   // Imagine that CoffeeScript prefixed all variables with `coffee$`. Even
   // though the minifier then also provides a name, the original name is
   // what corresponds to the source.
-  await assertName('foo', 'coffee$foo', 'foo');
+  await assertName("foo", "coffee$foo", "foo");
 
   // `foo = 1` -> `var coffee$foo = 1;` -> `var coffee$foo=1`
   // Minifiers can turn off variable mangling. Then there’s no need to
   // provide names in the source map, but the names from the original map are
   // still needed.
-  await assertName('foo', null, 'foo');
+  await assertName("foo", null, "foo");
 
   // `foo = 1` -> `var foo = 1;` -> `var foo=1`
   // No renaming at all.
   await assertName(null, null, null);
 };
 
-exports['test sorting with duplicate generated mappings'] = function (assert) {
+exports["test sorting with duplicate generated mappings"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'test.js'
+    file: "test.js"
   });
   map.addMapping({
     generated: { line: 3, column: 0 },
     original: { line: 2, column: 0 },
-    source: 'a.js'
+    source: "a.js"
   });
   map.addMapping({
     generated: { line: 2, column: 0 }
@@ -590,20 +590,20 @@ exports['test sorting with duplicate generated mappings'] = function (assert) {
   map.addMapping({
     generated: { line: 1, column: 0 },
     original: { line: 1, column: 0 },
-    source: 'a.js'
+    source: "a.js"
   });
 
   util.assertEqualMaps(assert, map.toJSON(), {
     version: 3,
-    file: 'test.js',
-    sources: ['a.js'],
+    file: "test.js",
+    sources: ["a.js"],
     names: [],
-    mappings: 'AAAA;A;AACA'
+    mappings: "AAAA;A;AACA"
   });
 };
 
-exports['test ignore duplicate mappings.'] = function (assert) {
-  var init = { file: 'min.js', sourceRoot: '/the/root' };
+exports["test ignore duplicate mappings."] = function(assert) {
+  var init = { file: "min.js", sourceRoot: "/the/root" };
   var map1, map2;
 
   // null original source location
@@ -635,12 +635,12 @@ exports['test ignore duplicate mappings.'] = function (assert) {
   var srcMapping1 = {
     generated: { line: 1, column: 0 },
     original: { line: 11, column: 0 },
-    source: 'srcMapping1.js'
+    source: "srcMapping1.js"
   };
   var srcMapping2 = {
     generated: { line: 2, column: 2 },
     original: { line: 11, column: 0 },
-    source: 'srcMapping2.js'
+    source: "srcMapping2.js"
   };
 
   map1 = new SourceMapGenerator(init);
@@ -664,14 +664,14 @@ exports['test ignore duplicate mappings.'] = function (assert) {
   var fullMapping1 = {
     generated: { line: 1, column: 0 },
     original: { line: 11, column: 0 },
-    source: 'fullMapping1.js',
-    name: 'fullMapping1'
+    source: "fullMapping1.js",
+    name: "fullMapping1"
   };
   var fullMapping2 = {
     generated: { line: 2, column: 2 },
     original: { line: 11, column: 0 },
-    source: 'fullMapping2.js',
-    name: 'fullMapping2'
+    source: "fullMapping2.js",
+    name: "fullMapping2"
   };
 
   map1 = new SourceMapGenerator(init);
@@ -692,74 +692,74 @@ exports['test ignore duplicate mappings.'] = function (assert) {
   util.assertEqualMaps(assert, map1.toJSON(), map2.toJSON());
 };
 
-exports['test github issue #72, check for duplicate names or sources'] = function (assert) {
+exports["test github issue #72, check for duplicate names or sources"] = function(assert) {
   var map = new SourceMapGenerator({
-    file: 'test.js'
+    file: "test.js"
   });
   map.addMapping({
     generated: { line: 1, column: 1 },
     original: { line: 2, column: 2 },
-    source: 'a.js',
-    name: 'foo'
+    source: "a.js",
+    name: "foo"
   });
   map.addMapping({
     generated: { line: 3, column: 3 },
     original: { line: 4, column: 4 },
-    source: 'a.js',
-    name: 'foo'
+    source: "a.js",
+    name: "foo"
   });
   util.assertEqualMaps(assert, map.toJSON(), {
     version: 3,
-    file: 'test.js',
-    sources: ['a.js'],
-    names: ['foo'],
-    mappings: 'CACEA;;GAEEA'
+    file: "test.js",
+    sources: ["a.js"],
+    names: ["foo"],
+    mappings: "CACEA;;GAEEA"
   });
 };
 
-exports['test setting sourcesContent to null when already null'] = function (assert) {
+exports["test setting sourcesContent to null when already null"] = function(assert) {
   var smg = new SourceMapGenerator({ file: "foo.js" });
   assert.doesNotThrow(function() {
     smg.setSourceContent("bar.js", null);
   });
 };
 
-exports['test applySourceMap with unexact match'] = async function (assert) {
+exports["test applySourceMap with unexact match"] = async function(assert) {
   var map1 = new SourceMapGenerator({
-    file: 'bundled-source'
+    file: "bundled-source"
   });
   map1.addMapping({
     generated: { line: 1, column: 4 },
     original: { line: 1, column: 4 },
-    source: 'transformed-source'
+    source: "transformed-source"
   });
   map1.addMapping({
     generated: { line: 2, column: 4 },
     original: { line: 2, column: 4 },
-    source: 'transformed-source'
+    source: "transformed-source"
   });
 
   var map2 = new SourceMapGenerator({
-    file: 'transformed-source'
+    file: "transformed-source"
   });
   map2.addMapping({
     generated: { line: 2, column: 0 },
     original: { line: 1, column: 0 },
-    source: 'original-source'
+    source: "original-source"
   });
 
   var expectedMap = new SourceMapGenerator({
-    file: 'bundled-source'
+    file: "bundled-source"
   });
   expectedMap.addMapping({
     generated: { line: 1, column: 4 },
     original: { line: 1, column: 4 },
-    source: 'transformed-source'
+    source: "transformed-source"
   });
   expectedMap.addMapping({
     generated: { line: 2, column: 4 },
     original: { line: 1, column: 0 },
-    source: 'original-source'
+    source: "original-source"
   });
 
   const consumer = await new SourceMapConsumer(map2.toJSON());
@@ -769,7 +769,7 @@ exports['test applySourceMap with unexact match'] = async function (assert) {
   util.assertEqualMaps(assert, map1.toJSON(), expectedMap.toJSON());
 };
 
-exports['test applySourceMap with empty mappings'] = async function (assert) {
+exports["test applySourceMap with empty mappings"] = async function(assert) {
   let consumer = await new SourceMapConsumer(util.testMapEmptyMappings);
   var generator =  SourceMapGenerator.fromSourceMap(consumer);
   consumer.destroy();
@@ -781,7 +781,7 @@ exports['test applySourceMap with empty mappings'] = async function (assert) {
   util.assertEqualMaps(assert, generator.toJSON(), util.testMapEmptyMappings);
 };
 
-exports['test applySourceMap with empty mappings and relative sources'] = async function (assert) {
+exports["test applySourceMap with empty mappings and relative sources"] = async function(assert) {
   let consumer = await new SourceMapConsumer(util.testMapEmptyMappingsRelativeSources);
   var generator =  SourceMapGenerator.fromSourceMap(consumer);
   consumer.destroy();
@@ -793,15 +793,15 @@ exports['test applySourceMap with empty mappings and relative sources'] = async 
   util.assertEqualMaps(assert, generator.toJSON(), util.testMapEmptyMappingsRelativeSources_generatedExpected);
 };
 
-exports['test issue #192'] = async function (assert) {
+exports["test issue #192"] = async function(assert) {
   var generator = new SourceMapGenerator();
   generator.addMapping({
-    source: 'a.js',
+    source: "a.js",
     generated: { line: 1, column: 10 },
     original: { line: 1, column: 10 },
   });
   generator.addMapping({
-    source: 'b.js',
+    source: "b.js",
     generated: { line: 1, column: 10 },
     original: { line: 2, column: 20 },
   });
@@ -809,7 +809,7 @@ exports['test issue #192'] = async function (assert) {
   var consumer = await new SourceMapConsumer(generator.toJSON());
 
   var n = 0;
-  consumer.eachMapping(function () { n++ });
+  consumer.eachMapping(function() { n++; });
 
   assert.equal(n, 2,
                "Should not de-duplicate mappings that have the same " +
@@ -818,10 +818,10 @@ exports['test issue #192'] = async function (assert) {
   consumer.destroy();
 };
 
-exports['test numeric names #231'] = function (assert) {
+exports["test numeric names #231"] = function(assert) {
   var generator = new SourceMapGenerator();
   generator.addMapping({
-    source: 'a.js',
+    source: "a.js",
     generated: { line: 1, column: 10 },
     original: { line: 1, column: 10 },
     name: 8

--- a/test/test-source-node.js
+++ b/test/test-source-node.js
@@ -6,108 +6,108 @@
  */
 
 var util = require("./util");
-var SourceMapGenerator = require('../lib/source-map-generator').SourceMapGenerator;
-var SourceMapConsumer = require('../lib/source-map-consumer').SourceMapConsumer;
-var SourceNode = require('../lib/source-node').SourceNode;
+var SourceMapGenerator = require("../lib/source-map-generator").SourceMapGenerator;
+var SourceMapConsumer = require("../lib/source-map-consumer").SourceMapConsumer;
+var SourceNode = require("../lib/source-node").SourceNode;
 
 function forEachNewline(fn) {
-  return async function (assert) {
-    await fn(assert, '\n');
-    await fn(assert, '\r\n');
+  return async function(assert) {
+    await fn(assert, "\n");
+    await fn(assert, "\r\n");
   };
 }
 
-exports['test .add()'] = function (assert) {
+exports["test .add()"] = function(assert) {
   var node = new SourceNode(null, null, null);
 
   // Adding a string works.
-  node.add('function noop() {}');
+  node.add("function noop() {}");
 
   // Adding another source node works.
   node.add(new SourceNode(null, null, null));
 
   // Adding an array works.
-  node.add(['function foo() {',
+  node.add(["function foo() {",
             new SourceNode(null, null, null,
-                           'return 10;'),
-            '}']);
+                           "return 10;"),
+            "}"]);
 
   // Adding other stuff doesn't.
-  assert.throws(function () {
+  assert.throws(function() {
     node.add({});
   });
-  assert.throws(function () {
-    node.add(function () {});
+  assert.throws(function() {
+    node.add(function() {});
   });
 };
 
-exports['test .prepend()'] = function (assert) {
+exports["test .prepend()"] = function(assert) {
   var node = new SourceNode(null, null, null);
 
   // Prepending a string works.
-  node.prepend('function noop() {}');
-  assert.equal(node.children[0], 'function noop() {}');
+  node.prepend("function noop() {}");
+  assert.equal(node.children[0], "function noop() {}");
   assert.equal(node.children.length, 1);
 
   // Prepending another source node works.
   node.prepend(new SourceNode(null, null, null));
-  assert.equal(node.children[0], '');
-  assert.equal(node.children[1], 'function noop() {}');
+  assert.equal(node.children[0], "");
+  assert.equal(node.children[1], "function noop() {}");
   assert.equal(node.children.length, 2);
 
   // Prepending an array works.
-  node.prepend(['function foo() {',
+  node.prepend(["function foo() {",
             new SourceNode(null, null, null,
-                           'return 10;'),
-            '}']);
-  assert.equal(node.children[0], 'function foo() {');
-  assert.equal(node.children[1], 'return 10;');
-  assert.equal(node.children[2], '}');
-  assert.equal(node.children[3], '');
-  assert.equal(node.children[4], 'function noop() {}');
+                           "return 10;"),
+            "}"]);
+  assert.equal(node.children[0], "function foo() {");
+  assert.equal(node.children[1], "return 10;");
+  assert.equal(node.children[2], "}");
+  assert.equal(node.children[3], "");
+  assert.equal(node.children[4], "function noop() {}");
   assert.equal(node.children.length, 5);
 
   // Prepending other stuff doesn't.
-  assert.throws(function () {
+  assert.throws(function() {
     node.prepend({});
   });
-  assert.throws(function () {
-    node.prepend(function () {});
+  assert.throws(function() {
+    node.prepend(function() {});
   });
 };
 
-exports['test .toString()'] = function (assert) {
+exports["test .toString()"] = function(assert) {
   assert.equal((new SourceNode(null, null, null,
-                               ['function foo() {',
-                                new SourceNode(null, null, null, 'return 10;'),
-                                '}'])).toString(),
-               'function foo() {return 10;}');
+                               ["function foo() {",
+                                new SourceNode(null, null, null, "return 10;"),
+                                "}"])).toString(),
+               "function foo() {return 10;}");
 };
 
-exports['test .join()'] = function (assert) {
+exports["test .join()"] = function(assert) {
   assert.equal((new SourceNode(null, null, null,
-                               ['a', 'b', 'c', 'd'])).join(', ').toString(),
-               'a, b, c, d');
+                               ["a", "b", "c", "d"])).join(", ").toString(),
+               "a, b, c, d");
 };
 
-exports['test .walk()'] = function (assert) {
+exports["test .walk()"] = function(assert) {
   var node = new SourceNode(null, null, null,
-                            ['(function () {\n',
-                             '  ', new SourceNode(1, 0, 'a.js', ['someCall()']), ';\n',
-                             '  ', new SourceNode(2, 0, 'b.js', ['if (foo) bar()']), ';\n',
-                             '}());']);
+                            ["(function () {\n",
+                             "  ", new SourceNode(1, 0, "a.js", ["someCall()"]), ";\n",
+                             "  ", new SourceNode(2, 0, "b.js", ["if (foo) bar()"]), ";\n",
+                             "}());"]);
   var expected = [
-    { str: '(function () {\n', source: null,   line: null, column: null },
-    { str: '  ',               source: null,   line: null, column: null },
-    { str: 'someCall()',       source: 'a.js', line: 1,    column: 0    },
-    { str: ';\n',              source: null,   line: null, column: null },
-    { str: '  ',               source: null,   line: null, column: null },
-    { str: 'if (foo) bar()',   source: 'b.js', line: 2,    column: 0    },
-    { str: ';\n',              source: null,   line: null, column: null },
-    { str: '}());',            source: null,   line: null, column: null },
+    { str: "(function () {\n", source: null,   line: null, column: null },
+    { str: "  ",               source: null,   line: null, column: null },
+    { str: "someCall()",       source: "a.js", line: 1,    column: 0    },
+    { str: ";\n",              source: null,   line: null, column: null },
+    { str: "  ",               source: null,   line: null, column: null },
+    { str: "if (foo) bar()",   source: "b.js", line: 2,    column: 0    },
+    { str: ";\n",              source: null,   line: null, column: null },
+    { str: "}());",            source: null,   line: null, column: null },
   ];
   var i = 0;
-  node.walk(function (chunk, loc) {
+  node.walk(function(chunk, loc) {
     assert.equal(expected[i].str, chunk);
     assert.equal(expected[i].source, loc.source);
     assert.equal(expected[i].line, loc.line);
@@ -116,49 +116,49 @@ exports['test .walk()'] = function (assert) {
   });
 };
 
-exports['test .replaceRight'] = function (assert) {
+exports["test .replaceRight"] = function(assert) {
   var node;
 
   // Not nested
-  node = new SourceNode(null, null, null, 'hello world');
-  node.replaceRight(/world/, 'universe');
-  assert.equal(node.toString(), 'hello universe');
+  node = new SourceNode(null, null, null, "hello world");
+  node.replaceRight(/world/, "universe");
+  assert.equal(node.toString(), "hello universe");
 
   // Nested
   node = new SourceNode(null, null, null,
-                        [new SourceNode(null, null, null, 'hey sexy mama, '),
-                         new SourceNode(null, null, null, 'want to kill all humans?')]);
-  node.replaceRight(/kill all humans/, 'watch Futurama');
-  assert.equal(node.toString(), 'hey sexy mama, want to watch Futurama?');
+                        [new SourceNode(null, null, null, "hey sexy mama, "),
+                         new SourceNode(null, null, null, "want to kill all humans?")]);
+  node.replaceRight(/kill all humans/, "watch Futurama");
+  assert.equal(node.toString(), "hey sexy mama, want to watch Futurama?");
 };
 
-exports['test .toStringWithSourceMap()'] = forEachNewline(async function (assert, nl) {
+exports["test .toStringWithSourceMap()"] = forEachNewline(async function(assert, nl) {
   var node = new SourceNode(null, null, null,
-                            ['(function () {' + nl,
-                             '  ',
-                               new SourceNode(1, 0, 'a.js', 'someCall', 'originalCall'),
-                               new SourceNode(1, 8, 'a.js', '()'),
-                               ';' + nl,
-                             '  ', new SourceNode(2, 0, 'b.js', ['if (foo) bar()']), ';' + nl,
-                             '}());']);
+                            ["(function () {" + nl,
+                             "  ",
+                               new SourceNode(1, 0, "a.js", "someCall", "originalCall"),
+                               new SourceNode(1, 8, "a.js", "()"),
+                               ";" + nl,
+                             "  ", new SourceNode(2, 0, "b.js", ["if (foo) bar()"]), ";" + nl,
+                             "}());"]);
   var result = node.toStringWithSourceMap({
-    file: 'foo.js'
+    file: "foo.js"
   });
 
   assert.equal(result.code, [
-    '(function () {',
-    '  someCall();',
-    '  if (foo) bar();',
-    '}());'
+    "(function () {",
+    "  someCall();",
+    "  if (foo) bar();",
+    "}());"
   ].join(nl));
 
   var map = result.map;
   var mapWithoutOptions = node.toStringWithSourceMap().map;
 
-  assert.ok(map instanceof SourceMapGenerator, 'map instanceof SourceMapGenerator');
-  assert.ok(mapWithoutOptions instanceof SourceMapGenerator, 'mapWithoutOptions instanceof SourceMapGenerator');
-  assert.ok(!('file' in mapWithoutOptions));
-  mapWithoutOptions._file = 'foo.js';
+  assert.ok(map instanceof SourceMapGenerator, "map instanceof SourceMapGenerator");
+  assert.ok(mapWithoutOptions instanceof SourceMapGenerator, "mapWithoutOptions instanceof SourceMapGenerator");
+  assert.ok(!("file" in mapWithoutOptions));
+  mapWithoutOptions._file = "foo.js";
   util.assertEqualMaps(assert, map.toJSON(), mapWithoutOptions.toJSON());
 
   map = await new SourceMapConsumer(map.toString());
@@ -177,16 +177,16 @@ exports['test .toStringWithSourceMap()'] = forEachNewline(async function (assert
     line: 2,
     column: 2
   });
-  assert.equal(actual.source, 'a.js');
+  assert.equal(actual.source, "a.js");
   assert.equal(actual.line, 1);
   assert.equal(actual.column, 0);
-  assert.equal(actual.name, 'originalCall');
+  assert.equal(actual.name, "originalCall");
 
   actual = map.originalPositionFor({
     line: 3,
     column: 2
   });
-  assert.equal(actual.source, 'b.js');
+  assert.equal(actual.source, "b.js");
   assert.equal(actual.line, 2);
   assert.equal(actual.column, 0);
 
@@ -209,7 +209,7 @@ exports['test .toStringWithSourceMap()'] = forEachNewline(async function (assert
   map.destroy();
 });
 
-exports['test .fromStringWithSourceMap()'] = forEachNewline(async function (assert, nl) {
+exports["test .fromStringWithSourceMap()"] = forEachNewline(async function(assert, nl) {
   var testCode = util.testGeneratedCode.replace(/\n/g, nl);
   let map = await new SourceMapConsumer(util.testMap);
   var node = SourceNode.fromStringWithSourceMap(
@@ -219,20 +219,20 @@ exports['test .fromStringWithSourceMap()'] = forEachNewline(async function (asse
   map.destroy();
 
   var result = node.toStringWithSourceMap({
-    file: 'min.js'
+    file: "min.js"
   });
   map = result.map;
   var code = result.code;
 
   assert.equal(code, testCode);
-  assert.ok(map instanceof SourceMapGenerator, 'map instanceof SourceMapGenerator');
+  assert.ok(map instanceof SourceMapGenerator, "map instanceof SourceMapGenerator");
   map = map.toJSON();
   assert.equal(map.version, util.testMap.version);
   assert.equal(map.file, util.testMap.file);
   assert.equal(map.mappings, util.testMap.mappings);
 });
 
-exports['test .fromStringWithSourceMap() empty map'] = forEachNewline(async function (assert, nl) {
+exports["test .fromStringWithSourceMap() empty map"] = forEachNewline(async function(assert, nl) {
   let map = await new SourceMapConsumer(util.emptyMap);
   var node = SourceNode.fromStringWithSourceMap(
     util.testGeneratedCode.replace(/\n/g, nl),
@@ -241,13 +241,13 @@ exports['test .fromStringWithSourceMap() empty map'] = forEachNewline(async func
   map.destroy();
 
   var result = node.toStringWithSourceMap({
-    file: 'min.js'
+    file: "min.js"
   });
   map = result.map;
   var code = result.code;
 
   assert.equal(code, util.testGeneratedCode.replace(/\n/g, nl));
-  assert.ok(map instanceof SourceMapGenerator, 'map instanceof SourceMapGenerator');
+  assert.ok(map instanceof SourceMapGenerator, "map instanceof SourceMapGenerator");
   map = map.toJSON();
   assert.equal(map.version, util.emptyMap.version);
   assert.equal(map.file, util.emptyMap.file);
@@ -255,7 +255,7 @@ exports['test .fromStringWithSourceMap() empty map'] = forEachNewline(async func
   assert.equal(map.mappings, util.emptyMap.mappings);
 });
 
-exports['test .fromStringWithSourceMap() complex version'] = forEachNewline(async function (assert, nl) {
+exports["test .fromStringWithSourceMap() complex version"] = forEachNewline(async function(assert, nl) {
   var input = new SourceNode(null, null, null, [
     "(function() {" + nl,
       "  var Test = {};" + nl,
@@ -264,7 +264,7 @@ exports['test .fromStringWithSourceMap() complex version'] = forEachNewline(asyn
       "}());" + nl,
       "/* Generated Source */"]);
   input = input.toStringWithSourceMap({
-    file: 'foo.js'
+    file: "foo.js"
   });
 
   let map = await new SourceMapConsumer(input.map.toString());
@@ -275,19 +275,19 @@ exports['test .fromStringWithSourceMap() complex version'] = forEachNewline(asyn
   map.destroy();
 
   var result = node.toStringWithSourceMap({
-    file: 'foo.js'
+    file: "foo.js"
   });
   map = result.map;
   var code = result.code;
 
   assert.equal(code, input.code);
-  assert.ok(map instanceof SourceMapGenerator, 'map instanceof SourceMapGenerator');
+  assert.ok(map instanceof SourceMapGenerator, "map instanceof SourceMapGenerator");
   map = map.toJSON();
   var inputMap = input.map.toJSON();
   util.assertEqualMaps(assert, map, inputMap);
 });
 
-exports['test .fromStringWithSourceMap() third argument'] = async function (assert) {
+exports["test .fromStringWithSourceMap() third argument"] = async function(assert) {
   // Assume the following directory structure:
   //
   // http://foo.org/
@@ -303,14 +303,14 @@ exports['test .fromStringWithSourceMap() third argument'] = async function (asse
   //       app.js # Made from {foo,coffeeBundle}.js
   //       app.js.map
 
-  var coffeeBundle = new SourceNode(1, 0, 'foo.coffee', 'foo(coffee);\n');
-  coffeeBundle.setSourceContent('foo.coffee', 'foo coffee');
+  var coffeeBundle = new SourceNode(1, 0, "foo.coffee", "foo(coffee);\n");
+  coffeeBundle.setSourceContent("foo.coffee", "foo coffee");
   coffeeBundle = coffeeBundle.toStringWithSourceMap({
-    file: 'foo.js',
-    sourceRoot: '..'
+    file: "foo.js",
+    sourceRoot: ".."
   });
 
-  var foo = new SourceNode(1, 0, 'foo.js', 'foo(js);');
+  var foo = new SourceNode(1, 0, "foo.js", "foo(js);");
 
   var test = async function(relativePath, expectedSources) {
     var app = new SourceNode();
@@ -325,46 +325,46 @@ exports['test .fromStringWithSourceMap() third argument'] = async function (asse
 
     app.add(foo);
     var i = 0;
-    app.walk(function (chunk, loc) {
+    app.walk(function(chunk, loc) {
       assert.equal(loc.source, expectedSources[i]);
       i++;
     });
-    app.walkSourceContents(function (sourceFile, sourceContent) {
+    app.walkSourceContents(function(sourceFile, sourceContent) {
       assert.equal(sourceFile, expectedSources[0]);
-      assert.equal(sourceContent, 'foo coffee');
-    })
+      assert.equal(sourceContent, "foo coffee");
+    });
   };
 
-  await test('../coffee/maps', [
-    '../coffee/foo.coffee',
-    'foo.js'
+  await test("../coffee/maps", [
+    "../coffee/foo.coffee",
+    "foo.js"
   ]);
 
   // If the third parameter is omitted or set to the current working
   // directory we get incorrect source paths:
 
   await test(undefined, [
-    '../foo.coffee',
-    'foo.js'
+    "../foo.coffee",
+    "foo.js"
   ]);
 
-  await test('', [
-    '../foo.coffee',
-    'foo.js'
+  await test("", [
+    "../foo.coffee",
+    "foo.js"
   ]);
 
-  await test('.', [
-    '../foo.coffee',
-    'foo.js'
+  await test(".", [
+    "../foo.coffee",
+    "foo.js"
   ]);
 
-  await test('./', [
-    '../foo.coffee',
-    'foo.js'
+  await test("./", [
+    "../foo.coffee",
+    "foo.js"
   ]);
 };
 
-exports['test .toStringWithSourceMap() merging duplicate mappings'] = forEachNewline(function (assert, nl) {
+exports["test .toStringWithSourceMap() merging duplicate mappings"] = forEachNewline(function(assert, nl) {
   var input = new SourceNode(null, null, null, [
     new SourceNode(1, 0, "a.js", "(function"),
     new SourceNode(1, 0, "a.js", "() {" + nl),
@@ -380,7 +380,7 @@ exports['test .toStringWithSourceMap() merging duplicate mappings'] = forEachNew
     "/* Generated Source */"
   ]);
   input = input.toStringWithSourceMap({
-    file: 'foo.js'
+    file: "foo.js"
   });
 
   assert.equal(input.code, [
@@ -389,43 +389,43 @@ exports['test .toStringWithSourceMap() merging duplicate mappings'] = forEachNew
     "Test.A = { value: 1234 };",
     "}());",
     "/* Generated Source */"
-  ].join(nl))
+  ].join(nl));
 
   var correctMap = new SourceMapGenerator({
-    file: 'foo.js'
+    file: "foo.js"
   });
   correctMap.addMapping({
     generated: { line: 1, column: 0 },
-    source: 'a.js',
+    source: "a.js",
     original: { line: 1, column: 0 }
   });
   // Here is no need for a empty mapping,
   // because mappings ends at eol
   correctMap.addMapping({
     generated: { line: 2, column: 2 },
-    source: 'a.js',
+    source: "a.js",
     original: { line: 1, column: 0 }
   });
   correctMap.addMapping({
     generated: { line: 2, column: 13 },
-    source: 'b.js',
+    source: "b.js",
     original: { line: 1, column: 0 }
   });
   correctMap.addMapping({
     generated: { line: 3, column: 0 },
-    source: 'b.js',
+    source: "b.js",
     original: { line: 2, column: 0 }
   });
   correctMap.addMapping({
     generated: { line: 3, column: 4 },
-    source: 'b.js',
-    name: 'A',
+    source: "b.js",
+    name: "A",
     original: { line: 2, column: 0 }
   });
   correctMap.addMapping({
     generated: { line: 3, column: 6 },
-    source: 'b.js',
-    name: 'A',
+    source: "b.js",
+    name: "A",
     original: { line: 2, column: 20 }
   });
   // This empty mapping is required,
@@ -435,8 +435,8 @@ exports['test .toStringWithSourceMap() merging duplicate mappings'] = forEachNew
   });
   correctMap.addMapping({
     generated: { line: 3, column: 22 },
-    source: 'b.js',
-    name: 'A',
+    source: "b.js",
+    name: "A",
     original: { line: 2, column: 40 }
   });
   // Here is no need for a empty mapping,
@@ -447,7 +447,7 @@ exports['test .toStringWithSourceMap() merging duplicate mappings'] = forEachNew
   util.assertEqualMaps(assert, inputMap, correctMap);
 });
 
-exports['test .toStringWithSourceMap() multi-line SourceNodes'] = forEachNewline(function (assert, nl) {
+exports["test .toStringWithSourceMap() multi-line SourceNodes"] = forEachNewline(function(assert, nl) {
   var input = new SourceNode(null, null, null, [
     new SourceNode(1, 0, "a.js", "(function() {" + nl + "var nextLine = 1;" + nl + "anotherLine();" + nl),
     new SourceNode(2, 2, "b.js", "Test.call(this, 123);" + nl),
@@ -458,7 +458,7 @@ exports['test .toStringWithSourceMap() multi-line SourceNodes'] = forEachNewline
     "/*" + nl + "Generated" + nl + "Source" + nl + "*/"
   ]);
   input = input.toStringWithSourceMap({
-    file: 'foo.js'
+    file: "foo.js"
   });
 
   assert.equal(input.code, [
@@ -480,41 +480,41 @@ exports['test .toStringWithSourceMap() multi-line SourceNodes'] = forEachNewline
   ].join(nl));
 
   var correctMap = new SourceMapGenerator({
-    file: 'foo.js'
+    file: "foo.js"
   });
   correctMap.addMapping({
     generated: { line: 1, column: 0 },
-    source: 'a.js',
+    source: "a.js",
     original: { line: 1, column: 0 }
   });
   correctMap.addMapping({
     generated: { line: 2, column: 0 },
-    source: 'a.js',
+    source: "a.js",
     original: { line: 1, column: 0 }
   });
   correctMap.addMapping({
     generated: { line: 3, column: 0 },
-    source: 'a.js',
+    source: "a.js",
     original: { line: 1, column: 0 }
   });
   correctMap.addMapping({
     generated: { line: 4, column: 0 },
-    source: 'b.js',
+    source: "b.js",
     original: { line: 2, column: 2 }
   });
   correctMap.addMapping({
     generated: { line: 5, column: 0 },
-    source: 'b.js',
+    source: "b.js",
     original: { line: 2, column: 2 }
   });
   correctMap.addMapping({
     generated: { line: 6, column: 0 },
-    source: 'b.js',
+    source: "b.js",
     original: { line: 2, column: 2 }
   });
   correctMap.addMapping({
     generated: { line: 11, column: 0 },
-    source: 'c.js',
+    source: "c.js",
     original: { line: 3, column: 4 }
   });
 
@@ -523,20 +523,20 @@ exports['test .toStringWithSourceMap() multi-line SourceNodes'] = forEachNewline
   util.assertEqualMaps(assert, inputMap, correctMap);
 });
 
-exports['test .toStringWithSourceMap() with empty string'] = function (assert) {
-  var node = new SourceNode(1, 0, 'empty.js', '');
+exports["test .toStringWithSourceMap() with empty string"] = function(assert) {
+  var node = new SourceNode(1, 0, "empty.js", "");
   var result = node.toStringWithSourceMap();
-  assert.equal(result.code, '');
+  assert.equal(result.code, "");
 };
 
-exports['test .toStringWithSourceMap() with consecutive newlines'] = forEachNewline(function (assert, nl) {
+exports["test .toStringWithSourceMap() with consecutive newlines"] = forEachNewline(function(assert, nl) {
   var input = new SourceNode(null, null, null, [
     "/***/" + nl + nl,
     new SourceNode(1, 0, "a.js", "'use strict';" + nl),
     new SourceNode(2, 0, "a.js", "a();"),
   ]);
   input = input.toStringWithSourceMap({
-    file: 'foo.js'
+    file: "foo.js"
   });
 
   assert.equal(input.code, [
@@ -547,16 +547,16 @@ exports['test .toStringWithSourceMap() with consecutive newlines'] = forEachNewl
   ].join(nl));
 
   var correctMap = new SourceMapGenerator({
-    file: 'foo.js'
+    file: "foo.js"
   });
   correctMap.addMapping({
     generated: { line: 3, column: 0 },
-    source: 'a.js',
+    source: "a.js",
     original: { line: 1, column: 0 }
   });
   correctMap.addMapping({
     generated: { line: 4, column: 0 },
-    source: 'a.js',
+    source: "a.js",
     original: { line: 2, column: 0 }
   });
 
@@ -565,60 +565,60 @@ exports['test .toStringWithSourceMap() with consecutive newlines'] = forEachNewl
   util.assertEqualMaps(assert, inputMap, correctMap);
 });
 
-exports['test setSourceContent with toStringWithSourceMap'] = async function (assert) {
-  var aNode = new SourceNode(1, 1, 'a.js', 'a');
-  aNode.setSourceContent('a.js', 'someContent');
+exports["test setSourceContent with toStringWithSourceMap"] = async function(assert) {
+  var aNode = new SourceNode(1, 1, "a.js", "a");
+  aNode.setSourceContent("a.js", "someContent");
   var node = new SourceNode(null, null, null,
-                            ['(function () {\n',
-                             '  ', aNode,
-                             '  ', new SourceNode(1, 1, 'b.js', 'b'),
-                             '}());']);
-  node.setSourceContent('b.js', 'otherContent');
+                            ["(function () {\n",
+                             "  ", aNode,
+                             "  ", new SourceNode(1, 1, "b.js", "b"),
+                             "}());"]);
+  node.setSourceContent("b.js", "otherContent");
   var map = node.toStringWithSourceMap({
-    file: 'foo.js'
+    file: "foo.js"
   }).map;
 
-  assert.ok(map instanceof SourceMapGenerator, 'map instanceof SourceMapGenerator');
+  assert.ok(map instanceof SourceMapGenerator, "map instanceof SourceMapGenerator");
   map = await new SourceMapConsumer(map.toString());
 
   assert.equal(map.sources.length, 2);
-  assert.equal(map.sources[0], 'a.js');
-  assert.equal(map.sources[1], 'b.js');
+  assert.equal(map.sources[0], "a.js");
+  assert.equal(map.sources[1], "b.js");
   assert.equal(map.sourcesContent.length, 2);
-  assert.equal(map.sourcesContent[0], 'someContent');
-  assert.equal(map.sourcesContent[1], 'otherContent');
+  assert.equal(map.sourcesContent[0], "someContent");
+  assert.equal(map.sourcesContent[1], "otherContent");
 
   map.destroy();
 };
 
-exports['test walkSourceContents'] = function (assert) {
-  var aNode = new SourceNode(1, 1, 'a.js', 'a');
-  aNode.setSourceContent('a.js', 'someContent');
+exports["test walkSourceContents"] = function(assert) {
+  var aNode = new SourceNode(1, 1, "a.js", "a");
+  aNode.setSourceContent("a.js", "someContent");
   var node = new SourceNode(null, null, null,
-                            ['(function () {\n',
-                             '  ', aNode,
-                             '  ', new SourceNode(1, 1, 'b.js', 'b'),
-                             '}());']);
-  node.setSourceContent('b.js', 'otherContent');
+                            ["(function () {\n",
+                             "  ", aNode,
+                             "  ", new SourceNode(1, 1, "b.js", "b"),
+                             "}());"]);
+  node.setSourceContent("b.js", "otherContent");
   var results = [];
-  node.walkSourceContents(function (sourceFile, sourceContent) {
+  node.walkSourceContents(function(sourceFile, sourceContent) {
     results.push([sourceFile, sourceContent]);
   });
   assert.equal(results.length, 2);
-  assert.equal(results[0][0], 'a.js');
-  assert.equal(results[0][1], 'someContent');
-  assert.equal(results[1][0], 'b.js');
-  assert.equal(results[1][1], 'otherContent');
+  assert.equal(results[0][0], "a.js");
+  assert.equal(results[0][1], "someContent");
+  assert.equal(results[1][0], "b.js");
+  assert.equal(results[1][1], "otherContent");
 };
 
-exports['test from issue 258'] = async function (assert) {
+exports["test from issue 258"] = async function(assert) {
   var node = new SourceNode();
 
   var reactCode =
       ";require(0);\n//# sourceMappingURL=/index.ios.map?platform=ios&dev=false&minify=true";
 
   var reactMap =
-      "{\"version\":3,\"file\":\"/index.ios.bundle?platform=ios&dev=false&minify=true\",\"sections\":[{\"offset\":{\"line\":0,\"column\":0},\"map\":{\"version\":3,\"sources\":[\"require-0.js\"],\"names\":[],\"mappings\":\"AAAA;\",\"file\":\"require-0.js\",\"sourcesContent\":[\";require(0);\"]}}]}";
+      '{"version":3,"file":"/index.ios.bundle?platform=ios&dev=false&minify=true","sections":[{"offset":{"line":0,"column":0},"map":{"version":3,"sources":["require-0.js"],"names":[],"mappings":"AAAA;","file":"require-0.js","sourcesContent":[";require(0);"]}}]}';
 
   let map = await new SourceMapConsumer(reactMap);
   node.add(SourceNode.fromStringWithSourceMap(
@@ -626,4 +626,4 @@ exports['test from issue 258'] = async function (assert) {
     map
   ));
   map.destroy();
-}
+};

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -5,254 +5,254 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var libUtil = require('../lib/util');
+var libUtil = require("../lib/util");
 
-exports['test urls'] = function (assert) {
-  var assertUrl = function (url) {
+exports["test urls"] = function(assert) {
+  var assertUrl = function(url) {
     assert.equal(url, libUtil.urlGenerate(libUtil.urlParse(url)));
   };
-  assertUrl('http://');
-  assertUrl('http://www.example.com');
-  assertUrl('http://user:pass@www.example.com');
-  assertUrl('http://www.example.com:80');
-  assertUrl('http://www.example.com/');
-  assertUrl('http://www.example.com/foo/bar');
-  assertUrl('http://www.example.com/foo/bar/');
-  assertUrl('http://user:pass@www.example.com:80/foo/bar/');
+  assertUrl("http://");
+  assertUrl("http://www.example.com");
+  assertUrl("http://user:pass@www.example.com");
+  assertUrl("http://www.example.com:80");
+  assertUrl("http://www.example.com/");
+  assertUrl("http://www.example.com/foo/bar");
+  assertUrl("http://www.example.com/foo/bar/");
+  assertUrl("http://user:pass@www.example.com:80/foo/bar/");
 
-  assertUrl('//');
-  assertUrl('//www.example.com');
-  assertUrl('file:///www.example.com');
+  assertUrl("//");
+  assertUrl("//www.example.com");
+  assertUrl("file:///www.example.com");
 
-  assert.equal(libUtil.urlParse(''), null);
-  assert.equal(libUtil.urlParse('.'), null);
-  assert.equal(libUtil.urlParse('..'), null);
-  assert.equal(libUtil.urlParse('a'), null);
-  assert.equal(libUtil.urlParse('a/b'), null);
-  assert.equal(libUtil.urlParse('a//b'), null);
-  assert.equal(libUtil.urlParse('/a'), null);
-  assert.equal(libUtil.urlParse('data:foo,bar'), null);
+  assert.equal(libUtil.urlParse(""), null);
+  assert.equal(libUtil.urlParse("."), null);
+  assert.equal(libUtil.urlParse(".."), null);
+  assert.equal(libUtil.urlParse("a"), null);
+  assert.equal(libUtil.urlParse("a/b"), null);
+  assert.equal(libUtil.urlParse("a//b"), null);
+  assert.equal(libUtil.urlParse("/a"), null);
+  assert.equal(libUtil.urlParse("data:foo,bar"), null);
 
-  var parsed = libUtil.urlParse('http://x-y.com/bar');
-  assert.equal(parsed.scheme, 'http');
-  assert.equal(parsed.host, 'x-y.com');
-  assert.equal(parsed.path, '/bar');
+  var parsed = libUtil.urlParse("http://x-y.com/bar");
+  assert.equal(parsed.scheme, "http");
+  assert.equal(parsed.host, "x-y.com");
+  assert.equal(parsed.path, "/bar");
 
-  var webpackURL = 'webpack:///webpack/bootstrap 67e184f9679733298d44'
+  var webpackURL = "webpack:///webpack/bootstrap 67e184f9679733298d44";
   parsed = libUtil.urlParse(webpackURL);
-  assert.equal(parsed.scheme, 'webpack');
-  assert.equal(parsed.host, '');
-  assert.equal(parsed.path, '/webpack/bootstrap 67e184f9679733298d44');
+  assert.equal(parsed.scheme, "webpack");
+  assert.equal(parsed.host, "");
+  assert.equal(parsed.path, "/webpack/bootstrap 67e184f9679733298d44");
   assert.equal(webpackURL, libUtil.urlGenerate(parsed));
 };
 
-exports['test normalize()'] = function (assert) {
-  assert.equal(libUtil.normalize('/..'), '/');
-  assert.equal(libUtil.normalize('/../'), '/');
-  assert.equal(libUtil.normalize('/../../../..'), '/');
-  assert.equal(libUtil.normalize('/../../../../a/b/c'), '/a/b/c');
-  assert.equal(libUtil.normalize('/a/b/c/../../../d/../../e'), '/e');
+exports["test normalize()"] = function(assert) {
+  assert.equal(libUtil.normalize("/.."), "/");
+  assert.equal(libUtil.normalize("/../"), "/");
+  assert.equal(libUtil.normalize("/../../../.."), "/");
+  assert.equal(libUtil.normalize("/../../../../a/b/c"), "/a/b/c");
+  assert.equal(libUtil.normalize("/a/b/c/../../../d/../../e"), "/e");
 
-  assert.equal(libUtil.normalize('..'), '..');
-  assert.equal(libUtil.normalize('../'), '../');
-  assert.equal(libUtil.normalize('../../a/'), '../../a/');
-  assert.equal(libUtil.normalize('a/..'), '.');
-  assert.equal(libUtil.normalize('a/../../..'), '../..');
+  assert.equal(libUtil.normalize(".."), "..");
+  assert.equal(libUtil.normalize("../"), "../");
+  assert.equal(libUtil.normalize("../../a/"), "../../a/");
+  assert.equal(libUtil.normalize("a/.."), ".");
+  assert.equal(libUtil.normalize("a/../../.."), "../..");
 
-  assert.equal(libUtil.normalize('/.'), '/');
-  assert.equal(libUtil.normalize('/./'), '/');
-  assert.equal(libUtil.normalize('/./././.'), '/');
-  assert.equal(libUtil.normalize('/././././a/b/c'), '/a/b/c');
-  assert.equal(libUtil.normalize('/a/b/c/./././d/././e'), '/a/b/c/d/e');
+  assert.equal(libUtil.normalize("/."), "/");
+  assert.equal(libUtil.normalize("/./"), "/");
+  assert.equal(libUtil.normalize("/./././."), "/");
+  assert.equal(libUtil.normalize("/././././a/b/c"), "/a/b/c");
+  assert.equal(libUtil.normalize("/a/b/c/./././d/././e"), "/a/b/c/d/e");
 
-  assert.equal(libUtil.normalize(''), '.');
-  assert.equal(libUtil.normalize('.'), '.');
-  assert.equal(libUtil.normalize('./'), '.');
-  assert.equal(libUtil.normalize('././a'), 'a');
-  assert.equal(libUtil.normalize('a/./'), 'a/');
-  assert.equal(libUtil.normalize('a/././.'), 'a');
+  assert.equal(libUtil.normalize(""), ".");
+  assert.equal(libUtil.normalize("."), ".");
+  assert.equal(libUtil.normalize("./"), ".");
+  assert.equal(libUtil.normalize("././a"), "a");
+  assert.equal(libUtil.normalize("a/./"), "a/");
+  assert.equal(libUtil.normalize("a/././."), "a");
 
-  assert.equal(libUtil.normalize('/a/b//c////d/////'), '/a/b/c/d/');
-  assert.equal(libUtil.normalize('///a/b//c////d/////'), '///a/b/c/d/');
-  assert.equal(libUtil.normalize('a/b//c////d'), 'a/b/c/d');
+  assert.equal(libUtil.normalize("/a/b//c////d/////"), "/a/b/c/d/");
+  assert.equal(libUtil.normalize("///a/b//c////d/////"), "///a/b/c/d/");
+  assert.equal(libUtil.normalize("a/b//c////d"), "a/b/c/d");
 
-  assert.equal(libUtil.normalize('.///.././../a/b//./..'), '../../a')
+  assert.equal(libUtil.normalize(".///.././../a/b//./.."), "../../a");
 
-  assert.equal(libUtil.normalize('http://www.example.com'), 'http://www.example.com');
-  assert.equal(libUtil.normalize('http://www.example.com/'), 'http://www.example.com/');
-  assert.equal(libUtil.normalize('http://www.example.com/./..//a/b/c/.././d//'), 'http://www.example.com/a/b/d/');
+  assert.equal(libUtil.normalize("http://www.example.com"), "http://www.example.com");
+  assert.equal(libUtil.normalize("http://www.example.com/"), "http://www.example.com/");
+  assert.equal(libUtil.normalize("http://www.example.com/./..//a/b/c/.././d//"), "http://www.example.com/a/b/d/");
 };
 
-exports['test join()'] = function (assert) {
-  assert.equal(libUtil.join('a', 'b'), 'a/b');
-  assert.equal(libUtil.join('a/', 'b'), 'a/b');
-  assert.equal(libUtil.join('a//', 'b'), 'a/b');
-  assert.equal(libUtil.join('a', 'b/'), 'a/b/');
-  assert.equal(libUtil.join('a', 'b//'), 'a/b/');
-  assert.equal(libUtil.join('a/', '/b'), '/b');
-  assert.equal(libUtil.join('a//', '//b'), '//b');
+exports["test join()"] = function(assert) {
+  assert.equal(libUtil.join("a", "b"), "a/b");
+  assert.equal(libUtil.join("a/", "b"), "a/b");
+  assert.equal(libUtil.join("a//", "b"), "a/b");
+  assert.equal(libUtil.join("a", "b/"), "a/b/");
+  assert.equal(libUtil.join("a", "b//"), "a/b/");
+  assert.equal(libUtil.join("a/", "/b"), "/b");
+  assert.equal(libUtil.join("a//", "//b"), "//b");
 
-  assert.equal(libUtil.join('a', '..'), '.');
-  assert.equal(libUtil.join('a', '../b'), 'b');
-  assert.equal(libUtil.join('a/b', '../c'), 'a/c');
+  assert.equal(libUtil.join("a", ".."), ".");
+  assert.equal(libUtil.join("a", "../b"), "b");
+  assert.equal(libUtil.join("a/b", "../c"), "a/c");
 
-  assert.equal(libUtil.join('a', '.'), 'a');
-  assert.equal(libUtil.join('a', './b'), 'a/b');
-  assert.equal(libUtil.join('a/b', './c'), 'a/b/c');
+  assert.equal(libUtil.join("a", "."), "a");
+  assert.equal(libUtil.join("a", "./b"), "a/b");
+  assert.equal(libUtil.join("a/b", "./c"), "a/b/c");
 
-  assert.equal(libUtil.join('a', 'http://www.example.com'), 'http://www.example.com');
-  assert.equal(libUtil.join('a', 'data:foo,bar'), 'data:foo,bar');
-
-
-  assert.equal(libUtil.join('', 'b'), 'b');
-  assert.equal(libUtil.join('.', 'b'), 'b');
-  assert.equal(libUtil.join('', 'b/'), 'b/');
-  assert.equal(libUtil.join('.', 'b/'), 'b/');
-  assert.equal(libUtil.join('', 'b//'), 'b/');
-  assert.equal(libUtil.join('.', 'b//'), 'b/');
-
-  assert.equal(libUtil.join('', '..'), '..');
-  assert.equal(libUtil.join('.', '..'), '..');
-  assert.equal(libUtil.join('', '../b'), '../b');
-  assert.equal(libUtil.join('.', '../b'), '../b');
-
-  assert.equal(libUtil.join('', '.'), '.');
-  assert.equal(libUtil.join('.', '.'), '.');
-  assert.equal(libUtil.join('', './b'), 'b');
-  assert.equal(libUtil.join('.', './b'), 'b');
-
-  assert.equal(libUtil.join('', 'http://www.example.com'), 'http://www.example.com');
-  assert.equal(libUtil.join('.', 'http://www.example.com'), 'http://www.example.com');
-  assert.equal(libUtil.join('', 'data:foo,bar'), 'data:foo,bar');
-  assert.equal(libUtil.join('.', 'data:foo,bar'), 'data:foo,bar');
+  assert.equal(libUtil.join("a", "http://www.example.com"), "http://www.example.com");
+  assert.equal(libUtil.join("a", "data:foo,bar"), "data:foo,bar");
 
 
-  assert.equal(libUtil.join('..', 'b'), '../b');
-  assert.equal(libUtil.join('..', 'b/'), '../b/');
-  assert.equal(libUtil.join('..', 'b//'), '../b/');
+  assert.equal(libUtil.join("", "b"), "b");
+  assert.equal(libUtil.join(".", "b"), "b");
+  assert.equal(libUtil.join("", "b/"), "b/");
+  assert.equal(libUtil.join(".", "b/"), "b/");
+  assert.equal(libUtil.join("", "b//"), "b/");
+  assert.equal(libUtil.join(".", "b//"), "b/");
 
-  assert.equal(libUtil.join('..', '..'), '../..');
-  assert.equal(libUtil.join('..', '../b'), '../../b');
+  assert.equal(libUtil.join("", ".."), "..");
+  assert.equal(libUtil.join(".", ".."), "..");
+  assert.equal(libUtil.join("", "../b"), "../b");
+  assert.equal(libUtil.join(".", "../b"), "../b");
 
-  assert.equal(libUtil.join('..', '.'), '..');
-  assert.equal(libUtil.join('..', './b'), '../b');
+  assert.equal(libUtil.join("", "."), ".");
+  assert.equal(libUtil.join(".", "."), ".");
+  assert.equal(libUtil.join("", "./b"), "b");
+  assert.equal(libUtil.join(".", "./b"), "b");
 
-  assert.equal(libUtil.join('..', 'http://www.example.com'), 'http://www.example.com');
-  assert.equal(libUtil.join('..', 'data:foo,bar'), 'data:foo,bar');
-
-
-  assert.equal(libUtil.join('a', ''), 'a');
-  assert.equal(libUtil.join('a', '.'), 'a');
-  assert.equal(libUtil.join('a/', ''), 'a');
-  assert.equal(libUtil.join('a/', '.'), 'a');
-  assert.equal(libUtil.join('a//', ''), 'a');
-  assert.equal(libUtil.join('a//', '.'), 'a');
-  assert.equal(libUtil.join('/a', ''), '/a');
-  assert.equal(libUtil.join('/a', '.'), '/a');
-  assert.equal(libUtil.join('', ''), '.');
-  assert.equal(libUtil.join('.', ''), '.');
-  assert.equal(libUtil.join('.', ''), '.');
-  assert.equal(libUtil.join('.', '.'), '.');
-  assert.equal(libUtil.join('..', ''), '..');
-  assert.equal(libUtil.join('..', '.'), '..');
-  assert.equal(libUtil.join('http://foo.org/a', ''), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org/a', '.'), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org/a/', ''), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org/a/', '.'), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org/a//', ''), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org/a//', '.'), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org', ''), 'http://foo.org/');
-  assert.equal(libUtil.join('http://foo.org', '.'), 'http://foo.org/');
-  assert.equal(libUtil.join('http://foo.org/', ''), 'http://foo.org/');
-  assert.equal(libUtil.join('http://foo.org/', '.'), 'http://foo.org/');
-  assert.equal(libUtil.join('http://foo.org//', ''), 'http://foo.org/');
-  assert.equal(libUtil.join('http://foo.org//', '.'), 'http://foo.org/');
-  assert.equal(libUtil.join('//www.example.com', ''), '//www.example.com/');
-  assert.equal(libUtil.join('//www.example.com', '.'), '//www.example.com/');
+  assert.equal(libUtil.join("", "http://www.example.com"), "http://www.example.com");
+  assert.equal(libUtil.join(".", "http://www.example.com"), "http://www.example.com");
+  assert.equal(libUtil.join("", "data:foo,bar"), "data:foo,bar");
+  assert.equal(libUtil.join(".", "data:foo,bar"), "data:foo,bar");
 
 
-  assert.equal(libUtil.join('http://foo.org/a', 'b'), 'http://foo.org/a/b');
-  assert.equal(libUtil.join('http://foo.org/a/', 'b'), 'http://foo.org/a/b');
-  assert.equal(libUtil.join('http://foo.org/a//', 'b'), 'http://foo.org/a/b');
-  assert.equal(libUtil.join('http://foo.org/a', 'b/'), 'http://foo.org/a/b/');
-  assert.equal(libUtil.join('http://foo.org/a', 'b//'), 'http://foo.org/a/b/');
-  assert.equal(libUtil.join('http://foo.org/a/', '/b'), 'http://foo.org/b');
-  assert.equal(libUtil.join('http://foo.org/a//', '//b'), 'http://b');
+  assert.equal(libUtil.join("..", "b"), "../b");
+  assert.equal(libUtil.join("..", "b/"), "../b/");
+  assert.equal(libUtil.join("..", "b//"), "../b/");
 
-  assert.equal(libUtil.join('http://foo.org/a', '..'), 'http://foo.org/');
-  assert.equal(libUtil.join('http://foo.org/a', '../b'), 'http://foo.org/b');
-  assert.equal(libUtil.join('http://foo.org/a/b', '../c'), 'http://foo.org/a/c');
+  assert.equal(libUtil.join("..", ".."), "../..");
+  assert.equal(libUtil.join("..", "../b"), "../../b");
 
-  assert.equal(libUtil.join('http://foo.org/a', '.'), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org/a', './b'), 'http://foo.org/a/b');
-  assert.equal(libUtil.join('http://foo.org/a/b', './c'), 'http://foo.org/a/b/c');
+  assert.equal(libUtil.join("..", "."), "..");
+  assert.equal(libUtil.join("..", "./b"), "../b");
 
-  assert.equal(libUtil.join('http://foo.org/a', 'http://www.example.com'), 'http://www.example.com');
-  assert.equal(libUtil.join('http://foo.org/a', 'data:foo,bar'), 'data:foo,bar');
+  assert.equal(libUtil.join("..", "http://www.example.com"), "http://www.example.com");
+  assert.equal(libUtil.join("..", "data:foo,bar"), "data:foo,bar");
 
 
-  assert.equal(libUtil.join('http://foo.org', 'a'), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org/', 'a'), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org//', 'a'), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org', '/a'), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org/', '/a'), 'http://foo.org/a');
-  assert.equal(libUtil.join('http://foo.org//', '/a'), 'http://foo.org/a');
+  assert.equal(libUtil.join("a", ""), "a");
+  assert.equal(libUtil.join("a", "."), "a");
+  assert.equal(libUtil.join("a/", ""), "a");
+  assert.equal(libUtil.join("a/", "."), "a");
+  assert.equal(libUtil.join("a//", ""), "a");
+  assert.equal(libUtil.join("a//", "."), "a");
+  assert.equal(libUtil.join("/a", ""), "/a");
+  assert.equal(libUtil.join("/a", "."), "/a");
+  assert.equal(libUtil.join("", ""), ".");
+  assert.equal(libUtil.join(".", ""), ".");
+  assert.equal(libUtil.join(".", ""), ".");
+  assert.equal(libUtil.join(".", "."), ".");
+  assert.equal(libUtil.join("..", ""), "..");
+  assert.equal(libUtil.join("..", "."), "..");
+  assert.equal(libUtil.join("http://foo.org/a", ""), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org/a", "."), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org/a/", ""), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org/a/", "."), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org/a//", ""), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org/a//", "."), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org", ""), "http://foo.org/");
+  assert.equal(libUtil.join("http://foo.org", "."), "http://foo.org/");
+  assert.equal(libUtil.join("http://foo.org/", ""), "http://foo.org/");
+  assert.equal(libUtil.join("http://foo.org/", "."), "http://foo.org/");
+  assert.equal(libUtil.join("http://foo.org//", ""), "http://foo.org/");
+  assert.equal(libUtil.join("http://foo.org//", "."), "http://foo.org/");
+  assert.equal(libUtil.join("//www.example.com", ""), "//www.example.com/");
+  assert.equal(libUtil.join("//www.example.com", "."), "//www.example.com/");
 
 
-  assert.equal(libUtil.join('http://', 'www.example.com'), 'http://www.example.com');
-  assert.equal(libUtil.join('file:///', 'www.example.com'), 'file:///www.example.com');
-  assert.equal(libUtil.join('http://', 'ftp://example.com'), 'ftp://example.com');
+  assert.equal(libUtil.join("http://foo.org/a", "b"), "http://foo.org/a/b");
+  assert.equal(libUtil.join("http://foo.org/a/", "b"), "http://foo.org/a/b");
+  assert.equal(libUtil.join("http://foo.org/a//", "b"), "http://foo.org/a/b");
+  assert.equal(libUtil.join("http://foo.org/a", "b/"), "http://foo.org/a/b/");
+  assert.equal(libUtil.join("http://foo.org/a", "b//"), "http://foo.org/a/b/");
+  assert.equal(libUtil.join("http://foo.org/a/", "/b"), "http://foo.org/b");
+  assert.equal(libUtil.join("http://foo.org/a//", "//b"), "http://b");
 
-  assert.equal(libUtil.join('http://www.example.com', '//foo.org/bar'), 'http://foo.org/bar');
-  assert.equal(libUtil.join('//www.example.com', '//foo.org/bar'), '//foo.org/bar');
+  assert.equal(libUtil.join("http://foo.org/a", ".."), "http://foo.org/");
+  assert.equal(libUtil.join("http://foo.org/a", "../b"), "http://foo.org/b");
+  assert.equal(libUtil.join("http://foo.org/a/b", "../c"), "http://foo.org/a/c");
+
+  assert.equal(libUtil.join("http://foo.org/a", "."), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org/a", "./b"), "http://foo.org/a/b");
+  assert.equal(libUtil.join("http://foo.org/a/b", "./c"), "http://foo.org/a/b/c");
+
+  assert.equal(libUtil.join("http://foo.org/a", "http://www.example.com"), "http://www.example.com");
+  assert.equal(libUtil.join("http://foo.org/a", "data:foo,bar"), "data:foo,bar");
+
+
+  assert.equal(libUtil.join("http://foo.org", "a"), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org/", "a"), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org//", "a"), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org", "/a"), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org/", "/a"), "http://foo.org/a");
+  assert.equal(libUtil.join("http://foo.org//", "/a"), "http://foo.org/a");
+
+
+  assert.equal(libUtil.join("http://", "www.example.com"), "http://www.example.com");
+  assert.equal(libUtil.join("file:///", "www.example.com"), "file:///www.example.com");
+  assert.equal(libUtil.join("http://", "ftp://example.com"), "ftp://example.com");
+
+  assert.equal(libUtil.join("http://www.example.com", "//foo.org/bar"), "http://foo.org/bar");
+  assert.equal(libUtil.join("//www.example.com", "//foo.org/bar"), "//foo.org/bar");
 };
 
 // TODO Issue #128: Define and test this function properly.
-exports['test relative()'] = function (assert) {
-  assert.equal(libUtil.relative('/the/root', '/the/root/one.js'), 'one.js');
-  assert.equal(libUtil.relative('http://the/root', 'http://the/root/one.js'), 'one.js');
-  assert.equal(libUtil.relative('/the/root', '/the/rootone.js'), '../rootone.js');
-  assert.equal(libUtil.relative('http://the/root', 'http://the/rootone.js'), '../rootone.js');
-  assert.equal(libUtil.relative('/the/root', '/therootone.js'), '/therootone.js');
-  assert.equal(libUtil.relative('http://the/root', '/therootone.js'), '/therootone.js');
+exports["test relative()"] = function(assert) {
+  assert.equal(libUtil.relative("/the/root", "/the/root/one.js"), "one.js");
+  assert.equal(libUtil.relative("http://the/root", "http://the/root/one.js"), "one.js");
+  assert.equal(libUtil.relative("/the/root", "/the/rootone.js"), "../rootone.js");
+  assert.equal(libUtil.relative("http://the/root", "http://the/rootone.js"), "../rootone.js");
+  assert.equal(libUtil.relative("/the/root", "/therootone.js"), "/therootone.js");
+  assert.equal(libUtil.relative("http://the/root", "/therootone.js"), "/therootone.js");
 
-  assert.equal(libUtil.relative('', '/the/root/one.js'), '/the/root/one.js');
-  assert.equal(libUtil.relative('.', '/the/root/one.js'), '/the/root/one.js');
-  assert.equal(libUtil.relative('', 'the/root/one.js'), 'the/root/one.js');
-  assert.equal(libUtil.relative('.', 'the/root/one.js'), 'the/root/one.js');
+  assert.equal(libUtil.relative("", "/the/root/one.js"), "/the/root/one.js");
+  assert.equal(libUtil.relative(".", "/the/root/one.js"), "/the/root/one.js");
+  assert.equal(libUtil.relative("", "the/root/one.js"), "the/root/one.js");
+  assert.equal(libUtil.relative(".", "the/root/one.js"), "the/root/one.js");
 
-  assert.equal(libUtil.relative('/', '/the/root/one.js'), 'the/root/one.js');
-  assert.equal(libUtil.relative('/', 'the/root/one.js'), 'the/root/one.js');
+  assert.equal(libUtil.relative("/", "/the/root/one.js"), "the/root/one.js");
+  assert.equal(libUtil.relative("/", "the/root/one.js"), "the/root/one.js");
 };
 
-exports['test computeSourceURL'] = function (assert) {
+exports["test computeSourceURL"] = function(assert) {
   // Tests with sourceMapURL.
-  assert.equal(libUtil.computeSourceURL('', 'src/test.js', 'http://example.com'),
-               'http://example.com/src/test.js');
-  assert.equal(libUtil.computeSourceURL(undefined, 'src/test.js', 'http://example.com'),
-               'http://example.com/src/test.js');
-  assert.equal(libUtil.computeSourceURL('src', 'test.js', 'http://example.com'),
-               'http://example.com/src/test.js');
-  assert.equal(libUtil.computeSourceURL('src/', 'test.js', 'http://example.com'),
-               'http://example.com/src/test.js');
-  assert.equal(libUtil.computeSourceURL('src', '/test.js', 'http://example.com'),
-               'http://example.com/src/test.js');
-  assert.equal(libUtil.computeSourceURL('http://mozilla.com', 'src/test.js', 'http://example.com'),
-               'http://mozilla.com/src/test.js');
-  assert.equal(libUtil.computeSourceURL('', 'test.js', 'http://example.com/src/test.js.map'),
-               'http://example.com/src/test.js');
+  assert.equal(libUtil.computeSourceURL("", "src/test.js", "http://example.com"),
+               "http://example.com/src/test.js");
+  assert.equal(libUtil.computeSourceURL(undefined, "src/test.js", "http://example.com"),
+               "http://example.com/src/test.js");
+  assert.equal(libUtil.computeSourceURL("src", "test.js", "http://example.com"),
+               "http://example.com/src/test.js");
+  assert.equal(libUtil.computeSourceURL("src/", "test.js", "http://example.com"),
+               "http://example.com/src/test.js");
+  assert.equal(libUtil.computeSourceURL("src", "/test.js", "http://example.com"),
+               "http://example.com/src/test.js");
+  assert.equal(libUtil.computeSourceURL("http://mozilla.com", "src/test.js", "http://example.com"),
+               "http://mozilla.com/src/test.js");
+  assert.equal(libUtil.computeSourceURL("", "test.js", "http://example.com/src/test.js.map"),
+               "http://example.com/src/test.js");
 
   // Legacy code won't pass in the sourceMapURL.
-  assert.equal(libUtil.computeSourceURL('', 'src/test.js'), 'src/test.js');
-  assert.equal(libUtil.computeSourceURL(undefined, 'src/test.js'), 'src/test.js');
-  assert.equal(libUtil.computeSourceURL('src', 'test.js'), 'src/test.js');
-  assert.equal(libUtil.computeSourceURL('src/', 'test.js'), 'src/test.js');
-  assert.equal(libUtil.computeSourceURL('src', '/test.js'), 'src/test.js');
-  assert.equal(libUtil.computeSourceURL('src', '../test.js'), 'test.js');
-  assert.equal(libUtil.computeSourceURL('src/dir', '../././../test.js'), 'test.js');
+  assert.equal(libUtil.computeSourceURL("", "src/test.js"), "src/test.js");
+  assert.equal(libUtil.computeSourceURL(undefined, "src/test.js"), "src/test.js");
+  assert.equal(libUtil.computeSourceURL("src", "test.js"), "src/test.js");
+  assert.equal(libUtil.computeSourceURL("src/", "test.js"), "src/test.js");
+  assert.equal(libUtil.computeSourceURL("src", "/test.js"), "src/test.js");
+  assert.equal(libUtil.computeSourceURL("src", "../test.js"), "test.js");
+  assert.equal(libUtil.computeSourceURL("src/dir", "../././../test.js"), "test.js");
 
   // This gives different results with the old algorithm and the new
   // spec-compliant algorithm.
-  assert.equal(libUtil.computeSourceURL('http://example.com/dir', '/test.js'),
-               'http://example.com/dir/test.js');
+  assert.equal(libUtil.computeSourceURL("http://example.com/dir", "/test.js"),
+               "http://example.com/dir/test.js");
 };

--- a/test/util.js
+++ b/test/util.js
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-var util = require('../lib/util');
+var util = require("../lib/util");
 
 // This is a test mapping which maps functions from two different files
 // (one.js and two.js) to a minified generated source.
@@ -26,87 +26,87 @@ var util = require('../lib/util');
 //
 //   ONE.foo=function(a){return baz(a);};
 //   TWO.inc=function(a){return a+1;};
-exports.testGeneratedCode = " ONE.foo=function(a){return baz(a);};\n"+
+exports.testGeneratedCode = " ONE.foo=function(a){return baz(a);};\n" +
                             " TWO.inc=function(a){return a+1;};";
 exports.testMap = {
   version: 3,
-  file: 'min.js',
-  names: ['bar', 'baz', 'n'],
-  sources: ['one.js', 'two.js'],
-  sourceRoot: '/the/root',
-  mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
+  file: "min.js",
+  names: ["bar", "baz", "n"],
+  sources: ["one.js", "two.js"],
+  sourceRoot: "/the/root",
+  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
 };
 exports.testMapNoSourceRoot = {
   version: 3,
-  file: 'min.js',
-  names: ['bar', 'baz', 'n'],
-  sources: ['one.js', 'two.js'],
-  mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
+  file: "min.js",
+  names: ["bar", "baz", "n"],
+  sources: ["one.js", "two.js"],
+  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
 };
 exports.testMapEmptySourceRoot = {
   version: 3,
-  file: 'min.js',
-  names: ['bar', 'baz', 'n'],
-  sources: ['one.js', 'two.js'],
-  sourceRoot: '',
-  mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
+  file: "min.js",
+  names: ["bar", "baz", "n"],
+  sources: ["one.js", "two.js"],
+  sourceRoot: "",
+  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
 };
 exports.testMapSingleSource = {
   version: 3,
-  file: 'min.js',
-  names: ['bar', 'baz'],
-  sources: ['one.js'],
-  sourceRoot: '',
-  mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID'
+  file: "min.js",
+  names: ["bar", "baz"],
+  sources: ["one.js"],
+  sourceRoot: "",
+  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID"
 };
 exports.testMapEmptyMappings = {
   version: 3,
-  file: 'min.js',
+  file: "min.js",
   names: [],
-  sources: ['one.js', 'two.js'],
+  sources: ["one.js", "two.js"],
   sourcesContent: [
-    ' ONE.foo = 1;',
-    ' TWO.inc = 2;'
+    " ONE.foo = 1;",
+    " TWO.inc = 2;"
   ],
-  sourceRoot: '',
-  mappings: ''
+  sourceRoot: "",
+  mappings: ""
 };
 exports.testMapEmptyMappingsRelativeSources = {
   version: 3,
-  file: 'min.js',
+  file: "min.js",
   names: [],
-  sources: ['./one.js', './two.js'],
+  sources: ["./one.js", "./two.js"],
   sourcesContent: [
-    ' ONE.foo = 1;',
-    ' TWO.inc = 2;'
+    " ONE.foo = 1;",
+    " TWO.inc = 2;"
   ],
-  sourceRoot: '/the/root',
-  mappings: ''
+  sourceRoot: "/the/root",
+  mappings: ""
 };
 exports.testMapEmptyMappingsRelativeSources_generatedExpected = {
   version: 3,
-  file: 'min.js',
+  file: "min.js",
   names: [],
-  sources: ['one.js', 'two.js'],
+  sources: ["one.js", "two.js"],
   sourcesContent: [
-    ' ONE.foo = 1;',
-    ' TWO.inc = 2;'
+    " ONE.foo = 1;",
+    " TWO.inc = 2;"
   ],
-  sourceRoot: '/the/root',
-  mappings: ''
+  sourceRoot: "/the/root",
+  mappings: ""
 };
 exports.testMapMultiSourcesMappingRefersSingleSourceOnly = {
     version: 3,
-    file: 'min.js',
-    names: ['bar', 'baz'],
-    sources: ['one.js', 'withoutMappings.js'],
-    sourceRoot: '',
-    mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID'
+    file: "min.js",
+    names: ["bar", "baz"],
+    sources: ["one.js", "withoutMappings.js"],
+    sourceRoot: "",
+    mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID"
 };
 // This mapping is identical to above, but uses the indexed format instead.
 exports.indexedTestMap = {
   version: 3,
-  file: 'min.js',
+  file: "min.js",
   sections: [
     {
       offset: {
@@ -119,9 +119,9 @@ exports.indexedTestMap = {
           "one.js"
         ],
         sourcesContent: [
-          ' ONE.foo = function (bar) {\n' +
-          '   return baz(bar);\n' +
-          ' };',
+          " ONE.foo = function (bar) {\n" +
+          "   return baz(bar);\n" +
+          " };",
         ],
         names: [
           "bar",
@@ -143,9 +143,9 @@ exports.indexedTestMap = {
           "two.js"
         ],
         sourcesContent: [
-          ' TWO.inc = function (n) {\n' +
-          '   return n + 1;\n' +
-          ' };'
+          " TWO.inc = function (n) {\n" +
+          "   return n + 1;\n" +
+          " };"
         ],
         names: [
           "n"
@@ -159,7 +159,7 @@ exports.indexedTestMap = {
 };
 exports.indexedTestMapDifferentSourceRoots = {
   version: 3,
-  file: 'min.js',
+  file: "min.js",
   sections: [
     {
       offset: {
@@ -172,9 +172,9 @@ exports.indexedTestMapDifferentSourceRoots = {
           "one.js"
         ],
         sourcesContent: [
-          ' ONE.foo = function (bar) {\n' +
-          '   return baz(bar);\n' +
-          ' };',
+          " ONE.foo = function (bar) {\n" +
+          "   return baz(bar);\n" +
+          " };",
         ],
         names: [
           "bar",
@@ -196,9 +196,9 @@ exports.indexedTestMapDifferentSourceRoots = {
           "two.js"
         ],
         sourcesContent: [
-          ' TWO.inc = function (n) {\n' +
-          '   return n + 1;\n' +
-          ' };'
+          " TWO.inc = function (n) {\n" +
+          "   return n + 1;\n" +
+          " };"
         ],
         names: [
           "n"
@@ -212,49 +212,49 @@ exports.indexedTestMapDifferentSourceRoots = {
 };
 exports.testMapWithSourcesContent = {
   version: 3,
-  file: 'min.js',
-  names: ['bar', 'baz', 'n'],
-  sources: ['one.js', 'two.js'],
+  file: "min.js",
+  names: ["bar", "baz", "n"],
+  sources: ["one.js", "two.js"],
   sourcesContent: [
-    ' ONE.foo = function (bar) {\n' +
-    '   return baz(bar);\n' +
-    ' };',
-    ' TWO.inc = function (n) {\n' +
-    '   return n + 1;\n' +
-    ' };'
+    " ONE.foo = function (bar) {\n" +
+    "   return baz(bar);\n" +
+    " };",
+    " TWO.inc = function (n) {\n" +
+    "   return n + 1;\n" +
+    " };"
   ],
-  sourceRoot: '/the/root',
-  mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
+  sourceRoot: "/the/root",
+  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
 };
 exports.testMapRelativeSources = {
   version: 3,
-  file: 'min.js',
-  names: ['bar', 'baz', 'n'],
-  sources: ['./one.js', './two.js'],
+  file: "min.js",
+  names: ["bar", "baz", "n"],
+  sources: ["./one.js", "./two.js"],
   sourcesContent: [
-    ' ONE.foo = function (bar) {\n' +
-    '   return baz(bar);\n' +
-    ' };',
-    ' TWO.inc = function (n) {\n' +
-    '   return n + 1;\n' +
-    ' };'
+    " ONE.foo = function (bar) {\n" +
+    "   return baz(bar);\n" +
+    " };",
+    " TWO.inc = function (n) {\n" +
+    "   return n + 1;\n" +
+    " };"
   ],
-  sourceRoot: '/the/root',
-  mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA'
+  sourceRoot: "/the/root",
+  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
 };
 exports.emptyMap = {
   version: 3,
-  file: 'min.js',
+  file: "min.js",
   names: [],
   sources: [],
-  mappings: ''
+  mappings: ""
 };
 exports.mapWithSourcelessMapping = {
   version: 3,
-  file: 'example.js',
+  file: "example.js",
   names: [],
-  sources: ['example.js'],
-  mappings: 'AAgCA,C'
+  sources: ["example.js"],
+  mappings: "AAgCA,C"
 };
 
 
@@ -265,17 +265,17 @@ function assertMapping(generatedLine, generatedColumn, originalSource,
     var origMapping = map.originalPositionFor({
       line: generatedLine,
       column: generatedColumn,
-      bias: bias
+      bias
     });
     assert.equal(origMapping.name, name,
-                 'Incorrect name, expected ' + JSON.stringify(name)
-                 + ', got ' + JSON.stringify(origMapping.name));
+                 "Incorrect name, expected " + JSON.stringify(name)
+                 + ", got " + JSON.stringify(origMapping.name));
     assert.equal(origMapping.line, originalLine,
-                 'Incorrect line, expected ' + JSON.stringify(originalLine)
-                 + ', got ' + JSON.stringify(origMapping.line));
+                 "Incorrect line, expected " + JSON.stringify(originalLine)
+                 + ", got " + JSON.stringify(origMapping.line));
     assert.equal(origMapping.column, originalColumn,
-                 'Incorrect column, expected ' + JSON.stringify(originalColumn)
-                 + ', got ' + JSON.stringify(origMapping.column));
+                 "Incorrect column, expected " + JSON.stringify(originalColumn)
+                 + ", got " + JSON.stringify(origMapping.column));
 
     var expectedSource;
 
@@ -290,8 +290,8 @@ function assertMapping(generatedLine, generatedColumn, originalSource,
     }
 
     assert.equal(origMapping.source, expectedSource,
-                 'Incorrect source, expected ' + JSON.stringify(expectedSource)
-                 + ', got ' + JSON.stringify(origMapping.source));
+                 "Incorrect source, expected " + JSON.stringify(expectedSource)
+                 + ", got " + JSON.stringify(origMapping.source));
   }
 
   if (!dontTestGenerated) {
@@ -299,14 +299,14 @@ function assertMapping(generatedLine, generatedColumn, originalSource,
       source: originalSource,
       line: originalLine,
       column: originalColumn,
-      bias: bias
+      bias
     });
     assert.equal(genMapping.line, generatedLine,
-                 'Incorrect line, expected ' + JSON.stringify(generatedLine)
-                 + ', got ' + JSON.stringify(genMapping.line));
+                 "Incorrect line, expected " + JSON.stringify(generatedLine)
+                 + ", got " + JSON.stringify(genMapping.line));
     assert.equal(genMapping.column, generatedColumn,
-                 'Incorrect column, expected ' + JSON.stringify(generatedColumn)
-                 + ', got ' + JSON.stringify(genMapping.column));
+                 "Incorrect column, expected " + JSON.stringify(generatedColumn)
+                 + ", got " + JSON.stringify(genMapping.column));
   }
 }
 exports.assertMapping = assertMapping;
@@ -318,7 +318,7 @@ function assertEqualMaps(assert, actualMap, expectedMap) {
                expectedMap.names.length,
                "names length mismatch: " +
                  actualMap.names.join(", ") + " != " + expectedMap.names.join(", "));
-  for (var i = 0; i < actualMap.names.length; i++) {
+  for (let i = 0; i < actualMap.names.length; i++) {
     assert.equal(actualMap.names[i],
                  expectedMap.names[i],
                  "names[" + i + "] mismatch: " +
@@ -328,7 +328,7 @@ function assertEqualMaps(assert, actualMap, expectedMap) {
                expectedMap.sources.length,
                "sources length mismatch: " +
                  actualMap.sources.join(", ") + " != " + expectedMap.sources.join(", "));
-  for (var i = 0; i < actualMap.sources.length; i++) {
+  for (let i = 0; i < actualMap.sources.length; i++) {
     assert.equal(actualMap.sources[i],
                  expectedMap.sources[i],
                  "sources[" + i + "] length mismatch: " +


### PR DESCRIPTION
Fix up the myriad changes.  Justification for the large changeset for quotes: they were inconsistent before.