### PR TITLE
TypeScript: MappingItem.source can be null

### DIFF
--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -58,7 +58,7 @@ export interface NullableMappedPosition {
 }
 
 export interface MappingItem {
-  source: string;
+  source: string | null;
   generatedLine: number;
   generatedColumn: number;
   lastGeneratedColumn: number | null;


### PR DESCRIPTION
There is a check in the code
```
 this._wasm.withMappingCallback(
      mapping => {
        if (mapping.source !== null) {
          mapping.source = this._absoluteSources.at(mapping.source);

          if (mapping.name !== null) {
            mapping.name = this._names.at(mapping.name);
          }
        }
        if (this._computedColumnSpans && mapping.lastGeneratedColumn === null) {
          mapping.lastGeneratedColumn = Infinity;
        }

        aCallback.call(context, mapping);
      },
```
therefore `source` can be `null`

create-react-app main.*.chunk,js.map contains null source