### PR TITLE
`sourceContentFor(aSource, nullOnMissing=false)` should NEVER return NULL, but throw an exception instead

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -527,7 +527,11 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
    */
   sourceContentFor(aSource, nullOnMissing) {
     if (!this.sourcesContent) {
-      return null;
+      if (nullOnMissing) {
+        return null;
+      }
+
+      throw new Error('"' + aSource + '" is not in the SourceMap.');
     }
 
     const index = this._findSourceIndex(aSource);

--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -79,7 +79,7 @@ class SourceMapGenerator {
         generator._sources.add(sourceRelative);
       }
 
-      const content = aSourceMapConsumer.sourceContentFor(sourceFile);
+      const content = aSourceMapConsumer.sourceContentFor(sourceFile, true);
       if (content != null) {
         generator.setSourceContent(sourceFile, content);
       }
@@ -238,7 +238,7 @@ class SourceMapGenerator {
 
     // Copy sourcesContents of applied map.
     aSourceMapConsumer.sources.forEach(function(srcFile) {
-      const content = aSourceMapConsumer.sourceContentFor(srcFile);
+      const content = aSourceMapConsumer.sourceContentFor(srcFile, true);
       if (content != null) {
         if (aSourceMapPath != null) {
           srcFile = util.join(aSourceMapPath, srcFile);

--- a/lib/source-node.js
+++ b/lib/source-node.js
@@ -137,7 +137,7 @@ class SourceNode {
 
     // Copy sourcesContent into SourceNode
     aSourceMapConsumer.sources.forEach(function(sourceFile) {
-      const content = aSourceMapConsumer.sourceContentFor(sourceFile);
+      const content = aSourceMapConsumer.sourceContentFor(sourceFile, true);
       if (content != null) {
         if (aRelativePath != null) {
           sourceFile = util.join(aRelativePath, sourceFile);


### PR DESCRIPTION
when `sourceContentFor(aSource, nullOnMissing=false)` shouldn't this situation (see patch/diff) also throw an exception? In the other situation, where this API might also produce a NULL return, an exception *is* thrown instead, so this looks to me like the more consistent behaviour.

I.e. one flow path does return NULL, while the other choses NULL or exception, depending on this `nullOrMissing` parameter. Which seems odd, at least to me.

