### PR TITLE
fix(types): fix sourceContent type to match spec

### DIFF
--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -17,7 +17,7 @@ export interface RawSourceMap {
   sources: string[];
   names: string[];
   sourceRoot?: string;
-  sourcesContent?: string[];
+  sourcesContent?: Array<string | null>;
   mappings: string;
   file: string;
 }


### PR DESCRIPTION
the source map rev 3 spec allows `sourceContent` to have null entries:

>  “null” may be used if some original sources should be retrieved by name.

https://sourcemaps.info/spec.html