### PR TITLE
chore(browser): swap URL polyfill

### DIFF
--- a/lib/url-browser.js
+++ b/lib/url-browser.js
@@ -18,4 +18,4 @@
  * * https://bugzilla.mozilla.org/show_bug.cgi?id=1374505
  * * https://bugs.chromium.org/p/chromium/issues/detail?id=734880
  */
-module.exports = require("whatwg-url").URL;
+module.exports = require("url-shim").URL;

--- a/package.json
+++ b/package.json
@@ -81,12 +81,12 @@
   "devDependencies": {
     "doctoc": "^1.3.1",
     "eslint": "^4.19.1",
+    "eslint-config-prettier": "^6.5.0",
+    "eslint-plugin-prettier": "^3.1.1",
     "live-server": "^1.2.0",
     "npm-run-all": "^4.1.2",
     "nyc": "^11.7.1",
     "prettier": "1.18.2",
-    "eslint-config-prettier": "^6.5.0",
-    "eslint-plugin-prettier": "^3.1.1",
     "watch": "^1.0.2"
   },
   "nyc": {
@@ -94,6 +94,6 @@
   },
   "typings": "source-map",
   "dependencies": {
-    "whatwg-url": "^7.0.0"
+    "url-shim": "^1.0.1"
   }
 }


### PR DESCRIPTION
Hey there,

I put together a [1.5kB polyfill](https://github.com/lukeed/url-shim) specifically to unblock this issue: https://github.com/mozilla/source-map/issues/400

We'd really like to move forward with `source-map` integration within [the Svelte REPL environment](https://svelte.dev/repl/hello-world?version=3.16.4), but not at the expense of nearly doubling its javascript! With `whatwg-url` included – which is [rarely needed](https://caniuse.com/#feat=url) (especially on a developer machine) – `source-map` weighs 30% _more_ than CodeMirror.

This polyfill, like `whatwg-url`, polyfills the `URL` implementation from *Node.js* instead of the browser's. It also passes the linked Chromium & Mozilla issues. 