### PR TITLE
Fix `package.json#typings` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "nyc": {
     "reporter": "html"
   },
-  "typings": "source-map",
+  "typings": "source-map.d.ts",
   "dependencies": {
     "whatwg-url": "^7.0.0"
   }


### PR DESCRIPTION
Fixes: https://stackoverflow.com/questions/63124462/how-to-fix-file-node-modules-dotenv-types-not-found-error-coming-from-j