### PR TITLE
Coverage tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/*
 build/
 package-lock.json
 bench/*.svg
+.nyc_output/
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,16 @@ node_js:
   - "8"
   - "9"
 
+install:
+- npm install
+- npm install coveralls
+
+script:
+- npm run coverage
+
+after_success:
+- nyc report --reporter=text-lcov | coveralls
+
 cache:
   directories:
     - node_modules

--- a/.waiting.html
+++ b/.waiting.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Code coverage report for All files</title>
+  <style>
+body {
+    font-family: Helvetica Neue, Helvetica, Arial;
+    font-size: 20px;
+    color:#333;
+    margin: 50px;
+}
+code {
+  color: green;
+}
+  </style>
+</head>
+<body>
+  <div>This page will refresh with a coverage report, as long as you have
+    executed <code>npm run dev</code>.  Please be patient.</div>
+</body>
+</html>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ very appreciated.
 - [Submitting Pull Requests](#submitting-pull-requests)
 - [Running Tests](#running-tests)
 - [Writing New Tests](#writing-new-tests)
+- [Checking code coverage](#checking-code-coverage)
 - [Updating the `lib/mappings.wasm` WebAssembly Module](#updating-the-libmappingswasm-webassembly-module)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -112,6 +113,29 @@ can use as well:
 ```js
 var util = require('./util');
 ```
+
+## Checking code coverage
+
+It's fun to find ways to test lines of code that aren't visited by
+the tests yet.
+
+```shell
+$ npm run coverage
+$ open coverage/index.html
+```
+
+This will allow you to browse to red sections of the code that need
+more attention.  Even more cool, however, is to run:
+
+```shell
+$ npm run dev
+```
+
+(On some operating systems, this may pop up a request for node to be able to open a socket.  Click "Allow" or the equivalent.)
+
+This will run the coverage tools, and monitor all of the files in the
+project, re-running the coverage tools and refreshing the browser when
+any files change.  There will be a small web server running on port 4103 to enable this.  Control-C to stop.
 
 ## Updating the `lib/mappings.wasm` WebAssembly Module
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/mozilla/source-map.png?branch=master)](https://travis-ci.org/mozilla/source-map)
 
+[![Coverage Status](https://coveralls.io/repos/github/mozilla/source-map/badge.svg)](https://coveralls.io/github/mozilla/source-map)
+
 [![NPM](https://nodei.co/npm/source-map.png?downloads=true&downloadRank=true)](https://www.npmjs.com/package/source-map)
 
 This is a library to generate and consume the source map format

--- a/package.json
+++ b/package.json
@@ -59,15 +59,32 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "test": "npm run lint && npm run build && node test/run-tests.js",
-    "build": "webpack --color",
     "lint": "eslint *.js lib/ test/",
+    "prebuild": "npm run lint",
+    "build": "webpack --color",
+    "pretest": "npm run build",
+    "test": "node test/run-tests.js",
+    "precoverage": "npm run build",
+    "coverage": "nyc node test/run-tests.js",
+    "setup": "mkdir -p coverage && cp -n .waiting.html coverage/index.html || true",
+    "dev:live": "live-server --port=4103 --ignorePattern='(js|css|png)$' coverage",
+    "dev:watch": "watch 'npm run coverage' lib/ test/",
+    "predev": "npm run setup",
+    "dev": "npm-run-all -p --silent dev:*",
+    "clean": "rm -rf coverage .nyc_output",
     "toc": "doctoc --title '## Table of Contents' README.md && doctoc --title '## Table of Contents' CONTRIBUTING.md"
   },
   "devDependencies": {
     "doctoc": "^0.15.0",
-    "webpack": "^3.10",
-    "eslint": "^4.19.1"
+    "eslint": "^4.19.1",
+    "live-server": "^1.2.0",
+    "npm-run-all": "^4.1.2",
+    "nyc": "^11.7.1",
+    "watch": "^1.0.2",
+    "webpack": "^3.10"
+  },
+  "nyc": {
+    "reporter": "html"
   },
   "typings": "source-map"
 }


### PR DESCRIPTION
This is just a suggestion, but I've used a similar approach on several projects and really like how it drives coverage up.

Rebased on #332.  Adds support for a developer workflow kicked off with `npm run dev`, which will:

- Kick off a webserver
- Run coverage metrics
- Open the metrics in the default browser
- On file change, re-run metrics, and update metrics in browser

Also add support for reporting coverage on travis builds.  For an example, see
https://coveralls.io/github/hildjj/source-map

To enable coveralls for the mozilla branch, go to https://coveralls.io/repos/new , log in with GitHub, find source-map, and click the enable button.  I think I may have the necessary privileges to do that for us, needed.