### PR TITLE
`addMapping()`: ensure that `originalLine` and `originalColumn` are `null` when `original` argument was undefined/`null`

### DIFF
--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -124,8 +124,8 @@ class SourceMapGenerator {
     this._mappings.add({
       generatedLine: generated.line,
       generatedColumn: generated.column,
-      originalLine: original != null && original.line,
-      originalColumn: original != null && original.column,
+      originalLine: original && original.line,
+      originalColumn: original && original.column,
       source,
       name
     });


### PR DESCRIPTION
`addMapping()`: ensure that `originalLine` and `originalColumn` are `null` when `original` argument was undefined/`null`. `originalLine` et all are checked using `!= null`, which won't catch the potential `false` turning up due to the original code.

Popped up during code review for other issue(s). No extra tests added as this is trivial.