### PR TITLE
Include types file extension in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "nyc": {
     "reporter": "html"
   },
-  "typings": "source-map",
+  "typings": "source-map.d.ts",
   "dependencies": {
     "whatwg-url": "^7.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
   "nyc": {
     "reporter": "html"
   },
-  "typings": "source-map.d.ts",
   "dependencies": {
     "whatwg-url": "^7.0.0"
   }


### PR DESCRIPTION
Otherwise, the TypeScript language service used in VS Code (and other editors) won't pick up the types.