### PR TITLE
fix crash in url util function due to undefined root value

### DIFF
--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -71,7 +71,7 @@ class SourceMapGenerator {
     });
     aSourceMapConsumer.sources.forEach(function(sourceFile) {
       let sourceRelative = sourceFile;
-      if (sourceRoot !== null) {
+      if (sourceRoot != null) {
         sourceRelative = util.relative(sourceRoot, sourceFile);
       }
 


### PR DESCRIPTION
fix crash in url util function due to undefined root value: `sourceRoot` is checked everywhere using `!= null` except in 1(one) spot, which caused a crash in my test set, while debugging indexed map issues with the origin API.

Crash uncovered during other work - to be filed. That pullreq/issue report will be linked in comment below once I've got that stuff filed.