### PR TITLE
minor binary-search code/comment fixes

### DIFF
--- a/lib/binary-search.js
+++ b/lib/binary-search.js
@@ -45,7 +45,7 @@ function recursiveSearch(aLow, aHigh, aNeedle, aHaystack, aCompare, aBias) {
 
     // The exact needle element was not found in this haystack. Determine if
     // we are in termination case (3) or (2) and return the appropriate thing.
-    if (aBias == exports.LEAST_UPPER_BOUND) {
+    if (aBias === exports.LEAST_UPPER_BOUND) {
       return aHigh < aHaystack.length ? aHigh : -1;
     }
     return mid;
@@ -93,7 +93,7 @@ exports.search = function search(aNeedle, aHaystack, aCompare, aBias) {
     return -1;
   }
 
-  // We have found either the exact element, or the next-closest element than
+  // We have found either the exact element, or the next-closest element to
   // the one we are searching for. However, there may be more than one such
   // element. Make sure we always return the smallest of these.
   while (index - 1 >= 0) {


### PR DESCRIPTION
binary-search:
+ `===` precise numeric enum check for bias
+ typo fix in comment

---

This is the extra stuff/details that popped up during code review and is not directly relevant for #392, hence filed as a separate pullreq.