### PR TITLE
Try 2 bias values when calling originalPositionFor from applySourceMap

### DIFF
--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -200,11 +200,19 @@ class SourceMapGenerator {
     // Find mappings for the "sourceFile"
     this._mappings.unsortedForEach(function(mapping) {
       if (mapping.source === sourceFile && mapping.originalLine != null) {
+        
         // Check if it can be mapped by the source map, then update the mapping.
-        const original = aSourceMapConsumer.originalPositionFor({
+        let generatedPosition = {
           line: mapping.originalLine,
-          column: mapping.originalColumn
-        });
+          column: mapping.originalColumn,
+          bias: SourceMapConsumer.GREATEST_LOWER_BOUND
+        };
+        let original = aSourceMapConsumer.originalPositionFor(generatedPosition);
+        if (original.source === null) {
+          generatedPosition.bias = SourceMapConsumer.LEAST_UPPER_BOUND;
+          original = aSourceMapConsumer.originalPositionFor(generatedPosition);
+        }
+
         if (original.source != null) {
           // Copy mapping
           mapping.source = original.source;


### PR DESCRIPTION
The method applySourceMap is calling originalPositionFor without providing the `bias` value.
By default `bias` equals to GREATEST_LOWER_BOUND which means: if exact column value was not found - take nearest item from the left. In some cases there is "no nearest value on the left" because most correct value is nearest "from the right". I believe it is worth to try to call `originalPositionFor` with both available bias values rather then just try one and claim that we cannot find mapping while it is exists.

Initially the GREATEST_LOWER_BOUND value is used (like it was before). If `originalPositionFor` cannot find relevant mapping then LEAST_UPPER_BOUND bias value is used to search again. 
I don't think that `applySourceMap` should made any assumptions on the structure of the source maps and it should be symmetric as much as possible (in proposed implementation preference is given to the "left" element but this is how it always was before).