### PR TITLE
Memoize URL parsing while calculating absolute soruces

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -203,9 +203,11 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
       that._names = ArraySet.fromArray(names.map(String), true);
       that._sources = ArraySet.fromArray(sources, true);
 
+      util.createUrlParser();
       that._absoluteSources = ArraySet.fromArray(that._sources.toArray().map(function(s) {
         return util.computeSourceURL(sourceRoot, s, aSourceMapURL);
       }), true);
+      util.clearURLParser();
 
       that.sourceRoot = sourceRoot;
       that.sourcesContent = sourcesContent;

--- a/lib/util.js
+++ b/lib/util.js
@@ -7,6 +7,44 @@
 
 const URL = require("./url");
 
+function createUrlParser(url, base) {
+  const urlMap = new Map();
+  parser = function(url, base) {
+
+    let baseMap = urlMap.get(url);
+
+    if (!baseMap) {
+      baseMap = new Map();
+      urlMap.set(url, baseMap);
+    }
+
+    if (!baseMap.has(base)) {
+      const parsedUrl = new URL(url, base);
+      baseMap.set(base, parsedUrl);
+      return parsedUrl;
+    }
+
+    return baseMap.get(base);
+  }
+}
+
+function clearURLParser() {
+  parser = undefined;
+}
+
+let parser;
+
+function parseURL(url, base) {
+  if (parser) {
+    return parser(url, base)
+  }
+
+  return new URL(url, base);
+}
+
+exports.createUrlParser = createUrlParser
+exports.clearURLParser = createUrlParser
+
 /**
  * This is a helper function for getting values from parameter/options
  * objects.
@@ -176,7 +214,7 @@ function createSafeHandler(cb) {
   return input => {
     const type = getURLType(input);
     const base = buildSafeBase(input);
-    const url = new URL(input, base);
+    const url = parseURL(input, base);
 
     cb(url);
 
@@ -197,7 +235,7 @@ function createSafeHandler(cb) {
 }
 
 function withBase(url, base) {
-  return new URL(url, base).toString();
+  return parseURL(url, base).toString();
 }
 
 function buildUniqueSegment(prefix, str) {
@@ -251,8 +289,8 @@ function getURLType(url) {
  * @return A rootURL-relative, normalized URL value.
  */
 function computeRelativeURL(rootURL, targetURL) {
-  if (typeof rootURL === "string") rootURL = new URL(rootURL);
-  if (typeof targetURL === "string") targetURL = new URL(targetURL);
+  if (typeof rootURL === "string") rootURL = parseURL(rootURL);
+  if (typeof targetURL === "string") targetURL = parseURL(targetURL);
 
   const targetParts = targetURL.pathname.split("/");
   const rootParts = rootURL.pathname.split("/");
@@ -297,7 +335,7 @@ const ensureDirectory = createSafeHandler(url => {
  * @return A normalized URL value.
  */
 const trimFilename = createSafeHandler(url => {
-  url.href = new URL(".", url.toString()).toString();
+  url.href = parseURL(".", url.toString()).toString();
 });
 
 /**
@@ -376,11 +414,11 @@ function relativeIfPossible(rootURL, targetURL) {
   }
 
   const base = buildSafeBase(rootURL + targetURL);
-  const root = new URL(rootURL, base);
-  const target = new URL(targetURL, base);
+  const root = parseURL(rootURL, base);
+  const target = parseURL(targetURL, base);
 
   try {
-    new URL("", target.toString());
+    parseURL("", target.toString());
   } catch (err) {
     // Bail if the URL doesn't support things being relative to it,
     // For example, data: and blob: URLs.


### PR DESCRIPTION
URL parsing is the slowest part of instantiating a source map consumer. Many of the URLs parsed are the same, which means that memoizing can have a nice performance improvement.



In this example, memoizing URL parsing saves ~200ms (475ms --> 287ms) . [old][o2] --> [new][n2]

[n2]: https://perf-html.io/from-addon/stack-chart/?globalTrackOrder=0-1-2-3&hiddenGlobalTracks=1-2&hiddenLocalTracksByPid=27840-0-1-2-3-5-6-7~27841-0-1~27846-0-1-2-3&implementation=js&localTrackOrderByPid=27840-8-9-0-1-2-3-4-5-6-7~27844-0~27841-2-0-1~27846-4-5-0-1-2-3~&range=3.4987_3.9449&thread=5&v=3
[o2]: https://profiler.firefox.com/public/723865c56f0a15016593599b9de00ee95057f148/stack-chart/?globalTrackOrder=0-1-2-3&hiddenGlobalTracks=1-2&hiddenLocalTracksByPid=98052-0-1-2-4-5-6~98053-0-1-2-3&implementation=js&localTrackOrderByPid=98052-7-8-0-1-2-3-4-5-6~98058-0~98055-0~98053-4-5-0-1-2-3~&profileName=&range=2.6638_6.1840~2.6858_3.6155~2.7150_3.2378&thread=4&v=3