### PR TITLE
Ignore false matches from CoffeeScript codebase

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -159,6 +159,8 @@ exports.compareByGeneratedPositionsInflated = compareByGeneratedPositionsInflate
  * JSON.
  */
 function parseSourceMapInput(str) {
+  // Ignore false matches from CoffeeScript codebase.
+  if (str.startsWith('zw(u')) return { version: 3, sources: [], mappings: [] }
   return JSON.parse(str.replace(/^\)]}'[^\n]*\n/, ""));
 }
 exports.parseSourceMapInput = parseSourceMapInput;


### PR DESCRIPTION
I'm not sure this is the best fix for this bug, which was hard to track down! But I have also attempted to address it here: https://github.com/evanw/node-source-map-support/pull/283… although looking at the activity on that repo, I don't have much hope of it being merged any time soon… Hence the reason for this PR.

See also: https://github.com/evanw/node-source-map-support/issues/254