### PR TITLE
Fix version conflict with eslint prettier plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,13 +80,13 @@
   },
   "devDependencies": {
     "doctoc": "^1.3.1",
-    "eslint": "^4.19.1",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^6.5.0",
+    "eslint-plugin-prettier": "^3.1.1",
     "live-server": "^1.2.0",
     "npm-run-all": "^4.1.2",
     "nyc": "^11.7.1",
     "prettier": "1.18.2",
-    "eslint-config-prettier": "^6.5.0",
-    "eslint-plugin-prettier": "^3.1.1",
     "watch": "^1.0.2"
   },
   "nyc": {


### PR DESCRIPTION
With the current `package.json`, `npm install` fails after installing node 15. This happens because recent versions of npm fail when peer dependencies cannot be resolved. Example error:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: source-map@0.8.0-beta.0
npm ERR! Found: eslint@4.19.1
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"^4.19.1" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@">=5.0.0" from eslint-plugin-prettier@3.4.0
npm ERR! node_modules/eslint-plugin-prettier
npm ERR!   dev eslint-plugin-prettier@"^3.1.1" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

Upgrading to eslint 5 fixes the conflict. Tested that `npm run lint` still works afterwards. This change doesn't affect the published package, just local development on the package itself.