### PR TITLE
Split up wasm loading based on compilation target.

### DIFF
--- a/lib/read-wasm-browser.js
+++ b/lib/read-wasm-browser.js
@@ -1,0 +1,22 @@
+"use strict";
+
+let mappingsWasm = null;
+
+module.exports = function readWasm() {
+  if (typeof mappingsWasm === "string") {
+    return fetch(mappingsWasm)
+      .then(response => response.arrayBuffer());
+  }
+  if (mappingsWasm instanceof ArrayBuffer) {
+    return Promise.resolve(mappingsWasm);
+  }
+
+  throw new Error("You must provide the string URL or ArrayBuffer contents " +
+                  "of lib/mappings.wasm by calling " +
+                  "SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) " +
+                  "before using SourceMapConsumer");
+};
+
+module.exports.initialize = input => {
+  mappingsWasm = input;
+};

--- a/lib/read-wasm.js
+++ b/lib/read-wasm.js
@@ -1,49 +1,25 @@
-/* Determine browser vs node environment by testing the default top level context. Solution courtesy of: https://stackoverflow.com/questions/17575790/environment-detection-node-js-or-browser */
-const isBrowserEnvironment = (function() {
-    // eslint-disable-next-line no-undef
-    return (typeof window !== "undefined") && (this === window);
-}).call();
+"use strict";
 
-if (isBrowserEnvironment) {
-  // Web version of reading a wasm file into an array buffer.
+// Note: This file is replaced with "read-wasm-browser.js" when this module is
+// bundled with a packager that takes package.json#browser fields into account.
 
-  let mappingsWasm = null;
+const fs = require("fs");
+const path = require("path");
 
-  module.exports = function readWasm() {
-    if (typeof mappingsWasm === "string") {
-      return fetch(mappingsWasm)
-        .then(response => response.arrayBuffer());
-    }
-    if (mappingsWasm instanceof ArrayBuffer) {
-      return Promise.resolve(mappingsWasm);
-    }
-    throw new Error("You must provide the string URL or ArrayBuffer contents " +
-                    "of lib/mappings.wasm by calling " +
-                    "SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) " +
-                    "before using SourceMapConsumer");
-  };
+module.exports = function readWasm() {
+  return new Promise((resolve, reject) => {
+    const wasmPath = path.join(__dirname, "mappings.wasm");
+    fs.readFile(wasmPath, null, (error, data) => {
+      if (error) {
+        reject(error);
+        return;
+      }
 
-  module.exports.initialize = input => mappingsWasm = input;
-} else {
-  // Node version of reading a wasm file into an array buffer.
-  const fs = require("fs");
-  const path = require("path");
-
-  module.exports = function readWasm() {
-    return new Promise((resolve, reject) => {
-      const wasmPath = path.join(__dirname, "mappings.wasm");
-      fs.readFile(wasmPath, null, (error, data) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-
-        resolve(data.buffer);
-      });
+      resolve(data.buffer);
     });
-  };
+  });
+};
 
-  module.exports.initialize = _ => {
-    console.debug("SourceMapConsumer.initialize is a no-op when running in node.js");
-  };
-}
+module.exports.initialize = _ => {
+  console.debug("SourceMapConsumer.initialize is a no-op when running in node.js");
+};

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
   },
   "main": "./source-map.js",
   "types": "./source-map.d.ts",
+  "browser": {
+    "./lib/read-wasm.js": "./lib/read-wasm-browser.js"
+  },
   "files": [
     "source-map.js",
     "source-map.d.ts",


### PR DESCRIPTION
Per my comment in https://github.com/mozilla/source-map/pull/350#issuecomment-424174926, this feels like a more ideal way to approach this. This leaves it up to bundlers to swap out the files when bundling for browser use.

I'm personally a fan of this approach because it's also an easily-reproducible check. As it is, there's no way for a module making use of `source-map` to know whether a call to `SourceMapConsumer.initialize` is needed, or will result in a `console.debug("SourceMapConsumer.initialize is a no-op when running in node.js");` message. This gives one central toggle for that, which they can also use in their own code when deciding whether to call `.initialize` or not.