### PR TITLE
Treat generated column number as 0-based in indexed originalPositionFor

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -785,7 +785,7 @@ class IndexedSourceMapConsumer extends SourceMapConsumer {
           return cmp;
         }
 
-        return (aNeedle.generatedColumn -
+        return ((aNeedle.generatedColumn + 1) -
                 section.generatedOffset.generatedColumn);
       });
     const section = this._sections[sectionIndex];

--- a/test/test-source-map-consumer.js
+++ b/test/test-source-map-consumer.js
@@ -692,6 +692,52 @@ exports["test index map + generatedPositionFor"] = async function(assert) {
   map.destroy();
 };
 
+exports["test index map + originalPositionFor"] = async function(assert) {
+  const map = await new SourceMapConsumer(util.indexedTestMapWithMappingsAtSectionStart);
+
+  let pos = map.originalPositionFor({
+    line: 1,
+    column: 0
+  });
+
+  assert.equal(pos.line, 1);
+  assert.equal(pos.column, 0);
+  assert.equal(pos.source, "foo.js");
+  assert.equal(pos.name, "first");
+
+  pos = map.originalPositionFor({
+    line: 1,
+    column: 1
+  });
+
+  assert.equal(pos.line, 2);
+  assert.equal(pos.column, 1);
+  assert.equal(pos.source, "bar.js");
+  assert.equal(pos.name, "second");
+
+  pos = map.originalPositionFor({
+    line: 1,
+    column: 2
+  });
+
+  assert.equal(pos.line, 1);
+  assert.equal(pos.column, 0);
+  assert.equal(pos.source, "baz.js");
+  assert.equal(pos.name, "third");
+
+  pos = map.originalPositionFor({
+    line: 1,
+    column: 3
+  });
+
+  assert.equal(pos.line, 2);
+  assert.equal(pos.column, 1);
+  assert.equal(pos.source, "quux.js");
+  assert.equal(pos.name, "fourth");
+
+  map.destroy();
+};
+
 exports["test allGeneratedPositionsFor for line"] = async function(assert) {
   let map = new SourceMapGenerator({
     file: "generated.js"

--- a/test/util.js
+++ b/test/util.js
@@ -265,6 +265,29 @@ exports.indexedTestMapColumnOffset = {
     }
   ]
 };
+exports.indexedTestMapWithMappingsAtSectionStart = {
+  version: 3,
+  sections: [
+    {
+      offset: {"line": 0, "column": 0},
+      map: {
+        version: 3,
+        names: ["first", "second"],
+        sources: ["foo.js", "bar.js"],
+        mappings: "AAAAA,CCCCC"
+      }
+    },
+    {
+      offset: {"line": 0, "column": 2},
+      map: {
+        version: 3,
+        names: ["third", "fourth"],
+        sources: ["baz.js", "quux.js"],
+        mappings: "AAAAA,CCCCC"
+      }
+    }
+  ]
+};
 exports.testMapWithSourcesContent = {
   version: 3,
   file: "min.js",


### PR DESCRIPTION
Currently `originalPositionFor` behaves differently in `BasicSourceMapConsumer` and `IndexedSourceMapConsumer`:

* In the former, the `column` argument is (correctly and as documented) treated as 0-based.
* In the latter, the `column` argument is treated as 1-based for the purpose of locating the section in which the generated position occurs (as the internal `section.generatedOffset.generatedColumn` field is, for whatever reason, 1-based).

This is a longstanding issue, going back to the introduction of `IndexedSourceMapConsumer` AFAICT, but the behavior is incorrect. This PR fixes the issue and adds a corresponding test.