### PR TITLE
Bump webpack-cli to v3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "nyc": "^11.7.1",
     "watch": "^1.0.2",
     "webpack": "^4.9.1",
-    "webpack-cli": "^2.1.4"
+    "webpack-cli": "^3.1"
   },
   "nyc": {
     "reporter": "html"


### PR DESCRIPTION
webpack v4.20 introduces a change making webpack-cli v2 unusable.

Check: webpack/webpack#8082.