### PR TITLE
Add expected arguments to assert.throws calls

### DIFF
--- a/test/test-base64.js
+++ b/test/test-base64.js
@@ -10,10 +10,10 @@ const base64 = require("../lib/base64");
 exports["test out of range encoding"] = function(assert) {
   assert.throws(function() {
     base64.encode(-1);
-  });
+  }, /Must be between 0 and 63/);
   assert.throws(function() {
     base64.encode(64);
-  });
+  }, /Must be between 0 and 63/);
 };
 
 exports["test normal encoding and decoding"] = function(assert) {

--- a/test/test-source-map-generator.js
+++ b/test/test-source-map-generator.js
@@ -84,7 +84,7 @@ exports["test adding mappings (invalid)"] = function(assert) {
   // Not enough info.
   assert.throws(function() {
     map.addMapping({});
-  });
+  }, /"generated" is a required argument/);
 
   // Original file position, but no source.
   assert.throws(function() {
@@ -92,7 +92,7 @@ exports["test adding mappings (invalid)"] = function(assert) {
       generated: { line: 1, column: 1 },
       original: { line: 1, column: 1 }
     });
-  });
+  }, /Invalid mapping/);
 };
 
 exports["test adding mappings with skipValidation"] = function(assert) {
@@ -105,7 +105,7 @@ exports["test adding mappings with skipValidation"] = function(assert) {
   // Not enough info, caught by `util.getArgs`
   assert.throws(function() {
     map.addMapping({});
-  });
+  }, /"generated" is a required argument/);
 
   // Original file position, but no source. Not checked.
   assert.doesNotThrow(function() {
@@ -113,7 +113,7 @@ exports["test adding mappings with skipValidation"] = function(assert) {
       generated: { line: 1, column: 1 },
       original: { line: 1, column: 1 }
     });
-  });
+  }, /Invalid mapping/);
 };
 
 exports["test that the correct mappings are being generated"] = function(assert) {

--- a/test/test-source-node.js
+++ b/test/test-source-node.js
@@ -35,10 +35,10 @@ exports["test .add()"] = function(assert) {
   // Adding other stuff doesn't.
   assert.throws(function() {
     node.add({});
-  });
+  }, /TypeError: Expected a SourceNode, string, or an array of SourceNodes and strings/);
   assert.throws(function() {
     node.add(function() {});
-  });
+  }, /TypeError: Expected a SourceNode, string, or an array of SourceNodes and strings/);
 };
 
 exports["test .prepend()"] = function(assert) {
@@ -70,10 +70,10 @@ exports["test .prepend()"] = function(assert) {
   // Prepending other stuff doesn't.
   assert.throws(function() {
     node.prepend({});
-  });
+  }, /TypeError: Expected a SourceNode, string, or an array of SourceNodes and strings/);
   assert.throws(function() {
     node.prepend(function() {});
-  });
+  }, /TypeError: Expected a SourceNode, string, or an array of SourceNodes and strings/);
 };
 
 exports["test .toString()"] = function(assert) {


### PR DESCRIPTION
In [bug 1452706](https://bugzilla.mozilla.org/show_bug.cgi?id=1452706) we are moving mozilla-central towards requiring the "expected" argument to Assert.throws (and friends).

This is currently an ESLint rule, however we are working on moving it to be hard-coded in Assert.jsm.

Hence, this PR updates source-map, and I'll file a bug once it is accepted to get source-map updated in mozilla-central.