### PR TITLE
Add lastGeneratedColumn to typing for MappingItem

### DIFF
--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -61,6 +61,7 @@ export interface MappingItem {
     source: string;
     generatedLine: number;
     generatedColumn: number;
+    lastGeneratedColumn: number | null;
     originalLine: number;
     originalColumn: number;
     name: string;


### PR DESCRIPTION
This is generated when someone calls `computeColumnSpans` so we mark the property as optional as well.