### PR TITLE
Add function to SourceMapConsumer TS interface

### DIFF
--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -79,7 +79,23 @@ export interface CodeWithSourceMap {
   map: SourceMapGenerator;
 }
 
+export interface SourceMappings {
+  "lib/mappings.wasm": SourceMapUrl | ArrayBuffer;
+}
+
 export interface SourceMapConsumer {
+  /**
+   * When using SourceMapConsumer outside of node.js, for example on the Web, it
+   * needs to know from what URL to load lib/mappings.wasm. You must inform it
+   * by calling initialize before constructing any SourceMapConsumers.
+   *
+   * @param mappings an object with the following property:
+   *   - "lib/mappings.wasm": A String containing the URL of the
+   *     lib/mappings.wasm file, or an ArrayBuffer with the contents of
+   *     lib/mappings.wasm.
+   */
+  initialize(mappings: SourceMappings): void;
+
   /**
    * Compute the last column for each generated mapping. The last column is
    * inclusive.


### PR DESCRIPTION
This adds the `initialize(opts)` function (defined on [`source-map-consumer.js`][1])
to the typescript interface for `SourceMapConsumer`.

Fixes: #423

[1]: https://github.com/andersonvom/source-map/blob/07657671/lib/source-map-consumer.js#L29-L31