### PR TITLE
Skip updating coveralls.io coverage

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,4 @@ jobs:
       - run: npm install --legacy-peer-deps
       - run: npm run lint
       - run: npm run coverage
-      - run: npx nyc report --reporter=text-lcov > coverage/lcov.info
-      - uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: npx nyc report --reporter=text

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Source Map
 
-[![Coverage Status](https://coveralls.io/repos/github/mozilla/source-map/badge.svg)](https://coveralls.io/github/mozilla/source-map)
-
 [![NPM](https://nodei.co/npm/source-map.png?downloads=true&downloadRank=true)](https://www.npmjs.com/package/source-map)
 
 This is a library to generate and consume the source map format


### PR DESCRIPTION
The action for reporting code coverage to coveralls.io isn't whitelisted in the `mozilla` GitHub org, so let's disable it for now to get the CI tests to run.