### PR TITLE
Off by one(1) error in column addressing: fixing `originalPositionFor()` API for indexed maps + added test adapted from the 0.6.x dev tree

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -785,8 +785,7 @@ class IndexedSourceMapConsumer extends SourceMapConsumer {
           return cmp;
         }
 
-        return (aNeedle.generatedColumn -
-                section.generatedOffset.generatedColumn);
+        return aNeedle.generatedColumn - (section.generatedOffset.generatedColumn - 1);
       });
     const section = this._sections[sectionIndex];
 

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -527,7 +527,11 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
    */
   sourceContentFor(aSource, nullOnMissing) {
     if (!this.sourcesContent) {
-      return null;
+      if (nullOnMissing) {
+        return null;
+      }
+
+      throw new Error('"' + aSource + '" is not in the SourceMap.');
     }
 
     const index = this._findSourceIndex(aSource);

--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -79,7 +79,7 @@ class SourceMapGenerator {
         generator._sources.add(sourceRelative);
       }
 
-      const content = aSourceMapConsumer.sourceContentFor(sourceFile);
+      const content = aSourceMapConsumer.sourceContentFor(sourceFile, true);
       if (content != null) {
         generator.setSourceContent(sourceFile, content);
       }
@@ -238,7 +238,7 @@ class SourceMapGenerator {
 
     // Copy sourcesContents of applied map.
     aSourceMapConsumer.sources.forEach(function(srcFile) {
-      const content = aSourceMapConsumer.sourceContentFor(srcFile);
+      const content = aSourceMapConsumer.sourceContentFor(srcFile, true);
       if (content != null) {
         if (aSourceMapPath != null) {
           srcFile = util.join(aSourceMapPath, srcFile);

--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -71,7 +71,7 @@ class SourceMapGenerator {
     });
     aSourceMapConsumer.sources.forEach(function(sourceFile) {
       let sourceRelative = sourceFile;
-      if (sourceRoot !== null) {
+      if (sourceRoot != null) {
         sourceRelative = util.relative(sourceRoot, sourceFile);
       }
 

--- a/lib/source-node.js
+++ b/lib/source-node.js
@@ -137,7 +137,7 @@ class SourceNode {
 
     // Copy sourcesContent into SourceNode
     aSourceMapConsumer.sources.forEach(function(sourceFile) {
-      const content = aSourceMapConsumer.sourceContentFor(sourceFile);
+      const content = aSourceMapConsumer.sourceContentFor(sourceFile, true);
       if (content != null) {
         if (aRelativePath != null) {
           sourceFile = util.join(aRelativePath, sourceFile);

--- a/test/test-source-map-consumer.js
+++ b/test/test-source-map-consumer.js
@@ -95,7 +95,6 @@ exports["test that the source root is reflected in a mapping's source field"] = 
   assert.equal(mapping.source, "/the/root/one.js");
   map.destroy();
 
-
   map = await new SourceMapConsumer(util.testMapNoSourceRoot);
 
   mapping = map.originalPositionFor({
@@ -110,7 +109,6 @@ exports["test that the source root is reflected in a mapping's source field"] = 
   });
   assert.equal(mapping.source, "one.js");
   map.destroy();
-
 
   map = await new SourceMapConsumer(util.testMapEmptySourceRoot);
 
@@ -583,7 +581,6 @@ exports["test sourceRoot + generatedPositionFor"] = async function(assert) {
     source: "bang.coffee"
   });
 
-
   map = await new SourceMapConsumer(map.toString(), "http://example.com/");
 
   // Should handle without sourceRoot.
@@ -688,6 +685,110 @@ exports["test index map + generatedPositionFor"] = async function(assert) {
   assert.equal(pos.line, 1);
   assert.equal(pos.column, 71);
   assert.equal(pos.lastColumn, 77);
+
+  map.destroy();
+};
+
+exports["test index map + originalPositionFor"] = async function(assert) {
+  console.warn("=================================");
+  var map = await new SourceMapConsumer(
+    util.indexedTestMapWithMappingsAtSectionStart
+  );
+  assert.ok(map instanceof IndexedSourceMapConsumer);
+
+  map.eachMapping(function(m) {
+    console.warn("mapping:", m);
+  });
+
+  map.sources.forEach(function(s, d) {
+    console.warn("section:", d, s);
+  });
+
+  for (let l = 0; l <= 2; l++) {
+    for (let c = 0; c < 6; c++) {
+      let pos = map.originalPositionFor({
+        line: l,
+        column: c
+      });
+      console.warn("originalPositionFor:", {
+        line: l,
+        column: c,
+        rv: pos
+      });
+    }
+  }
+
+  var gen = SourceMapGenerator.fromSourceMap(map);
+  var smStr = JSON.stringify(gen.toJSON(), null, 2);
+  console.warn("generated sourcemap:", smStr);
+  map.destroy();
+
+  console.warn("-----------------------------------");
+  map = await new SourceMapConsumer(smStr);
+  assert.ok(!(map instanceof IndexedSourceMapConsumer));
+
+  map.eachMapping(function(m) {
+    console.warn("mapping:", m);
+  });
+
+  map.sources.forEach(function(s, d) {
+    console.warn("section:", d, s);
+  });
+
+  for (let l = 1; l <= 2; l++) {
+    for (let c = 0; c < 6; c++) {
+      let pos = map.originalPositionFor({
+        line: l,
+        column: c
+      });
+      console.warn("originalPositionFor:", {
+        line: l,
+        column: c,
+        rv: pos
+      });
+    }
+  }
+
+
+  var pos = map.originalPositionFor({
+    line: 1,
+    column: 0
+  });
+
+  //  assert.equal(pos.line, 1);
+  //  assert.equal(pos.column, 0);
+  //  assert.equal(pos.source, "foo.js");
+  //  assert.equal(pos.name, "first");
+
+  pos = map.originalPositionFor({
+    line: 1,
+    column: 1
+  });
+
+  assert.equal(pos.line, 2);
+  assert.equal(pos.column, 1);
+  assert.equal(pos.source, "bar.js");
+  assert.equal(pos.name, "second");
+
+  pos = map.originalPositionFor({
+    line: 1,
+    column: 2
+  });
+
+  //  assert.equal(pos.line, 1);
+  //  assert.equal(pos.column, 0);
+  //  assert.equal(pos.source, "baz.js");
+  //  assert.equal(pos.name, "third");
+
+  pos = map.originalPositionFor({
+    line: 1,
+    column: 3
+  });
+
+  assert.equal(pos.line, 2);
+  assert.equal(pos.column, 1);
+  assert.equal(pos.source, "quux.js");
+  assert.equal(pos.name, "fourth");
 
   map.destroy();
 };

--- a/test/test-source-map-consumer.js
+++ b/test/test-source-map-consumer.js
@@ -690,75 +690,20 @@ exports["test index map + generatedPositionFor"] = async function(assert) {
 };
 
 exports["test index map + originalPositionFor"] = async function(assert) {
-  console.warn("=================================");
   var map = await new SourceMapConsumer(
     util.indexedTestMapWithMappingsAtSectionStart
   );
   assert.ok(map instanceof IndexedSourceMapConsumer);
-
-  map.eachMapping(function(m) {
-    console.warn("mapping:", m);
-  });
-
-  map.sources.forEach(function(s, d) {
-    console.warn("section:", d, s);
-  });
-
-  for (let l = 0; l <= 2; l++) {
-    for (let c = 0; c < 6; c++) {
-      let pos = map.originalPositionFor({
-        line: l,
-        column: c
-      });
-      console.warn("originalPositionFor:", {
-        line: l,
-        column: c,
-        rv: pos
-      });
-    }
-  }
-
-  var gen = SourceMapGenerator.fromSourceMap(map);
-  var smStr = JSON.stringify(gen.toJSON(), null, 2);
-  console.warn("generated sourcemap:", smStr);
-  map.destroy();
-
-  console.warn("-----------------------------------");
-  map = await new SourceMapConsumer(smStr);
-  assert.ok(!(map instanceof IndexedSourceMapConsumer));
-
-  map.eachMapping(function(m) {
-    console.warn("mapping:", m);
-  });
-
-  map.sources.forEach(function(s, d) {
-    console.warn("section:", d, s);
-  });
-
-  for (let l = 1; l <= 2; l++) {
-    for (let c = 0; c < 6; c++) {
-      let pos = map.originalPositionFor({
-        line: l,
-        column: c
-      });
-      console.warn("originalPositionFor:", {
-        line: l,
-        column: c,
-        rv: pos
-      });
-    }
-  }
-
 
   var pos = map.originalPositionFor({
     line: 1,
     column: 0
   });
 
-  //  assert.equal(pos.line, 1);
-  //  assert.equal(pos.column, 0);
-  //  assert.equal(pos.source, "foo.js");
-  //  assert.equal(pos.name, "first");
+  assert.equal(pos.line, 1);
+  assert.equal(pos.column, 0);
+  assert.equal(pos.source, "foo.js");
+  assert.equal(pos.name, "first");
 
   pos = map.originalPositionFor({
     line: 1,
@@ -775,10 +720,10 @@ exports["test index map + originalPositionFor"] = async function(assert) {
     column: 2
   });
 
-  //  assert.equal(pos.line, 1);
-  //  assert.equal(pos.column, 0);
-  //  assert.equal(pos.source, "baz.js");
-  //  assert.equal(pos.name, "third");
+  assert.equal(pos.line, 1);
+  assert.equal(pos.column, 0);
+  assert.equal(pos.source, "baz.js");
+  assert.equal(pos.name, "third");
 
   pos = map.originalPositionFor({
     line: 1,

--- a/test/util.js
+++ b/test/util.js
@@ -265,6 +265,29 @@ exports.indexedTestMapColumnOffset = {
     }
   ]
 };
+exports.indexedTestMapWithMappingsAtSectionStart = {
+  version: 3,
+  sections: [
+    {
+      offset: { line: 0, column: 0 },
+      map: {
+        version: 3,
+        names: ["first", "second"],
+        sources: ["foo.js", "bar.js"],
+        mappings: "AAAAA,CCCCC"
+      }
+    },
+    {
+      offset: { line: 0, column: 2 },
+      map: {
+        version: 3,
+        names: ["third", "fourth"],
+        sources: ["baz.js", "quux.js"],
+        mappings: "AAAAA,CCCCC"
+      }
+    }
+  ]
+};
 exports.testMapWithSourcesContent = {
   version: 3,
   file: "min.js",


### PR DESCRIPTION
The main work was done in SHA-1: 88efe6141cbf73c11170eba9e8696c7931554f6f

* fixing `originalPositionFor()` API for indexed maps + added test adapted from the 0.6.x dev tree: it turned out that due an off-by-1 error in the column value, half of the mapping nodes weren't hit by the `originalPositionFor()` internal search code, while it *should* find those.

The added tests are augmented with extra logging for diagnosis: run those tests with & without the given patch to observe the bug & change.

---

Before this pullreq, the 0.7.x/0.8.x did not test this situation; I ran into trouble with indexed maps crashing and acting crazy. The added test ensures there's no regression.

**WARNING / NOTE**: this pullreq includes #394 and #398 as required prerequisites: without those, this won't fly, as the crashes/failures in the test set will simply move to other spots in the code.
Hence this is more complex issue as #394 and #398 must be fixed before this one can work.

See the commit log for this one: patch-3 = #394 and patch-7 = #398 which are visible below as `git merge` commits.
