### PR TITLE
Adopt & enforce the mozilla-central Prettier config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,18 +3,18 @@
 module.exports = {
   env: {
     node: true,
-    es6: true
+    es6: true,
   },
 
   extends: ["prettier"],
 
   parserOptions: {
-    ecmaVersion: 9
+    ecmaVersion: 9,
   },
 
   globals: {
     fetch: false,
-    WebAssembly: false
+    WebAssembly: false,
   },
 
   rules: {
@@ -142,9 +142,9 @@ module.exports = {
           ArrayExpression: true,
           AssignmentExpression: true,
           ObjectExpression: true,
-          VariableDeclarator: true
-        }
-      }
+          VariableDeclarator: true,
+        },
+      },
     ],
 
     // No reassigning native JS objects
@@ -215,8 +215,8 @@ module.exports = {
       "error",
       {
         args: "none",
-        vars: "local"
-      }
+        vars: "local",
+      },
     ],
 
     // No using variables before defined
@@ -256,6 +256,6 @@ module.exports = {
     // Only check typeof against valid results
     "valid-typeof": "error",
 
-    "max-len": ["error", { code: 120, ignoreUrls: true }]
-  }
+    "max-len": ["error", { code: 120, ignoreUrls: true }],
+  },
 };

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -8,8 +8,8 @@ on:
 name: WASM tests
 
 defaults:
- run:
-  working-directory: ./wasm-mappings
+  run:
+    working-directory: ./wasm-mappings
 
 jobs:
   build_and_test:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,5 +31,6 @@ jobs:
       - uses: actions/setup-node@v3
       - run: npm install --legacy-peer-deps
       - run: npm run lint
+      - run: npx prettier --check .
       - run: npm run coverage
       - run: npx nyc report --reporter=text

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+.nyc_output/
+bench/
+coverage/
+node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "arrowParens": "avoid",
+  "endOfLine": "lf",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/.waiting.html
+++ b/.waiting.html
@@ -1,21 +1,23 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>Code coverage report for All files</title>
-  <style>
-body {
-    font-family: Helvetica Neue, Helvetica, Arial;
-    font-size: 20px;
-    color:#333;
-    margin: 50px;
-}
-code {
-  color: green;
-}
-  </style>
-</head>
-<body>
-  <div>This page will refresh with a coverage report, as long as you have
-    executed <code>npm run dev</code>.  Please be patient.</div>
-</body>
+  <head>
+    <title>Code coverage report for All files</title>
+    <style>
+      body {
+        font-family: Helvetica Neue, Helvetica, Arial;
+        font-size: 20px;
+        color: #333;
+        margin: 50px;
+      }
+      code {
+        color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      This page will refresh with a coverage report, as long as you have
+      executed <code>npm run dev</code>. Please be patient.
+    </div>
+  </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ This is a library to generate and consume the source map format
 ```html
 <script src="https://unpkg.com/source-map@0.7.3/dist/source-map.js"></script>
 <script>
-    sourceMap.SourceMapConsumer.initialize({
-        "lib/mappings.wasm": "https://unpkg.com/source-map@0.7.3/lib/mappings.wasm"
-    });
+  sourceMap.SourceMapConsumer.initialize({
+    "lib/mappings.wasm": "https://unpkg.com/source-map@0.7.3/lib/mappings.wasm",
+  });
 </script>
 ```
+
 ---
 
 <!-- `npm run toc` to regenerate the Table of Contents -->
@@ -81,7 +82,8 @@ const rawSourceMap = {
   names: ["bar", "baz", "n"],
   sources: ["one.js", "two.js"],
   sourceRoot: "http://example.com/www/js/",
-  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
+  mappings:
+    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA",
 };
 
 const whatever = await SourceMapConsumer.with(rawSourceMap, null, consumer => {
@@ -92,7 +94,7 @@ const whatever = await SourceMapConsumer.with(rawSourceMap, null, consumer => {
   console.log(
     consumer.originalPositionFor({
       line: 2,
-      column: 28
+      column: 28,
     })
   );
   // { source: 'http://example.com/www/js/two.js',
@@ -104,12 +106,12 @@ const whatever = await SourceMapConsumer.with(rawSourceMap, null, consumer => {
     consumer.generatedPositionFor({
       source: "http://example.com/www/js/two.js",
       line: 2,
-      column: 10
+      column: 10,
     })
   );
   // { line: 2, column: 28 }
 
-  consumer.eachMapping(function(m) {
+  consumer.eachMapping(function (m) {
     // ...
   });
 
@@ -128,13 +130,19 @@ In depth guide:
 function compile(ast) {
   switch (ast.type) {
     case "BinaryExpression":
-      return new SourceNode(ast.location.line, ast.location.column, ast.location.source, [
-        compile(ast.left),
-        " + ",
-        compile(ast.right)
-      ]);
+      return new SourceNode(
+        ast.location.line,
+        ast.location.column,
+        ast.location.source,
+        [compile(ast.left), " + ", compile(ast.right)]
+      );
     case "Literal":
-      return new SourceNode(ast.location.line, ast.location.column, ast.location.source, String(ast.value));
+      return new SourceNode(
+        ast.location.line,
+        ast.location.column,
+        ast.location.source,
+        String(ast.value)
+      );
     // ...
     default:
       throw new Error("Bad AST");
@@ -144,7 +152,7 @@ function compile(ast) {
 var ast = parse("40 + 2", "add.js");
 console.log(
   compile(ast).toStringWithSourceMap({
-    file: "add.js"
+    file: "add.js",
   })
 );
 // { code: '40 + 2',
@@ -155,20 +163,20 @@ console.log(
 
 ```js
 var map = new SourceMapGenerator({
-  file: "source-mapped.js"
+  file: "source-mapped.js",
 });
 
 map.addMapping({
   generated: {
     line: 10,
-    column: 35
+    column: 35,
   },
   source: "foo.js",
   original: {
     line: 33,
-    column: 2
+    column: 2,
   },
-  name: "christopher"
+  name: "christopher",
 });
 
 console.log(map.toString());
@@ -209,7 +217,7 @@ The options object has the following properties:
 
 ```js
 sourceMap.SourceMapConsumer.initialize({
-  "lib/mappings.wasm": "https://example.com/source-map/lib/mappings.wasm"
+  "lib/mappings.wasm": "https://example.com/source-map/lib/mappings.wasm",
 });
 ```
 
@@ -261,13 +269,17 @@ By using `with`, you do not have to remember to manually call `destroy` on
 the consumer, since it will be called automatically once `f` completes.
 
 ```js
-const xSquared = await SourceMapConsumer.with(myRawSourceMap, null, async function(consumer) {
-  // Use `consumer` inside here and don't worry about remembering
-  // to call `destroy`.
+const xSquared = await SourceMapConsumer.with(
+  myRawSourceMap,
+  null,
+  async function (consumer) {
+    // Use `consumer` inside here and don't worry about remembering
+    // to call `destroy`.
 
-  const x = await whatever(consumer);
-  return x * x;
-});
+    const x = await whatever(consumer);
+    return x * x;
+  }
+);
 
 // You may not use that `consumer` anymore out here; it has
 // been destroyed. But you can use `xSquared`.
@@ -357,7 +369,7 @@ consumer.originalPositionFor({ line: 2, column: 10 });
 
 consumer.originalPositionFor({
   line: 99999999999999999,
-  column: 999999999999999
+  column: 999999999999999,
 });
 // { source: null,
 //   line: null,
@@ -490,7 +502,7 @@ generated line/column in this source map.
   `SourceMapConsumer.GENERATED_ORDER`.
 
 ```js
-consumer.eachMapping(function(m) {
+consumer.eachMapping(function (m) {
   console.log(m);
 });
 // ...
@@ -531,7 +543,7 @@ You may pass an object with the following properties:
 ```js
 var generator = new sourceMap.SourceMapGenerator({
   file: "my-generated-javascript-file.js",
-  sourceRoot: "http://example.com/app/js/"
+  sourceRoot: "http://example.com/app/js/",
 });
 ```
 
@@ -563,7 +575,7 @@ should have the following properties:
 generator.addMapping({
   source: "module-one.scm",
   original: { line: 128, column: 0 },
-  generated: { line: 3, column: 456 }
+  generated: { line: 3, column: 456 },
 });
 ```
 
@@ -576,7 +588,10 @@ Set the source content for an original source file.
 - `sourceContent` the content of the source file.
 
 ```js
-generator.setSourceContent("module-one.scm", fs.readFileSync("path/to/module-one.scm"));
+generator.setSourceContent(
+  "module-one.scm",
+  fs.readFileSync("path/to/module-one.scm")
+);
 ```
 
 #### SourceMapGenerator.prototype.applySourceMap(sourceMapConsumer[, sourceFile[, sourceMapPath]])
@@ -640,7 +655,7 @@ use before outputting the generated JS and source map.
 var node = new SourceNode(1, 2, "a.cpp", [
   new SourceNode(3, 4, "b.cpp", "extern int status;\n"),
   new SourceNode(5, 6, "c.cpp", "std::string* make_string(size_t n);\n"),
-  new SourceNode(7, 8, "d.cpp", "int main(int argc, char** argv) {}\n")
+  new SourceNode(7, 8, "d.cpp", "int main(int argc, char** argv) {}\n"),
 ]);
 ```
 
@@ -656,8 +671,13 @@ Creates a SourceNode from generated code and a SourceMapConsumer.
   should be relative to.
 
 ```js
-const consumer = await new SourceMapConsumer(fs.readFileSync("path/to/my-file.js.map", "utf8"));
-const node = SourceNode.fromStringWithSourceMap(fs.readFileSync("path/to/my-file.js"), consumer);
+const consumer = await new SourceMapConsumer(
+  fs.readFileSync("path/to/my-file.js.map", "utf8")
+);
+const node = SourceNode.fromStringWithSourceMap(
+  fs.readFileSync("path/to/my-file.js"),
+  consumer
+);
 ```
 
 #### SourceNode.prototype.add(chunk)
@@ -694,7 +714,10 @@ Set the source content for a source file. This will be added to the
 - `sourceContent`: The content of the source file
 
 ```js
-node.setSourceContent("module-one.scm", fs.readFileSync("path/to/module-one.scm"));
+node.setSourceContent(
+  "module-one.scm",
+  fs.readFileSync("path/to/module-one.scm")
+);
 ```
 
 #### SourceNode.prototype.walk(fn)
@@ -709,10 +732,10 @@ the its original associated source's line/column location.
 var node = new SourceNode(1, 2, "a.js", [
   new SourceNode(3, 4, "b.js", "uno"),
   "dos",
-  ["tres", new SourceNode(5, 6, "c.js", "quatro")]
+  ["tres", new SourceNode(5, 6, "c.js", "quatro")],
 ]);
 
-node.walk(function(code, loc) {
+node.walk(function (code, loc) {
   console.log("WALK:", code, loc);
 });
 // WALK: uno { source: 'b.js', line: 3, column: 4, name: null }
@@ -737,7 +760,7 @@ var c = new SourceNode(1, 2, "c.js", "generated from c");
 c.setSourceContent("c.js", "original c");
 
 var node = new SourceNode(null, null, null, [a, b, c]);
-node.walkSourceContents(function(source, contents) {
+node.walkSourceContents(function (source, contents) {
   console.log("WALK:", source, ":", contents);
 });
 // WALK: a.js : original a
@@ -784,7 +807,7 @@ concatenates all the various snippets together to one string.
 var node = new SourceNode(1, 2, "a.js", [
   new SourceNode(3, 4, "b.js", "uno"),
   "dos",
-  ["tres", new SourceNode(5, 6, "c.js", "quatro")]
+  ["tres", new SourceNode(5, 6, "c.js", "quatro")],
 ]);
 
 node.toString();
@@ -803,11 +826,10 @@ The arguments are the same as those to `new SourceMapGenerator`.
 var node = new SourceNode(1, 2, "a.js", [
   new SourceNode(3, 4, "b.js", "uno"),
   "dos",
-  ["tres", new SourceNode(5, 6, "c.js", "quatro")]
+  ["tres", new SourceNode(5, 6, "c.js", "quatro")],
 ]);
 
 node.toStringWithSourceMap({ file: "my-output-file.js" });
 // { code: 'unodostresquatro',
 //   map: [object SourceMapGenerator] }
 ```
-

--- a/lib/base64.js
+++ b/lib/base64.js
@@ -5,14 +5,13 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-const intToCharMap = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split(
-  ""
-);
+const intToCharMap =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
 
 /**
  * Encode an integer in the range of 0 to 63 to a single base 64 digit.
  */
-exports.encode = function(number) {
+exports.encode = function (number) {
   if (0 <= number && number < intToCharMap.length) {
     return intToCharMap[number];
   }

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -204,7 +204,7 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
       that._sources = ArraySet.fromArray(sources, true);
 
       that._absoluteSources = ArraySet.fromArray(
-        that._sources.toArray().map(function(s) {
+        that._sources.toArray().map(function (s) {
           return util.computeSourceURL(sourceRoot, s, aSourceMapURL);
         }),
         true
@@ -406,7 +406,7 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
         mappings.push({
           line: m.generatedLine,
           column: m.generatedColumn,
-          lastColumn
+          lastColumn,
         });
       },
       () => {
@@ -470,7 +470,7 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
   originalPositionFor(aArgs) {
     const needle = {
       generatedLine: util.getArg(aArgs, "line"),
-      generatedColumn: util.getArg(aArgs, "column")
+      generatedColumn: util.getArg(aArgs, "column"),
     };
 
     if (needle.generatedLine < 1) {
@@ -519,7 +519,7 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
           source,
           line: util.getArg(mapping, "originalLine", null),
           column: util.getArg(mapping, "originalColumn", null),
-          name
+          name,
         };
       }
     }
@@ -528,7 +528,7 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
       source: null,
       line: null,
       column: null,
-      name: null
+      name: null,
     };
   }
 
@@ -542,7 +542,7 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
     }
     return (
       this.sourcesContent.length >= this._sources.size() &&
-      !this.sourcesContent.some(function(sc) {
+      !this.sourcesContent.some(function (sc) {
         return sc == null;
       })
     );
@@ -604,14 +604,14 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
       return {
         line: null,
         column: null,
-        lastColumn: null
+        lastColumn: null,
       };
     }
 
     const needle = {
       source,
       originalLine: util.getArg(aArgs, "line"),
-      originalColumn: util.getArg(aArgs, "column")
+      originalColumn: util.getArg(aArgs, "column"),
     };
 
     if (needle.originalLine < 1) {
@@ -654,7 +654,7 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
         return {
           line: util.getArg(mapping, "generatedLine", null),
           column: util.getArg(mapping, "generatedColumn", null),
-          lastColumn
+          lastColumn,
         };
       }
     }
@@ -662,7 +662,7 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
     return {
       line: null,
       column: null,
-      lastColumn: null
+      lastColumn: null,
     };
   }
 }
@@ -736,7 +736,7 @@ class IndexedSourceMapConsumer extends SourceMapConsumer {
 
       let lastOffset = {
         line: -1,
-        column: 0
+        column: 0,
       };
       return Promise.all(
         sections.map(s => {
@@ -771,9 +771,9 @@ class IndexedSourceMapConsumer extends SourceMapConsumer {
                 // The offset fields are 0-based, but we use 1-based indices when
                 // encoding/decoding from VLQ.
                 generatedLine: offsetLine + 1,
-                generatedColumn: offsetColumn + 1
+                generatedColumn: offsetColumn + 1,
               },
-              consumer
+              consumer,
             };
           });
         })
@@ -819,22 +819,26 @@ class IndexedSourceMapConsumer extends SourceMapConsumer {
   originalPositionFor(aArgs) {
     const needle = {
       generatedLine: util.getArg(aArgs, "line"),
-      generatedColumn: util.getArg(aArgs, "column")
+      generatedColumn: util.getArg(aArgs, "column"),
     };
 
     // Find the section containing the generated position we're trying to map
     // to an original position.
-    const sectionIndex = binarySearch.search(needle, this._sections, function(
-      aNeedle,
-      section
-    ) {
-      const cmp = aNeedle.generatedLine - section.generatedOffset.generatedLine;
-      if (cmp) {
-        return cmp;
-      }
+    const sectionIndex = binarySearch.search(
+      needle,
+      this._sections,
+      function (aNeedle, section) {
+        const cmp =
+          aNeedle.generatedLine - section.generatedOffset.generatedLine;
+        if (cmp) {
+          return cmp;
+        }
 
-      return aNeedle.generatedColumn - section.generatedOffset.generatedColumn;
-    });
+        return (
+          aNeedle.generatedColumn - section.generatedOffset.generatedColumn
+        );
+      }
+    );
     const section = this._sections[sectionIndex];
 
     if (!section) {
@@ -842,7 +846,7 @@ class IndexedSourceMapConsumer extends SourceMapConsumer {
         source: null,
         line: null,
         column: null,
-        name: null
+        name: null,
       };
     }
 
@@ -853,7 +857,7 @@ class IndexedSourceMapConsumer extends SourceMapConsumer {
         (section.generatedOffset.generatedLine === needle.generatedLine
           ? section.generatedOffset.generatedColumn - 1
           : 0),
-      bias: aArgs.bias
+      bias: aArgs.bias,
     });
   }
 
@@ -862,7 +866,7 @@ class IndexedSourceMapConsumer extends SourceMapConsumer {
    * map, false otherwise.
    */
   hasContentsOfAllSources() {
-    return this._sections.every(function(s) {
+    return this._sections.every(function (s) {
       return s.consumer.hasContentsOfAllSources();
     });
   }
@@ -952,7 +956,7 @@ class IndexedSourceMapConsumer extends SourceMapConsumer {
     return {
       line: null,
       column: null,
-      lastColumn: null
+      lastColumn: null,
     };
   }
 
@@ -1003,7 +1007,7 @@ class IndexedSourceMapConsumer extends SourceMapConsumer {
       const columnShift = generatedOffset.generatedColumn - 1;
 
       section.consumer.eachMapping(
-        function(mapping) {
+        function (mapping) {
           if (mapping.generatedLine === 1) {
             mapping.generatedColumn += columnShift;
 

--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -41,14 +41,14 @@ class SourceMapGenerator {
     const sourceRoot = aSourceMapConsumer.sourceRoot;
     const generator = new SourceMapGenerator({
       file: aSourceMapConsumer.file,
-      sourceRoot
+      sourceRoot,
     });
-    aSourceMapConsumer.eachMapping(function(mapping) {
+    aSourceMapConsumer.eachMapping(function (mapping) {
       const newMapping = {
         generated: {
           line: mapping.generatedLine,
-          column: mapping.generatedColumn
-        }
+          column: mapping.generatedColumn,
+        },
       };
 
       if (mapping.source != null) {
@@ -59,7 +59,7 @@ class SourceMapGenerator {
 
         newMapping.original = {
           line: mapping.originalLine,
-          column: mapping.originalColumn
+          column: mapping.originalColumn,
         };
 
         if (mapping.name != null) {
@@ -69,7 +69,7 @@ class SourceMapGenerator {
 
       generator.addMapping(newMapping);
     });
-    aSourceMapConsumer.sources.forEach(function(sourceFile) {
+    aSourceMapConsumer.sources.forEach(function (sourceFile) {
       let sourceRelative = sourceFile;
       if (sourceRoot != null) {
         sourceRelative = util.relative(sourceRoot, sourceFile);
@@ -127,7 +127,7 @@ class SourceMapGenerator {
       originalLine: original && original.line,
       originalColumn: original && original.column,
       source,
-      name
+      name,
     });
   }
 
@@ -197,12 +197,12 @@ class SourceMapGenerator {
     const newNames = new ArraySet();
 
     // Find mappings for the "sourceFile"
-    this._mappings.unsortedForEach(function(mapping) {
+    this._mappings.unsortedForEach(function (mapping) {
       if (mapping.source === sourceFile && mapping.originalLine != null) {
         // Check if it can be mapped by the source map, then update the mapping.
         const original = aSourceMapConsumer.originalPositionFor({
           line: mapping.originalLine,
-          column: mapping.originalColumn
+          column: mapping.originalColumn,
         });
         if (original.source != null) {
           // Copy mapping
@@ -235,7 +235,7 @@ class SourceMapGenerator {
     this._names = newNames;
 
     // Copy sourcesContents of applied map.
-    aSourceMapConsumer.sources.forEach(function(srcFile) {
+    aSourceMapConsumer.sources.forEach(function (srcFile) {
       const content = aSourceMapConsumer.sourceContentFor(srcFile);
       if (content != null) {
         if (aSourceMapPath != null) {
@@ -309,7 +309,7 @@ class SourceMapGenerator {
             generated: aGenerated,
             source: aSource,
             original: aOriginal,
-            name: aName
+            name: aName,
           })
       );
     }
@@ -387,7 +387,7 @@ class SourceMapGenerator {
   }
 
   _generateSourcesContent(aSources, aSourceRoot) {
-    return aSources.map(function(source) {
+    return aSources.map(function (source) {
       if (!this._sourcesContents) {
         return null;
       }
@@ -409,7 +409,7 @@ class SourceMapGenerator {
       version: this._version,
       sources: this._sources.toArray(),
       names: this._names.toArray(),
-      mappings: this._serializeMappings()
+      mappings: this._serializeMappings(),
     };
     if (this._file != null) {
       map.file = this._file;

--- a/lib/source-node.js
+++ b/lib/source-node.js
@@ -67,7 +67,7 @@ class SourceNode {
     // Processed fragments are accessed by calling `shiftNextLine`.
     const remainingLines = aGeneratedCode.split(REGEX_NEWLINE);
     let remainingLinesIndex = 0;
-    const shiftNextLine = function() {
+    const shiftNextLine = function () {
       const lineContents = getNextLine();
       // The last line of a file might not have a newline.
       const newLine = getNextLine() || "";
@@ -90,7 +90,7 @@ class SourceNode {
     let lastMapping = null;
     let nextLine;
 
-    aSourceMapConsumer.eachMapping(function(mapping) {
+    aSourceMapConsumer.eachMapping(function (mapping) {
       if (lastMapping !== null) {
         // We add the code from "lastMapping" to "mapping":
         // First check if there is a new line in between.
@@ -147,7 +147,7 @@ class SourceNode {
     }
 
     // Copy sourcesContent into SourceNode
-    aSourceMapConsumer.sources.forEach(function(sourceFile) {
+    aSourceMapConsumer.sources.forEach(function (sourceFile) {
       const content = aSourceMapConsumer.sourceContentFor(sourceFile);
       if (content != null) {
         if (aRelativePath != null) {
@@ -187,7 +187,7 @@ class SourceNode {
    */
   add(aChunk) {
     if (Array.isArray(aChunk)) {
-      aChunk.forEach(function(chunk) {
+      aChunk.forEach(function (chunk) {
         this.add(chunk);
       }, this);
     } else if (aChunk[isSourceNode] || typeof aChunk === "string") {
@@ -243,7 +243,7 @@ class SourceNode {
           source: this.source,
           line: this.line,
           column: this.column,
-          name: this.name
+          name: this.name,
         });
       }
     }
@@ -329,7 +329,7 @@ class SourceNode {
    */
   toString() {
     let str = "";
-    this.walk(function(chunk) {
+    this.walk(function (chunk) {
       str += chunk;
     });
     return str;
@@ -343,7 +343,7 @@ class SourceNode {
     const generated = {
       code: "",
       line: 1,
-      column: 0
+      column: 0,
     };
     const map = new SourceMapGenerator(aArgs);
     let sourceMappingActive = false;
@@ -351,7 +351,7 @@ class SourceNode {
     let lastOriginalLine = null;
     let lastOriginalColumn = null;
     let lastOriginalName = null;
-    this.walk(function(chunk, original) {
+    this.walk(function (chunk, original) {
       generated.code += chunk;
       if (
         original.source !== null &&
@@ -368,13 +368,13 @@ class SourceNode {
             source: original.source,
             original: {
               line: original.line,
-              column: original.column
+              column: original.column,
             },
             generated: {
               line: generated.line,
-              column: generated.column
+              column: generated.column,
             },
-            name: original.name
+            name: original.name,
           });
         }
         lastOriginalSource = original.source;
@@ -386,8 +386,8 @@ class SourceNode {
         map.addMapping({
           generated: {
             line: generated.line,
-            column: generated.column
-          }
+            column: generated.column,
+          },
         });
         lastOriginalSource = null;
         sourceMappingActive = false;
@@ -405,13 +405,13 @@ class SourceNode {
               source: original.source,
               original: {
                 line: original.line,
-                column: original.column
+                column: original.column,
               },
               generated: {
                 line: generated.line,
-                column: generated.column
+                column: generated.column,
               },
-              name: original.name
+              name: original.name,
             });
           }
         } else {
@@ -419,7 +419,7 @@ class SourceNode {
         }
       }
     });
-    this.walkSourceContents(function(sourceFile, sourceContent) {
+    this.walkSourceContents(function (sourceFile, sourceContent) {
       map.setSourceContent(sourceFile, sourceContent);
     });
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -27,7 +27,7 @@ function getArg(aArgs, aName, aDefaultValue) {
 }
 exports.getArg = getArg;
 
-const supportsNullProto = (function() {
+const supportsNullProto = (function () {
   const obj = Object.create(null);
   return !("__proto__" in obj);
 })();
@@ -151,7 +151,8 @@ function compareByGeneratedPositionsInflated(mappingA, mappingB) {
 
   return strcmp(mappingA.name, mappingB.name);
 }
-exports.compareByGeneratedPositionsInflated = compareByGeneratedPositionsInflated;
+exports.compareByGeneratedPositionsInflated =
+  compareByGeneratedPositionsInflated;
 
 /**
  * Strip any JSON XSSI avoidance prefix from the string (as documented

--- a/lib/wasm.js
+++ b/lib/wasm.js
@@ -112,8 +112,8 @@ module.exports = function wasm() {
           },
           end_sort_by_original_location() {
             console.timeEnd("sort_by_original_location");
-          }
-        }
+          },
+        },
       });
     })
     .then(Wasm => {
@@ -126,7 +126,7 @@ module.exports = function wasm() {
           } finally {
             callbackStack.pop();
           }
-        }
+        },
       };
     })
     .then(null, e => {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "dev:watch": "watch 'npm run coverage' lib/ test/",
     "predev": "npm run setup",
     "dev": "npm-run-all -p --silent dev:*",
-    "prettier": "prettier --write *.* lib/ test/",
+    "prettier": "prettier --write .",
     "clean": "rm -rf coverage .nyc_output",
     "toc": "doctoc --title '## Table of Contents' README.md && doctoc --title '## Table of Contents' CONTRIBUTING.md"
   },

--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -122,7 +122,9 @@ export interface SourceMapConsumer {
    *   - column: The column number in the original source, or null.
    *   - name: The original identifier, or null.
    */
-  originalPositionFor(generatedPosition: Position & { bias?: number }): NullableMappedPosition;
+  originalPositionFor(
+    generatedPosition: Position & { bias?: number }
+  ): NullableMappedPosition;
 
   /**
    * Returns the generated line and column information for the original source,
@@ -143,7 +145,9 @@ export interface SourceMapConsumer {
    *   - line: The line number in the generated source, or null.
    *   - column: The column number in the generated source, or null.
    */
-  generatedPositionFor(originalPosition: MappedPosition & { bias?: number }): NullablePosition;
+  generatedPositionFor(
+    originalPosition: MappedPosition & { bias?: number }
+  ): NullablePosition;
 
   /**
    * Returns all generated line and column information for the original source,
@@ -164,7 +168,9 @@ export interface SourceMapConsumer {
    *   - line: The line number in the generated source, or null.
    *   - column: The column number in the generated source, or null.
    */
-  allGeneratedPositionsFor(originalPosition: MappedPosition): NullablePosition[];
+  allGeneratedPositionsFor(
+    originalPosition: MappedPosition
+  ): NullablePosition[];
 
   /**
    * Return true if we have the source content for every source in the source
@@ -177,7 +183,10 @@ export interface SourceMapConsumer {
    * original source file. Returns null if no original source content is
    * available.
    */
-  sourceContentFor(source: string, returnNullOnMissing?: boolean): string | null;
+  sourceContentFor(
+    source: string,
+    returnNullOnMissing?: boolean
+  ): string | null;
 
   /**
    * Iterate over each mapping between an original source/line/column and a
@@ -195,7 +204,11 @@ export interface SourceMapConsumer {
    *        order or the original's source/line/column order, respectively. Defaults to
    *        `SourceMapConsumer.GENERATED_ORDER`.
    */
-  eachMapping(callback: (mapping: MappingItem) => void, context?: any, order?: number): void;
+  eachMapping(
+    callback: (mapping: MappingItem) => void,
+    context?: any,
+    order?: number
+  ): void;
   /**
    * Free this source map consumer's associated wasm data that is manually-managed.
    * Alternatively, you can use SourceMapConsumer.with to avoid needing to remember to call destroy.
@@ -211,11 +224,18 @@ export interface SourceMapConsumerConstructor {
   GREATEST_LOWER_BOUND: number;
   LEAST_UPPER_BOUND: number;
 
-  new (rawSourceMap: RawSourceMap, sourceMapUrl?: SourceMapUrl): Promise<BasicSourceMapConsumer>;
-  new (rawSourceMap: RawIndexMap, sourceMapUrl?: SourceMapUrl): Promise<IndexedSourceMapConsumer>;
-  new (rawSourceMap: RawSourceMap | RawIndexMap | string, sourceMapUrl?: SourceMapUrl): Promise<
-    BasicSourceMapConsumer | IndexedSourceMapConsumer
-  >;
+  new (
+    rawSourceMap: RawSourceMap,
+    sourceMapUrl?: SourceMapUrl
+  ): Promise<BasicSourceMapConsumer>;
+  new (
+    rawSourceMap: RawIndexMap,
+    sourceMapUrl?: SourceMapUrl
+  ): Promise<IndexedSourceMapConsumer>;
+  new (
+    rawSourceMap: RawSourceMap | RawIndexMap | string,
+    sourceMapUrl?: SourceMapUrl
+  ): Promise<BasicSourceMapConsumer | IndexedSourceMapConsumer>;
 
   /**
    * Create a BasicSourceMapConsumer from a SourceMapGenerator.
@@ -223,7 +243,10 @@ export interface SourceMapConsumerConstructor {
    * @param sourceMap
    *        The source map that will be consumed.
    */
-  fromSourceMap(sourceMap: SourceMapGenerator, sourceMapUrl?: SourceMapUrl): Promise<BasicSourceMapConsumer>;
+  fromSourceMap(
+    sourceMap: SourceMapGenerator,
+    sourceMapUrl?: SourceMapUrl
+  ): Promise<BasicSourceMapConsumer>;
 
   /**
    * Construct a new `SourceMapConsumer` from `rawSourceMap` and `sourceMapUrl`
@@ -258,7 +281,9 @@ export interface SourceMapConsumerConstructor {
   with<T>(
     rawSourceMap: RawSourceMap | RawIndexMap | string,
     sourceMapUrl: SourceMapUrl | null | undefined,
-    callback: (consumer: BasicSourceMapConsumer | IndexedSourceMapConsumer) => Promise<T> | T
+    callback: (
+      consumer: BasicSourceMapConsumer | IndexedSourceMapConsumer
+    ) => Promise<T> | T
   ): Promise<T>;
 }
 
@@ -307,7 +332,9 @@ export class SourceMapGenerator {
    *
    * @param sourceMapConsumer The SourceMap.
    */
-  static fromSourceMap(sourceMapConsumer: SourceMapConsumer): SourceMapGenerator;
+  static fromSourceMap(
+    sourceMapConsumer: SourceMapConsumer
+  ): SourceMapGenerator;
 
   /**
    * Add a single mapping from original source line and column to the generated
@@ -342,7 +369,11 @@ export class SourceMapGenerator {
    *        paths. If so, those relative source paths need to be rewritten
    *        relative to the SourceMapGenerator.
    */
-  applySourceMap(sourceMapConsumer: SourceMapConsumer, sourceFile?: string, sourceMapPath?: string): void;
+  applySourceMap(
+    sourceMapConsumer: SourceMapConsumer,
+    sourceFile?: string,
+    sourceMapPath?: string
+  ): void;
 
   toString(): string;
 
@@ -366,7 +397,11 @@ export class SourceNode {
     name?: string
   );
 
-  static fromStringWithSourceMap(code: string, sourceMapConsumer: SourceMapConsumer, relativePath?: string): SourceNode;
+  static fromStringWithSourceMap(
+    code: string,
+    sourceMapConsumer: SourceMapConsumer,
+    relativePath?: string
+  ): SourceNode;
 
   add(chunk: Array<string | SourceNode> | SourceNode | string): SourceNode;
 

--- a/source-map.js
+++ b/source-map.js
@@ -3,6 +3,8 @@
  * Licensed under the New BSD license. See LICENSE.txt or:
  * http://opensource.org/licenses/BSD-3-Clause
  */
-exports.SourceMapGenerator = require("./lib/source-map-generator").SourceMapGenerator;
-exports.SourceMapConsumer = require("./lib/source-map-consumer").SourceMapConsumer;
+exports.SourceMapGenerator =
+  require("./lib/source-map-generator").SourceMapGenerator;
+exports.SourceMapConsumer =
+  require("./lib/source-map-consumer").SourceMapConsumer;
 exports.SourceNode = require("./lib/source-node").SourceNode;

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -50,10 +50,10 @@ const requires = fs
   .map(toRelativeModule);
 
 run(
-  requires.map(require).map(function(mod, i) {
+  requires.map(require).map(function (mod, i) {
     return {
       name: requires[i],
-      testCase: mod
+      testCase: mod,
     };
   })
 ).then(

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -7,7 +7,7 @@
 
 const sourceMap = require("../source-map");
 
-exports["test that the api is properly exposed in the top level"] = function(
+exports["test that the api is properly exposed in the top level"] = function (
   assert
 ) {
   assert.equal(typeof sourceMap.SourceMapGenerator, "function");

--- a/test/test-array-set.js
+++ b/test/test-array-set.js
@@ -15,34 +15,34 @@ function makeTestSet() {
   return set;
 }
 
-exports["test .has() membership"] = function(assert) {
+exports["test .has() membership"] = function (assert) {
   const set = makeTestSet();
   for (let i = 0; i < 100; i++) {
     assert.ok(set.has(String(i)));
   }
 };
 
-exports["test .indexOf() elements"] = function(assert) {
+exports["test .indexOf() elements"] = function (assert) {
   const set = makeTestSet();
   for (let i = 0; i < 100; i++) {
     assert.strictEqual(set.indexOf(String(i)), i);
   }
 };
 
-exports["test .at() indexing"] = function(assert) {
+exports["test .at() indexing"] = function (assert) {
   const set = makeTestSet();
   for (let i = 0; i < 100; i++) {
     assert.strictEqual(set.at(i), String(i));
   }
 };
 
-exports["test creating from an array"] = function(assert) {
+exports["test creating from an array"] = function (assert) {
   const set = ArraySet.fromArray([
     "foo",
     "bar",
     "baz",
     "quux",
-    "hasOwnProperty"
+    "hasOwnProperty",
   ]);
 
   assert.ok(set.has("foo"));
@@ -62,7 +62,7 @@ exports["test creating from an array"] = function(assert) {
   assert.strictEqual(set.at(3), "quux");
 };
 
-exports["test that you can add __proto__; see github issue #30"] = function(
+exports["test that you can add __proto__; see github issue #30"] = function (
   assert
 ) {
   const set = new ArraySet();
@@ -72,7 +72,7 @@ exports["test that you can add __proto__; see github issue #30"] = function(
   assert.strictEqual(set.indexOf("__proto__"), 0);
 };
 
-exports["test .fromArray() with duplicates"] = function(assert) {
+exports["test .fromArray() with duplicates"] = function (assert) {
   let set = ArraySet.fromArray(["foo", "foo"]);
   assert.ok(set.has("foo"));
   assert.strictEqual(set.at(0), "foo");
@@ -87,7 +87,7 @@ exports["test .fromArray() with duplicates"] = function(assert) {
   assert.strictEqual(set.toArray().length, 2);
 };
 
-exports["test .add() with duplicates"] = function(assert) {
+exports["test .add() with duplicates"] = function (assert) {
   const set = new ArraySet();
   set.add("foo");
 
@@ -105,7 +105,7 @@ exports["test .add() with duplicates"] = function(assert) {
   assert.strictEqual(set.toArray().length, 2);
 };
 
-exports["test .size()"] = function(assert) {
+exports["test .size()"] = function (assert) {
   const set = new ArraySet();
   set.add("foo");
   set.add("bar");
@@ -113,7 +113,7 @@ exports["test .size()"] = function(assert) {
   assert.strictEqual(set.size(), 3);
 };
 
-exports["test .size() with disallowed duplicates"] = function(assert) {
+exports["test .size() with disallowed duplicates"] = function (assert) {
   const set = new ArraySet();
 
   set.add("foo");
@@ -128,7 +128,7 @@ exports["test .size() with disallowed duplicates"] = function(assert) {
   assert.strictEqual(set.size(), 3);
 };
 
-exports["test .size() with allowed duplicates"] = function(assert) {
+exports["test .size() with allowed duplicates"] = function (assert) {
   const set = new ArraySet();
 
   set.add("foo");

--- a/test/test-base64-vlq.js
+++ b/test/test-base64-vlq.js
@@ -514,10 +514,10 @@ const vlqs = [
   { number: 252, encoded: "4P" },
   { number: 253, encoded: "6P" },
   { number: 254, encoded: "8P" },
-  { number: 255, encoded: "+P" }
+  { number: 255, encoded: "+P" },
 ];
 
-exports["test normal encoding and decoding"] = function(assert) {
+exports["test normal encoding and decoding"] = function (assert) {
   for (let i = 0; i < vlqs.length; i++) {
     const str = base64VLQ.encode(vlqs[i].number);
     assert.equal(

--- a/test/test-base64.js
+++ b/test/test-base64.js
@@ -7,16 +7,16 @@
 
 const base64 = require("../lib/base64");
 
-exports["test out of range encoding"] = function(assert) {
-  assert.throws(function() {
+exports["test out of range encoding"] = function (assert) {
+  assert.throws(function () {
     base64.encode(-1);
   }, /Must be between 0 and 63/);
-  assert.throws(function() {
+  assert.throws(function () {
     base64.encode(64);
   }, /Must be between 0 and 63/);
 };
 
-exports["test normal encoding and decoding"] = function(assert) {
+exports["test normal encoding and decoding"] = function (assert) {
   for (let i = 0; i < 64; i++) {
     base64.encode(i);
   }

--- a/test/test-binary-search.js
+++ b/test/test-binary-search.js
@@ -11,11 +11,11 @@ function numberCompare(a, b) {
   return a - b;
 }
 
-exports["test too high with default (glb) bias"] = function(assert) {
+exports["test too high with default (glb) bias"] = function (assert) {
   const needle = 30;
   const haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
-  assert.doesNotThrow(function() {
+  assert.doesNotThrow(function () {
     binarySearch.search(needle, haystack, numberCompare);
   });
 
@@ -25,22 +25,22 @@ exports["test too high with default (glb) bias"] = function(assert) {
   );
 };
 
-exports["test too low with default (glb) bias"] = function(assert) {
+exports["test too low with default (glb) bias"] = function (assert) {
   const needle = 1;
   const haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
-  assert.doesNotThrow(function() {
+  assert.doesNotThrow(function () {
     binarySearch.search(needle, haystack, numberCompare);
   });
 
   assert.equal(binarySearch.search(needle, haystack, numberCompare), -1);
 };
 
-exports["test too high with lub bias"] = function(assert) {
+exports["test too high with lub bias"] = function (assert) {
   const needle = 30;
   const haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
-  assert.doesNotThrow(function() {
+  assert.doesNotThrow(function () {
     binarySearch.search(needle, haystack, numberCompare);
   });
 
@@ -55,11 +55,11 @@ exports["test too high with lub bias"] = function(assert) {
   );
 };
 
-exports["test too low with lub bias"] = function(assert) {
+exports["test too low with lub bias"] = function (assert) {
   const needle = 1;
   const haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
-  assert.doesNotThrow(function() {
+  assert.doesNotThrow(function () {
     binarySearch.search(needle, haystack, numberCompare);
   });
 
@@ -76,7 +76,7 @@ exports["test too low with lub bias"] = function(assert) {
   );
 };
 
-exports["test exact search"] = function(assert) {
+exports["test exact search"] = function (assert) {
   const needle = 4;
   const haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
@@ -86,7 +86,7 @@ exports["test exact search"] = function(assert) {
   );
 };
 
-exports["test fuzzy search with default (glb) bias"] = function(assert) {
+exports["test fuzzy search with default (glb) bias"] = function (assert) {
   const needle = 19;
   const haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
@@ -96,7 +96,7 @@ exports["test fuzzy search with default (glb) bias"] = function(assert) {
   );
 };
 
-exports["test fuzzy search with lub bias"] = function(assert) {
+exports["test fuzzy search with lub bias"] = function (assert) {
   const needle = 19;
   const haystack = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
 
@@ -113,7 +113,7 @@ exports["test fuzzy search with lub bias"] = function(assert) {
   );
 };
 
-exports["test multiple matches"] = function(assert) {
+exports["test multiple matches"] = function (assert) {
   const needle = 5;
   const haystack = [1, 1, 2, 5, 5, 5, 13, 21];
 
@@ -128,7 +128,7 @@ exports["test multiple matches"] = function(assert) {
   );
 };
 
-exports["test multiple matches at the beginning"] = function(assert) {
+exports["test multiple matches at the beginning"] = function (assert) {
   const needle = 1;
   const haystack = [1, 1, 2, 5, 5, 5, 13, 21];
 

--- a/test/test-dog-fooding.js
+++ b/test/test-dog-fooding.js
@@ -6,45 +6,45 @@
  */
 
 const util = require("./util");
-const SourceMapConsumer = require("../lib/source-map-consumer")
-  .SourceMapConsumer;
-const SourceMapGenerator = require("../lib/source-map-generator")
-  .SourceMapGenerator;
+const SourceMapConsumer =
+  require("../lib/source-map-consumer").SourceMapConsumer;
+const SourceMapGenerator =
+  require("../lib/source-map-generator").SourceMapGenerator;
 
-exports["test eating our own dog food"] = async function(assert) {
+exports["test eating our own dog food"] = async function (assert) {
   const smg = new SourceMapGenerator({
     file: "testing.js",
-    sourceRoot: "/wu/tang"
+    sourceRoot: "/wu/tang",
   });
 
   smg.addMapping({
     source: "gza.coffee",
     original: { line: 1, column: 0 },
-    generated: { line: 2, column: 2 }
+    generated: { line: 2, column: 2 },
   });
 
   smg.addMapping({
     source: "gza.coffee",
     original: { line: 2, column: 0 },
-    generated: { line: 3, column: 2 }
+    generated: { line: 3, column: 2 },
   });
 
   smg.addMapping({
     source: "gza.coffee",
     original: { line: 3, column: 0 },
-    generated: { line: 4, column: 2 }
+    generated: { line: 4, column: 2 },
   });
 
   smg.addMapping({
     source: "gza.coffee",
     original: { line: 4, column: 0 },
-    generated: { line: 5, column: 2 }
+    generated: { line: 5, column: 2 },
   });
 
   smg.addMapping({
     source: "gza.coffee",
     original: { line: 5, column: 10 },
-    generated: { line: 6, column: 12 }
+    generated: { line: 6, column: 12 },
   });
 
   const smc = await new SourceMapConsumer(smg.toString());

--- a/test/test-nested-consumer-usage.js
+++ b/test/test-nested-consumer-usage.js
@@ -10,8 +10,8 @@ const TS_MAP = {
     ";;AAKA;IACE,MAAM,CAAC,EAAC,MAAM,EAAE,SAAS,EAAC,CAAC;AAC7B,CAAC;AAFD,yBAEC",
   sourcesContent: [
     "\ntype Cheese = {\n  readonly cheese: string\n}\n\nexport default function Cheese(): Cheese {\n" +
-      "  return {cheese: 'stilton'};\n}\n"
-  ]
+      "  return {cheese: 'stilton'};\n}\n",
+  ],
 };
 
 const BABEL_MAP = {
@@ -24,15 +24,15 @@ const BABEL_MAP = {
     "value",
     "Cheese",
     "cheese",
-    "default"
+    "default",
   ],
   mappings:
     // eslint-disable-next-line
     "AAAA;;AACAA,OAAOC,cAAP,CAAsBC,OAAtB,EAA+B,YAA/B,EAA6C,EAAEC,OAAO,IAAT,EAA7C;AACA,SAASC,MAAT,GAAkB;AACd,WAAO,EAAEC,QAAQ,SAAV,EAAP;AACH;AACDH,QAAQI,OAAR,GAAkBF,MAAlB",
   sourcesContent: [
     '"use strict";\nObject.defineProperty(exports, "__esModule", { value: true });\nfunction Cheese() {\n' +
-      "    return { cheese: 'stilton' };\n}\nexports.default = Cheese;\n//# sourceMappingURL=blah.js.map"
-  ]
+      "    return { cheese: 'stilton' };\n}\nexports.default = Cheese;\n//# sourceMappingURL=blah.js.map",
+  ],
 };
 
 async function composeSourceMaps(tsMap, babelMap, tsFileName) {
@@ -46,25 +46,25 @@ async function composeSourceMaps(tsMap, babelMap, tsFileName) {
       generatedColumn,
       originalLine,
       originalColumn,
-      name
+      name,
     }) => {
       if (originalLine) {
         const original = tsConsumer.originalPositionFor({
           line: originalLine,
-          column: originalColumn
+          column: originalColumn,
         });
         if (original.line) {
           map.addMapping({
             generated: {
               line: generatedLine,
-              column: generatedColumn
+              column: generatedColumn,
             },
             original: {
               line: original.line,
-              column: original.column
+              column: original.column,
             },
             source: tsFileName,
-            name
+            name,
           });
         }
       }
@@ -73,6 +73,6 @@ async function composeSourceMaps(tsMap, babelMap, tsFileName) {
   return map.toJSON();
 }
 
-exports["test nested consumer usage"] = async function(assert) {
+exports["test nested consumer usage"] = async function (assert) {
   await composeSourceMaps(TS_MAP, BABEL_MAP, "blah.tsx");
 };

--- a/test/test-source-map-consumer.js
+++ b/test/test-source-map-consumer.js
@@ -6,27 +6,26 @@
  */
 
 const util = require("./util");
-const SourceMapConsumer = require("../lib/source-map-consumer")
-  .SourceMapConsumer;
-const IndexedSourceMapConsumer = require("../lib/source-map-consumer")
-  .IndexedSourceMapConsumer;
-const BasicSourceMapConsumer = require("../lib/source-map-consumer")
-  .BasicSourceMapConsumer;
-const SourceMapGenerator = require("../lib/source-map-generator")
-  .SourceMapGenerator;
+const SourceMapConsumer =
+  require("../lib/source-map-consumer").SourceMapConsumer;
+const IndexedSourceMapConsumer =
+  require("../lib/source-map-consumer").IndexedSourceMapConsumer;
+const BasicSourceMapConsumer =
+  require("../lib/source-map-consumer").BasicSourceMapConsumer;
+const SourceMapGenerator =
+  require("../lib/source-map-generator").SourceMapGenerator;
 
-exports[
-  "test that we can instantiate with a string or an object"
-] = async function(assert) {
-  let map = await new SourceMapConsumer(util.testMap);
-  map = await new SourceMapConsumer(JSON.stringify(util.testMap));
-  assert.ok(true);
-  map.destroy();
-};
+exports["test that we can instantiate with a string or an object"] =
+  async function (assert) {
+    let map = await new SourceMapConsumer(util.testMap);
+    map = await new SourceMapConsumer(JSON.stringify(util.testMap));
+    assert.ok(true);
+    map.destroy();
+  };
 
 exports[
   "test that the object returned from await new SourceMapConsumer inherits from SourceMapConsumer"
-] = async function(assert) {
+] = async function (assert) {
   const map = await new SourceMapConsumer(util.testMap);
   assert.ok(map instanceof SourceMapConsumer);
   map.destroy();
@@ -34,7 +33,7 @@ exports[
 
 exports[
   "test that a BasicSourceMapConsumer is returned for sourcemaps without sections"
-] = async function(assert) {
+] = async function (assert) {
   const map = await new SourceMapConsumer(util.testMap);
   assert.ok(map instanceof BasicSourceMapConsumer);
   map.destroy();
@@ -42,107 +41,105 @@ exports[
 
 exports[
   "test that an IndexedSourceMapConsumer is returned for sourcemaps with sections"
-] = async function(assert) {
+] = async function (assert) {
   const map = await new SourceMapConsumer(util.indexedTestMap);
   assert.ok(map instanceof IndexedSourceMapConsumer);
   map.destroy();
 };
 
-exports[
-  "test that the `sources` field has the original sources"
-] = async function(assert) {
-  let map;
-  let sources;
+exports["test that the `sources` field has the original sources"] =
+  async function (assert) {
+    let map;
+    let sources;
 
-  map = await new SourceMapConsumer(util.testMap);
-  sources = map.sources;
-  assert.equal(sources[0], "/the/root/one.js");
-  assert.equal(sources[1], "/the/root/two.js");
-  assert.equal(sources.length, 2);
-  map.destroy();
+    map = await new SourceMapConsumer(util.testMap);
+    sources = map.sources;
+    assert.equal(sources[0], "/the/root/one.js");
+    assert.equal(sources[1], "/the/root/two.js");
+    assert.equal(sources.length, 2);
+    map.destroy();
 
-  map = await new SourceMapConsumer(util.indexedTestMap);
-  sources = map.sources;
-  assert.equal(sources[0], "/the/root/one.js");
-  assert.equal(sources[1], "/the/root/two.js");
-  assert.equal(sources.length, 2);
-  map.destroy();
+    map = await new SourceMapConsumer(util.indexedTestMap);
+    sources = map.sources;
+    assert.equal(sources[0], "/the/root/one.js");
+    assert.equal(sources[1], "/the/root/two.js");
+    assert.equal(sources.length, 2);
+    map.destroy();
 
-  map = await new SourceMapConsumer(util.indexedTestMapDifferentSourceRoots);
-  sources = map.sources;
-  assert.equal(sources[0], "/the/root/one.js");
-  assert.equal(sources[1], "/different/root/two.js");
-  assert.equal(sources.length, 2);
-  map.destroy();
+    map = await new SourceMapConsumer(util.indexedTestMapDifferentSourceRoots);
+    sources = map.sources;
+    assert.equal(sources[0], "/the/root/one.js");
+    assert.equal(sources[1], "/different/root/two.js");
+    assert.equal(sources.length, 2);
+    map.destroy();
 
-  map = await new SourceMapConsumer(util.testMapNoSourceRoot);
-  sources = map.sources;
-  assert.equal(sources[0], "one.js");
-  assert.equal(sources[1], "two.js");
-  assert.equal(sources.length, 2);
-  map.destroy();
+    map = await new SourceMapConsumer(util.testMapNoSourceRoot);
+    sources = map.sources;
+    assert.equal(sources[0], "one.js");
+    assert.equal(sources[1], "two.js");
+    assert.equal(sources.length, 2);
+    map.destroy();
 
-  map = await new SourceMapConsumer(util.testMapEmptySourceRoot);
-  sources = map.sources;
-  assert.equal(sources[0], "one.js");
-  assert.equal(sources[1], "two.js");
-  assert.equal(sources.length, 2);
-  map.destroy();
-};
+    map = await new SourceMapConsumer(util.testMapEmptySourceRoot);
+    sources = map.sources;
+    assert.equal(sources[0], "one.js");
+    assert.equal(sources[1], "two.js");
+    assert.equal(sources.length, 2);
+    map.destroy();
+  };
 
-exports[
-  "test that the source root is reflected in a mapping's source field"
-] = async function(assert) {
-  let map;
-  let mapping;
+exports["test that the source root is reflected in a mapping's source field"] =
+  async function (assert) {
+    let map;
+    let mapping;
 
-  map = await new SourceMapConsumer(util.testMap);
+    map = await new SourceMapConsumer(util.testMap);
 
-  mapping = map.originalPositionFor({
-    line: 2,
-    column: 1
-  });
-  assert.equal(mapping.source, "/the/root/two.js");
+    mapping = map.originalPositionFor({
+      line: 2,
+      column: 1,
+    });
+    assert.equal(mapping.source, "/the/root/two.js");
 
-  mapping = map.originalPositionFor({
-    line: 1,
-    column: 1
-  });
-  assert.equal(mapping.source, "/the/root/one.js");
-  map.destroy();
+    mapping = map.originalPositionFor({
+      line: 1,
+      column: 1,
+    });
+    assert.equal(mapping.source, "/the/root/one.js");
+    map.destroy();
 
-  map = await new SourceMapConsumer(util.testMapNoSourceRoot);
+    map = await new SourceMapConsumer(util.testMapNoSourceRoot);
 
-  mapping = map.originalPositionFor({
-    line: 2,
-    column: 1
-  });
-  assert.equal(mapping.source, "two.js");
+    mapping = map.originalPositionFor({
+      line: 2,
+      column: 1,
+    });
+    assert.equal(mapping.source, "two.js");
 
-  mapping = map.originalPositionFor({
-    line: 1,
-    column: 1
-  });
-  assert.equal(mapping.source, "one.js");
-  map.destroy();
+    mapping = map.originalPositionFor({
+      line: 1,
+      column: 1,
+    });
+    assert.equal(mapping.source, "one.js");
+    map.destroy();
 
-  map = await new SourceMapConsumer(util.testMapEmptySourceRoot);
+    map = await new SourceMapConsumer(util.testMapEmptySourceRoot);
 
-  mapping = map.originalPositionFor({
-    line: 2,
-    column: 1
-  });
-  assert.equal(mapping.source, "two.js");
+    mapping = map.originalPositionFor({
+      line: 2,
+      column: 1,
+    });
+    assert.equal(mapping.source, "two.js");
 
-  mapping = map.originalPositionFor({
-    line: 1,
-    column: 1
-  });
-  assert.equal(mapping.source, "one.js");
-  map.destroy();
-};
+    mapping = map.originalPositionFor({
+      line: 1,
+      column: 1,
+    });
+    assert.equal(mapping.source, "one.js");
+    map.destroy();
+  };
 
-exports["test mapping tokens back exactly"] = async function(assert) {
+exports["test mapping tokens back exactly"] = async function (assert) {
   const map = await new SourceMapConsumer(util.testMap);
 
   util.assertMapping(1, 1, "/the/root/one.js", 1, 1, null, null, map, assert);
@@ -193,60 +190,119 @@ exports["test mapping tokens back exactly"] = async function(assert) {
   map.destroy();
 };
 
-exports[
-  "test mapping tokens back exactly in indexed source map"
-] = async function(assert) {
-  const map = await new SourceMapConsumer(util.indexedTestMap);
+exports["test mapping tokens back exactly in indexed source map"] =
+  async function (assert) {
+    const map = await new SourceMapConsumer(util.indexedTestMap);
 
-  util.assertMapping(1, 1, "/the/root/one.js", 1, 1, null, null, map, assert);
-  util.assertMapping(1, 5, "/the/root/one.js", 1, 5, null, null, map, assert);
-  util.assertMapping(1, 9, "/the/root/one.js", 1, 11, null, null, map, assert);
-  util.assertMapping(
-    1,
-    18,
-    "/the/root/one.js",
-    1,
-    21,
-    "bar",
-    null,
-    map,
-    assert
-  );
-  util.assertMapping(1, 21, "/the/root/one.js", 2, 3, null, null, map, assert);
-  util.assertMapping(
-    1,
-    28,
-    "/the/root/one.js",
-    2,
-    10,
-    "baz",
-    null,
-    map,
-    assert
-  );
-  util.assertMapping(
-    1,
-    32,
-    "/the/root/one.js",
-    2,
-    14,
-    "bar",
-    null,
-    map,
-    assert
-  );
+    util.assertMapping(1, 1, "/the/root/one.js", 1, 1, null, null, map, assert);
+    util.assertMapping(1, 5, "/the/root/one.js", 1, 5, null, null, map, assert);
+    util.assertMapping(
+      1,
+      9,
+      "/the/root/one.js",
+      1,
+      11,
+      null,
+      null,
+      map,
+      assert
+    );
+    util.assertMapping(
+      1,
+      18,
+      "/the/root/one.js",
+      1,
+      21,
+      "bar",
+      null,
+      map,
+      assert
+    );
+    util.assertMapping(
+      1,
+      21,
+      "/the/root/one.js",
+      2,
+      3,
+      null,
+      null,
+      map,
+      assert
+    );
+    util.assertMapping(
+      1,
+      28,
+      "/the/root/one.js",
+      2,
+      10,
+      "baz",
+      null,
+      map,
+      assert
+    );
+    util.assertMapping(
+      1,
+      32,
+      "/the/root/one.js",
+      2,
+      14,
+      "bar",
+      null,
+      map,
+      assert
+    );
 
-  util.assertMapping(2, 1, "/the/root/two.js", 1, 1, null, null, map, assert);
-  util.assertMapping(2, 5, "/the/root/two.js", 1, 5, null, null, map, assert);
-  util.assertMapping(2, 9, "/the/root/two.js", 1, 11, null, null, map, assert);
-  util.assertMapping(2, 18, "/the/root/two.js", 1, 21, "n", null, map, assert);
-  util.assertMapping(2, 21, "/the/root/two.js", 2, 3, null, null, map, assert);
-  util.assertMapping(2, 28, "/the/root/two.js", 2, 10, "n", null, map, assert);
+    util.assertMapping(2, 1, "/the/root/two.js", 1, 1, null, null, map, assert);
+    util.assertMapping(2, 5, "/the/root/two.js", 1, 5, null, null, map, assert);
+    util.assertMapping(
+      2,
+      9,
+      "/the/root/two.js",
+      1,
+      11,
+      null,
+      null,
+      map,
+      assert
+    );
+    util.assertMapping(
+      2,
+      18,
+      "/the/root/two.js",
+      1,
+      21,
+      "n",
+      null,
+      map,
+      assert
+    );
+    util.assertMapping(
+      2,
+      21,
+      "/the/root/two.js",
+      2,
+      3,
+      null,
+      null,
+      map,
+      assert
+    );
+    util.assertMapping(
+      2,
+      28,
+      "/the/root/two.js",
+      2,
+      10,
+      "n",
+      null,
+      map,
+      assert
+    );
 
-  map.destroy();
-};
+    map.destroy();
+  };
 
-exports["test mapping tokens fuzzy"] = async function(assert) {
+exports["test mapping tokens fuzzy"] = async function (assert) {
   const map = await new SourceMapConsumer(util.testMap);
 
   // Finding original positions with default (glb) bias.
@@ -410,7 +466,7 @@ exports["test mapping tokens fuzzy"] = async function(assert) {
   map.destroy();
 };
 
-exports["test mapping tokens fuzzy in indexed source map"] = async function(
+exports["test mapping tokens fuzzy in indexed source map"] = async function (
   assert
 ) {
   const map = await new SourceMapConsumer(util.indexedTestMap);
@@ -576,24 +632,24 @@ exports["test mapping tokens fuzzy in indexed source map"] = async function(
   map.destroy();
 };
 
-exports["test mappings and end of lines"] = async function(assert) {
+exports["test mappings and end of lines"] = async function (assert) {
   const smg = new SourceMapGenerator({
-    file: "foo.js"
+    file: "foo.js",
   });
   smg.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 1 },
-    source: "bar.js"
+    source: "bar.js",
   });
   smg.addMapping({
     original: { line: 2, column: 2 },
     generated: { line: 2, column: 2 },
-    source: "bar.js"
+    source: "bar.js",
   });
   smg.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 1 },
-    source: "baz.js"
+    source: "baz.js",
   });
 
   const map = await SourceMapConsumer.fromSourceMap(smg);
@@ -622,23 +678,22 @@ exports["test mappings and end of lines"] = async function(assert) {
   map.destroy();
 };
 
-exports["test creating source map consumers with )]}' prefix"] = async function(
-  assert
-) {
-  const map = await new SourceMapConsumer(
-    ")]}'\n" + JSON.stringify(util.testMap)
-  );
-  assert.ok(true);
-  map.destroy();
-};
+exports["test creating source map consumers with )]}' prefix"] =
+  async function (assert) {
+    const map = await new SourceMapConsumer(
+      ")]}'\n" + JSON.stringify(util.testMap)
+    );
+    assert.ok(true);
+    map.destroy();
+  };
 
-exports["test eachMapping"] = async function(assert) {
+exports["test eachMapping"] = async function (assert) {
   let map;
 
   map = await new SourceMapConsumer(util.testMap);
   let previousLine = -Infinity;
   let previousColumn = -Infinity;
-  map.eachMapping(function(mapping) {
+  map.eachMapping(function (mapping) {
     assert.ok(mapping.generatedLine >= previousLine);
 
     assert.ok(
@@ -657,19 +712,19 @@ exports["test eachMapping"] = async function(assert) {
   map.destroy();
 
   map = await new SourceMapConsumer(util.testMapNoSourceRoot);
-  map.eachMapping(function(mapping) {
+  map.eachMapping(function (mapping) {
     assert.ok(mapping.source === "one.js" || mapping.source === "two.js");
   });
   map.destroy();
 
   map = await new SourceMapConsumer(util.testMapEmptySourceRoot);
-  map.eachMapping(function(mapping) {
+  map.eachMapping(function (mapping) {
     assert.ok(mapping.source === "one.js" || mapping.source === "two.js");
   });
   map.destroy();
 
   map = await new SourceMapConsumer(util.mapWithSourcelessMapping);
-  map.eachMapping(function(mapping) {
+  map.eachMapping(function (mapping) {
     assert.ok(
       mapping.source === null ||
         (typeof mapping.originalColumn === "number" &&
@@ -679,14 +734,14 @@ exports["test eachMapping"] = async function(assert) {
   map.destroy();
 };
 
-exports["test eachMapping for indexed source maps"] = async function(assert) {
+exports["test eachMapping for indexed source maps"] = async function (assert) {
   const map = await new SourceMapConsumer(util.indexedTestMap);
   map.computeColumnSpans();
   let previousLine = -Infinity;
   let previousColumn = -Infinity;
   let previousLastColumn = -Infinity;
 
-  map.eachMapping(function(mapping) {
+  map.eachMapping(function (mapping) {
     assert.ok(mapping.generatedLine >= previousLine);
 
     if (mapping.source) {
@@ -710,40 +765,39 @@ exports["test eachMapping for indexed source maps"] = async function(assert) {
   map.destroy();
 };
 
-exports[
-  "test eachMapping for indexed source maps with column offsets"
-] = async function(assert) {
-  const map = await new SourceMapConsumer(util.indexedTestMapColumnOffset);
-  map.computeColumnSpans();
-  let previousLine = -Infinity;
-  let previousColumn = -Infinity;
-  let previousLastColumn = -Infinity;
+exports["test eachMapping for indexed source maps with column offsets"] =
+  async function (assert) {
+    const map = await new SourceMapConsumer(util.indexedTestMapColumnOffset);
+    map.computeColumnSpans();
+    let previousLine = -Infinity;
+    let previousColumn = -Infinity;
+    let previousLastColumn = -Infinity;
 
-  map.eachMapping(function(mapping) {
-    assert.ok(mapping.generatedLine >= previousLine);
+    map.eachMapping(function (mapping) {
+      assert.ok(mapping.generatedLine >= previousLine);
 
-    if (mapping.source) {
-      assert.equal(mapping.source.indexOf(util.testMap.sourceRoot), 0);
-    }
-
-    if (mapping.generatedLine === previousLine) {
-      assert.ok(mapping.generatedColumn >= previousColumn);
-      if (typeof previousLastColumn === "number") {
-        assert.ok(mapping.generatedColumn > previousLastColumn);
+      if (mapping.source) {
+        assert.equal(mapping.source.indexOf(util.testMap.sourceRoot), 0);
       }
-      previousColumn = mapping.generatedColumn;
-      previousLastColumn = mapping.lastGeneratedColumn;
-    } else {
-      previousLine = mapping.generatedLine;
-      previousColumn = -Infinity;
-      previousLastColumn = -Infinity;
-    }
-  });
 
-  map.destroy();
-};
+      if (mapping.generatedLine === previousLine) {
+        assert.ok(mapping.generatedColumn >= previousColumn);
+        if (typeof previousLastColumn === "number") {
+          assert.ok(mapping.generatedColumn > previousLastColumn);
+        }
+        previousColumn = mapping.generatedColumn;
+        previousLastColumn = mapping.lastGeneratedColumn;
+      } else {
+        previousLine = mapping.generatedLine;
+        previousColumn = -Infinity;
+        previousLastColumn = -Infinity;
+      }
+    });
 
-exports["test iterating over mappings in a different order"] = async function(
+    map.destroy();
+  };
+
+exports["test iterating over mappings in a different order"] = async function (
   assert
 ) {
   const map = await new SourceMapConsumer(util.testMap);
@@ -752,7 +806,7 @@ exports["test iterating over mappings in a different order"] = async function(
   let previousSource = "";
 
   map.eachMapping(
-    function(mapping) {
+    function (mapping) {
       assert.ok(mapping.source >= previousSource);
 
       if (mapping.source === previousSource) {
@@ -780,13 +834,13 @@ exports["test iterating over mappings in a different order"] = async function(
 
 exports[
   "test iterating over mappings in a different order in indexed source maps"
-] = async function(assert) {
+] = async function (assert) {
   const map = await new SourceMapConsumer(util.indexedTestMap);
   let previousLine = -Infinity;
   let previousColumn = -Infinity;
   let previousSource = "";
   map.eachMapping(
-    function(mapping) {
+    function (mapping) {
       assert.ok(mapping.source >= previousSource);
 
       if (mapping.source === previousSource) {
@@ -811,85 +865,82 @@ exports[
   map.destroy();
 };
 
-exports[
-  "test that we can set the context for `this` in eachMapping"
-] = async function(assert) {
-  const map = await new SourceMapConsumer(util.testMap);
-  const context = {};
-  map.eachMapping(function() {
-    assert.equal(this, context);
-  }, context);
-  map.destroy();
-};
+exports["test that we can set the context for `this` in eachMapping"] =
+  async function (assert) {
+    const map = await new SourceMapConsumer(util.testMap);
+    const context = {};
+    map.eachMapping(function () {
+      assert.equal(this, context);
+    }, context);
+    map.destroy();
+  };
 
 exports[
   "test that we can set the context for `this` in eachMapping in indexed source maps"
-] = async function(assert) {
+] = async function (assert) {
   const map = await new SourceMapConsumer(util.indexedTestMap);
   const context = {};
-  map.eachMapping(function() {
+  map.eachMapping(function () {
     assert.equal(this, context);
   }, context);
   map.destroy();
 };
 
-exports[
-  "test that the `sourcesContent` field has the original sources"
-] = async function(assert) {
-  const map = await new SourceMapConsumer(util.testMapWithSourcesContent);
-  const sourcesContent = map.sourcesContent;
+exports["test that the `sourcesContent` field has the original sources"] =
+  async function (assert) {
+    const map = await new SourceMapConsumer(util.testMapWithSourcesContent);
+    const sourcesContent = map.sourcesContent;
 
-  assert.equal(
-    sourcesContent[0],
-    " ONE.foo = function (bar) {\n   return baz(bar);\n };"
-  );
-  assert.equal(
-    sourcesContent[1],
-    " TWO.inc = function (n) {\n   return n + 1;\n };"
-  );
-  assert.equal(sourcesContent.length, 2);
+    assert.equal(
+      sourcesContent[0],
+      " ONE.foo = function (bar) {\n   return baz(bar);\n };"
+    );
+    assert.equal(
+      sourcesContent[1],
+      " TWO.inc = function (n) {\n   return n + 1;\n };"
+    );
+    assert.equal(sourcesContent.length, 2);
 
-  map.destroy();
-};
+    map.destroy();
+  };
 
-exports[
-  "test that we can get the original sources for the sources"
-] = async function(assert) {
-  const map = await new SourceMapConsumer(util.testMapWithSourcesContent);
-  const sources = map.sources;
+exports["test that we can get the original sources for the sources"] =
+  async function (assert) {
+    const map = await new SourceMapConsumer(util.testMapWithSourcesContent);
+    const sources = map.sources;
 
-  assert.equal(
-    map.sourceContentFor(sources[0]),
-    " ONE.foo = function (bar) {\n   return baz(bar);\n };"
-  );
-  assert.equal(
-    map.sourceContentFor(sources[1]),
-    " TWO.inc = function (n) {\n   return n + 1;\n };"
-  );
-  assert.equal(
-    map.sourceContentFor("one.js"),
-    " ONE.foo = function (bar) {\n   return baz(bar);\n };"
-  );
-  assert.equal(
-    map.sourceContentFor("two.js"),
-    " TWO.inc = function (n) {\n   return n + 1;\n };"
-  );
-  assert.throws(function() {
-    map.sourceContentFor("");
-  }, Error);
-  assert.throws(function() {
-    map.sourceContentFor("/the/root/three.js");
-  }, Error);
-  assert.throws(function() {
-    map.sourceContentFor("three.js");
-  }, Error);
+    assert.equal(
+      map.sourceContentFor(sources[0]),
+      " ONE.foo = function (bar) {\n   return baz(bar);\n };"
+    );
+    assert.equal(
+      map.sourceContentFor(sources[1]),
+      " TWO.inc = function (n) {\n   return n + 1;\n };"
+    );
+    assert.equal(
+      map.sourceContentFor("one.js"),
+      " ONE.foo = function (bar) {\n   return baz(bar);\n };"
+    );
+    assert.equal(
+      map.sourceContentFor("two.js"),
+      " TWO.inc = function (n) {\n   return n + 1;\n };"
+    );
+    assert.throws(function () {
+      map.sourceContentFor("");
+    }, Error);
+    assert.throws(function () {
+      map.sourceContentFor("/the/root/three.js");
+    }, Error);
+    assert.throws(function () {
+      map.sourceContentFor("three.js");
+    }, Error);
 
-  map.destroy();
-};
+    map.destroy();
+  };
 
 exports[
   "test that we can get the original source content with relative source paths"
-] = async function(assert) {
+] = async function (assert) {
   const map = await new SourceMapConsumer(util.testMapRelativeSources);
   const sources = map.sources;
 
@@ -909,13 +960,13 @@ exports[
     map.sourceContentFor("two.js"),
     " TWO.inc = function (n) {\n   return n + 1;\n };"
   );
-  assert.throws(function() {
+  assert.throws(function () {
     map.sourceContentFor("");
   }, Error);
-  assert.throws(function() {
+  assert.throws(function () {
     map.sourceContentFor("/the/root/three.js");
   }, Error);
-  assert.throws(function() {
+  assert.throws(function () {
     map.sourceContentFor("three.js");
   }, Error);
 
@@ -924,7 +975,7 @@ exports[
 
 exports[
   "test that we can get the original source content for the sources on an indexed source map"
-] = async function(assert) {
+] = async function (assert) {
   const map = await new SourceMapConsumer(util.indexedTestMap);
   const sources = map.sources;
 
@@ -944,87 +995,84 @@ exports[
     map.sourceContentFor("two.js"),
     " TWO.inc = function (n) {\n   return n + 1;\n };"
   );
-  assert.throws(function() {
+  assert.throws(function () {
     map.sourceContentFor("");
   }, Error);
-  assert.throws(function() {
+  assert.throws(function () {
     map.sourceContentFor("/the/root/three.js");
   }, Error);
-  assert.throws(function() {
+  assert.throws(function () {
     map.sourceContentFor("three.js");
   }, Error);
 
   map.destroy();
 };
 
-exports[
-  "test hasContentsOfAllSources, single source with contents"
-] = async function(assert) {
-  // Has one source: foo.js (with contents).
-  const mapWithContents = new SourceMapGenerator();
-  mapWithContents.addMapping({
-    source: "foo.js",
-    original: { line: 1, column: 10 },
-    generated: { line: 1, column: 10 }
-  });
-  mapWithContents.setSourceContent("foo.js", "content of foo.js");
+exports["test hasContentsOfAllSources, single source with contents"] =
+  async function (assert) {
+    // Has one source: foo.js (with contents).
+    const mapWithContents = new SourceMapGenerator();
+    mapWithContents.addMapping({
+      source: "foo.js",
+      original: { line: 1, column: 10 },
+      generated: { line: 1, column: 10 },
+    });
+    mapWithContents.setSourceContent("foo.js", "content of foo.js");
 
-  const consumer = await new SourceMapConsumer(mapWithContents.toJSON());
-  assert.ok(consumer.hasContentsOfAllSources());
-  consumer.destroy();
-};
+    const consumer = await new SourceMapConsumer(mapWithContents.toJSON());
+    assert.ok(consumer.hasContentsOfAllSources());
+    consumer.destroy();
+  };
 
-exports[
-  "test hasContentsOfAllSources, single source without contents"
-] = async function(assert) {
-  // Has one source: foo.js (without contents).
-  const mapWithoutContents = new SourceMapGenerator();
-  mapWithoutContents.addMapping({
-    source: "foo.js",
-    original: { line: 1, column: 10 },
-    generated: { line: 1, column: 10 }
-  });
-  const consumer = await new SourceMapConsumer(mapWithoutContents.toJSON());
-  assert.ok(!consumer.hasContentsOfAllSources());
-  consumer.destroy();
-};
+exports["test hasContentsOfAllSources, single source without contents"] =
+  async function (assert) {
+    // Has one source: foo.js (without contents).
+    const mapWithoutContents = new SourceMapGenerator();
+    mapWithoutContents.addMapping({
+      source: "foo.js",
+      original: { line: 1, column: 10 },
+      generated: { line: 1, column: 10 },
+    });
+    const consumer = await new SourceMapConsumer(mapWithoutContents.toJSON());
+    assert.ok(!consumer.hasContentsOfAllSources());
+    consumer.destroy();
+  };
 
-exports[
-  "test hasContentsOfAllSources, two sources with contents"
-] = async function(assert) {
-  // Has two sources: foo.js (with contents) and bar.js (with contents).
-  const mapWithBothContents = new SourceMapGenerator();
-  mapWithBothContents.addMapping({
-    source: "foo.js",
-    original: { line: 1, column: 10 },
-    generated: { line: 1, column: 10 }
-  });
-  mapWithBothContents.addMapping({
-    source: "bar.js",
-    original: { line: 1, column: 10 },
-    generated: { line: 1, column: 10 }
-  });
-  mapWithBothContents.setSourceContent("foo.js", "content of foo.js");
-  mapWithBothContents.setSourceContent("bar.js", "content of bar.js");
-  const consumer = await new SourceMapConsumer(mapWithBothContents.toJSON());
-  assert.ok(consumer.hasContentsOfAllSources());
-  consumer.destroy();
-};
+exports["test hasContentsOfAllSources, two sources with contents"] =
+  async function (assert) {
+    // Has two sources: foo.js (with contents) and bar.js (with contents).
+    const mapWithBothContents = new SourceMapGenerator();
+    mapWithBothContents.addMapping({
+      source: "foo.js",
+      original: { line: 1, column: 10 },
+      generated: { line: 1, column: 10 },
+    });
+    mapWithBothContents.addMapping({
+      source: "bar.js",
+      original: { line: 1, column: 10 },
+      generated: { line: 1, column: 10 },
+    });
+    mapWithBothContents.setSourceContent("foo.js", "content of foo.js");
+    mapWithBothContents.setSourceContent("bar.js", "content of bar.js");
+    const consumer = await new SourceMapConsumer(mapWithBothContents.toJSON());
+    assert.ok(consumer.hasContentsOfAllSources());
+    consumer.destroy();
+  };
 
 exports[
   "test hasContentsOfAllSources, two sources one with and one without contents"
-] = async function(assert) {
+] = async function (assert) {
   // Has two sources: foo.js (with contents) and bar.js (without contents).
   const mapWithoutSomeContents = new SourceMapGenerator();
   mapWithoutSomeContents.addMapping({
     source: "foo.js",
     original: { line: 1, column: 10 },
-    generated: { line: 1, column: 10 }
+    generated: { line: 1, column: 10 },
   });
   mapWithoutSomeContents.addMapping({
     source: "bar.js",
     original: { line: 1, column: 10 },
-    generated: { line: 1, column: 10 }
+    generated: { line: 1, column: 10 },
   });
   mapWithoutSomeContents.setSourceContent("foo.js", "content of foo.js");
   const consumer = await new SourceMapConsumer(mapWithoutSomeContents.toJSON());
@@ -1032,20 +1080,20 @@ exports[
   consumer.destroy();
 };
 
-exports["test sourceRoot + generatedPositionFor"] = async function(assert) {
+exports["test sourceRoot + generatedPositionFor"] = async function (assert) {
   let map = new SourceMapGenerator({
     sourceRoot: "foo/bar",
-    file: "baz.js"
+    file: "baz.js",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: "bang.coffee"
+    source: "bang.coffee",
   });
   map.addMapping({
     original: { line: 5, column: 5 },
     generated: { line: 6, column: 6 },
-    source: "bang.coffee"
+    source: "bang.coffee",
   });
 
   map = await new SourceMapConsumer(map.toString(), "http://example.com/");
@@ -1054,7 +1102,7 @@ exports["test sourceRoot + generatedPositionFor"] = async function(assert) {
   let pos = map.generatedPositionFor({
     line: 1,
     column: 1,
-    source: "bang.coffee"
+    source: "bang.coffee",
   });
 
   assert.equal(pos.line, 2);
@@ -1064,7 +1112,7 @@ exports["test sourceRoot + generatedPositionFor"] = async function(assert) {
   pos = map.generatedPositionFor({
     line: 1,
     column: 1,
-    source: "foo/bar/bang.coffee"
+    source: "foo/bar/bang.coffee",
   });
 
   assert.equal(pos.line, 2);
@@ -1074,7 +1122,7 @@ exports["test sourceRoot + generatedPositionFor"] = async function(assert) {
   pos = map.generatedPositionFor({
     line: 1,
     column: 1,
-    source: "http://example.com/foo/bar/bang.coffee"
+    source: "http://example.com/foo/bar/bang.coffee",
   });
 
   assert.equal(pos.line, 2);
@@ -1083,35 +1131,34 @@ exports["test sourceRoot + generatedPositionFor"] = async function(assert) {
   map.destroy();
 };
 
-exports[
-  "test sourceRoot + generatedPositionFor for path above the root"
-] = async function(assert) {
-  let map = new SourceMapGenerator({
-    sourceRoot: "foo/bar",
-    file: "baz.js"
-  });
-  map.addMapping({
-    original: { line: 1, column: 1 },
-    generated: { line: 2, column: 2 },
-    source: "../bang.coffee"
-  });
+exports["test sourceRoot + generatedPositionFor for path above the root"] =
+  async function (assert) {
+    let map = new SourceMapGenerator({
+      sourceRoot: "foo/bar",
+      file: "baz.js",
+    });
+    map.addMapping({
+      original: { line: 1, column: 1 },
+      generated: { line: 2, column: 2 },
+      source: "../bang.coffee",
+    });
 
-  map = await new SourceMapConsumer(map.toString());
+    map = await new SourceMapConsumer(map.toString());
 
-  // Should handle with sourceRoot.
-  const pos = map.generatedPositionFor({
-    line: 1,
-    column: 1,
-    source: "foo/bang.coffee"
-  });
+    // Should handle with sourceRoot.
+    const pos = map.generatedPositionFor({
+      line: 1,
+      column: 1,
+      source: "foo/bang.coffee",
+    });
 
-  assert.equal(pos.line, 2);
-  assert.equal(pos.column, 2);
+    assert.equal(pos.line, 2);
+    assert.equal(pos.column, 2);
 
-  map.destroy();
-};
+    map.destroy();
+  };
 
-exports["test index map + generatedPositionFor"] = async function(assert) {
+exports["test index map + generatedPositionFor"] = async function (assert) {
   const map = await new SourceMapConsumer(
     util.indexedTestMapColumnOffset,
     "http://example.com/"
@@ -1121,7 +1168,7 @@ exports["test index map + generatedPositionFor"] = async function(assert) {
   let pos = map.generatedPositionFor({
     line: 1,
     column: 11,
-    source: "one.js"
+    source: "one.js",
   });
 
   assert.equal(pos.line, 1);
@@ -1131,7 +1178,7 @@ exports["test index map + generatedPositionFor"] = async function(assert) {
   pos = map.generatedPositionFor({
     line: 2,
     column: 3,
-    source: "one.js"
+    source: "one.js",
   });
 
   assert.equal(pos.line, 1);
@@ -1141,7 +1188,7 @@ exports["test index map + generatedPositionFor"] = async function(assert) {
   pos = map.generatedPositionFor({
     line: 1,
     column: 11,
-    source: "two.js"
+    source: "two.js",
   });
 
   assert.equal(pos.line, 1);
@@ -1151,7 +1198,7 @@ exports["test index map + generatedPositionFor"] = async function(assert) {
   pos = map.generatedPositionFor({
     line: 2,
     column: 3,
-    source: "two.js"
+    source: "two.js",
   });
 
   assert.equal(pos.line, 1);
@@ -1161,41 +1208,41 @@ exports["test index map + generatedPositionFor"] = async function(assert) {
   map.destroy();
 };
 
-exports["test allGeneratedPositionsFor for line"] = async function(assert) {
+exports["test allGeneratedPositionsFor for line"] = async function (assert) {
   let map = new SourceMapGenerator({
-    file: "generated.js"
+    file: "generated.js",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: "bar.coffee"
+    source: "bar.coffee",
   });
   map.addMapping({
     original: { line: 2, column: 1 },
     generated: { line: 3, column: 2 },
-    source: "bar.coffee"
+    source: "bar.coffee",
   });
   map.addMapping({
     original: { line: 2, column: 2 },
     generated: { line: 3, column: 3 },
-    source: "bar.coffee"
+    source: "bar.coffee",
   });
   map.addMapping({
     original: { line: 3, column: 1 },
     generated: { line: 4, column: 2 },
-    source: "bar.coffee"
+    source: "bar.coffee",
   });
 
   map = await new SourceMapConsumer(map.toString(), "http://example.com/");
 
   let mappings = map.allGeneratedPositionsFor({
     line: 2,
-    source: "bar.coffee"
+    source: "bar.coffee",
   });
 
   assert.equal(mappings.length, 2);
@@ -1206,7 +1253,7 @@ exports["test allGeneratedPositionsFor for line"] = async function(assert) {
 
   mappings = map.allGeneratedPositionsFor({
     line: 2,
-    source: "http://example.com/bar.coffee"
+    source: "http://example.com/bar.coffee",
   });
 
   assert.equal(mappings.length, 2);
@@ -1218,33 +1265,33 @@ exports["test allGeneratedPositionsFor for line"] = async function(assert) {
   map.destroy();
 };
 
-exports["test allGeneratedPositionsFor for line fuzzy"] = async function(
+exports["test allGeneratedPositionsFor for line fuzzy"] = async function (
   assert
 ) {
   let map = new SourceMapGenerator({
-    file: "generated.js"
+    file: "generated.js",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: "bar.coffee"
+    source: "bar.coffee",
   });
   map.addMapping({
     original: { line: 3, column: 1 },
     generated: { line: 4, column: 2 },
-    source: "bar.coffee"
+    source: "bar.coffee",
   });
 
   map = await new SourceMapConsumer(map.toString());
 
   const mappings = map.allGeneratedPositionsFor({
     line: 2,
-    source: "bar.coffee"
+    source: "bar.coffee",
   });
 
   assert.equal(mappings.length, 1);
@@ -1254,17 +1301,17 @@ exports["test allGeneratedPositionsFor for line fuzzy"] = async function(
   map.destroy();
 };
 
-exports["test allGeneratedPositionsFor for empty source map"] = async function(
+exports["test allGeneratedPositionsFor for empty source map"] = async function (
   assert
 ) {
   let map = new SourceMapGenerator({
-    file: "generated.js"
+    file: "generated.js",
   });
   map = await new SourceMapConsumer(map.toString());
 
   const mappings = map.allGeneratedPositionsFor({
     line: 2,
-    source: "bar.coffee"
+    source: "bar.coffee",
   });
 
   assert.equal(mappings.length, 0);
@@ -1272,19 +1319,19 @@ exports["test allGeneratedPositionsFor for empty source map"] = async function(
   map.destroy();
 };
 
-exports["test allGeneratedPositionsFor for column"] = async function(assert) {
+exports["test allGeneratedPositionsFor for column"] = async function (assert) {
   let map = new SourceMapGenerator({
-    file: "generated.js"
+    file: "generated.js",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 2 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 3 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
 
   map = await new SourceMapConsumer(map.toString());
@@ -1292,7 +1339,7 @@ exports["test allGeneratedPositionsFor for column"] = async function(assert) {
   const mappings = map.allGeneratedPositionsFor({
     line: 1,
     column: 1,
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
 
   assert.equal(mappings.length, 2);
@@ -1304,21 +1351,21 @@ exports["test allGeneratedPositionsFor for column"] = async function(assert) {
   map.destroy();
 };
 
-exports["test allGeneratedPositionsFor for column fuzzy"] = async function(
+exports["test allGeneratedPositionsFor for column fuzzy"] = async function (
   assert
 ) {
   let map = new SourceMapGenerator({
-    file: "generated.js"
+    file: "generated.js",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 2 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 3 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
 
   map = await new SourceMapConsumer(map.toString());
@@ -1326,7 +1373,7 @@ exports["test allGeneratedPositionsFor for column fuzzy"] = async function(
   const mappings = map.allGeneratedPositionsFor({
     line: 1,
     column: 0,
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
 
   assert.equal(mappings.length, 2);
@@ -1338,37 +1385,36 @@ exports["test allGeneratedPositionsFor for column fuzzy"] = async function(
   map.destroy();
 };
 
-exports[
-  "test allGeneratedPositionsFor for column on different line fuzzy"
-] = async function(assert) {
-  let map = new SourceMapGenerator({
-    file: "generated.js"
-  });
-  map.addMapping({
-    original: { line: 2, column: 1 },
-    generated: { line: 2, column: 2 },
-    source: "foo.coffee"
-  });
-  map.addMapping({
-    original: { line: 2, column: 1 },
-    generated: { line: 2, column: 3 },
-    source: "foo.coffee"
-  });
+exports["test allGeneratedPositionsFor for column on different line fuzzy"] =
+  async function (assert) {
+    let map = new SourceMapGenerator({
+      file: "generated.js",
+    });
+    map.addMapping({
+      original: { line: 2, column: 1 },
+      generated: { line: 2, column: 2 },
+      source: "foo.coffee",
+    });
+    map.addMapping({
+      original: { line: 2, column: 1 },
+      generated: { line: 2, column: 3 },
+      source: "foo.coffee",
+    });
 
-  map = await new SourceMapConsumer(map.toString());
+    map = await new SourceMapConsumer(map.toString());
 
-  const mappings = map.allGeneratedPositionsFor({
-    line: 1,
-    column: 0,
-    source: "foo.coffee"
-  });
+    const mappings = map.allGeneratedPositionsFor({
+      line: 1,
+      column: 0,
+      source: "foo.coffee",
+    });
 
-  assert.equal(mappings.length, 0);
+    assert.equal(mappings.length, 0);
 
-  map.destroy();
-};
+    map.destroy();
+  };
 
-exports["test allGeneratedPositionsFor for index map"] = async function(
+exports["test allGeneratedPositionsFor for index map"] = async function (
   assert
 ) {
   const map = await new SourceMapConsumer(util.indexedTestMapColumnOffset);
@@ -1377,95 +1423,95 @@ exports["test allGeneratedPositionsFor for index map"] = async function(
   let mappings = map.allGeneratedPositionsFor({
     line: 2,
     column: 3,
-    source: "one.js"
+    source: "one.js",
   });
 
   assert.deepEqual(mappings, [
     {
       line: 1,
       column: 21,
-      lastColumn: 27
-    }
+      lastColumn: 27,
+    },
   ]);
 
   mappings = map.allGeneratedPositionsFor({
     line: 2,
     column: 14,
-    source: "one.js"
+    source: "one.js",
   });
 
   assert.deepEqual(mappings, [
     {
       line: 1,
       column: 32,
-      lastColumn: 49
-    }
+      lastColumn: 49,
+    },
   ]);
 
   mappings = map.allGeneratedPositionsFor({
     line: 2,
     column: 3,
-    source: "two.js"
+    source: "two.js",
   });
 
   assert.deepEqual(mappings, [
     {
       line: 1,
       column: 71,
-      lastColumn: 77
-    }
+      lastColumn: 77,
+    },
   ]);
 
   mappings = map.allGeneratedPositionsFor({
     line: 2,
     column: 10,
-    source: "two.js"
+    source: "two.js",
   });
 
   assert.deepEqual(mappings, [
     {
       line: 1,
       column: 78,
-      lastColumn: Infinity
-    }
+      lastColumn: Infinity,
+    },
   ]);
 
   map.destroy();
 };
 
-exports["test computeColumnSpans"] = async function(assert) {
+exports["test computeColumnSpans"] = async function (assert) {
   let map = new SourceMapGenerator({
-    file: "generated.js"
+    file: "generated.js",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 1, column: 1 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
   map.addMapping({
     original: { line: 2, column: 1 },
     generated: { line: 2, column: 1 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
   map.addMapping({
     original: { line: 2, column: 2 },
     generated: { line: 2, column: 10 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
   map.addMapping({
     original: { line: 2, column: 3 },
     generated: { line: 2, column: 20 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
   map.addMapping({
     original: { line: 3, column: 1 },
     generated: { line: 3, column: 1 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
   map.addMapping({
     original: { line: 3, column: 2 },
     generated: { line: 3, column: 2 },
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
 
   map = await new SourceMapConsumer(map.toString());
@@ -1474,7 +1520,7 @@ exports["test computeColumnSpans"] = async function(assert) {
 
   let mappings = map.allGeneratedPositionsFor({
     line: 1,
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
 
   assert.equal(mappings.length, 1);
@@ -1482,7 +1528,7 @@ exports["test computeColumnSpans"] = async function(assert) {
 
   mappings = map.allGeneratedPositionsFor({
     line: 2,
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
 
   assert.equal(mappings.length, 3);
@@ -1492,7 +1538,7 @@ exports["test computeColumnSpans"] = async function(assert) {
 
   mappings = map.allGeneratedPositionsFor({
     line: 3,
-    source: "foo.coffee"
+    source: "foo.coffee",
   });
 
   assert.equal(mappings.length, 2);
@@ -1502,22 +1548,22 @@ exports["test computeColumnSpans"] = async function(assert) {
   map.destroy();
 };
 
-exports["test sourceRoot + originalPositionFor"] = async function(assert) {
+exports["test sourceRoot + originalPositionFor"] = async function (assert) {
   let map = new SourceMapGenerator({
     sourceRoot: "foo/bar",
-    file: "baz.js"
+    file: "baz.js",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: "bang.coffee"
+    source: "bang.coffee",
   });
 
   map = await new SourceMapConsumer(map.toString());
 
   const pos = map.originalPositionFor({
     line: 2,
-    column: 2
+    column: 2,
   });
 
   // Should always have the prepended source root
@@ -1529,15 +1575,15 @@ exports["test sourceRoot + originalPositionFor"] = async function(assert) {
 };
 
 // Was github issue #43, but that's no longer valid.
-exports["test source resolution with sourceMapURL"] = async function(assert) {
+exports["test source resolution with sourceMapURL"] = async function (assert) {
   let map = new SourceMapGenerator({
     sourceRoot: "",
-    file: "foo.js"
+    file: "foo.js",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: "original.js"
+    source: "original.js",
   });
 
   map = await new SourceMapConsumer(map.toString(), "http://cdn.example.com");
@@ -1553,15 +1599,15 @@ exports["test source resolution with sourceMapURL"] = async function(assert) {
   map.destroy();
 };
 
-exports["test sourceRoot prepending"] = async function(assert) {
+exports["test sourceRoot prepending"] = async function (assert) {
   let map = new SourceMapGenerator({
     sourceRoot: "http://example.com/foo/bar",
-    file: "foo.js"
+    file: "foo.js",
   });
   map.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: "/original.js"
+    source: "/original.js",
   });
 
   map = await new SourceMapConsumer(map.toString());
@@ -1579,7 +1625,7 @@ exports["test sourceRoot prepending"] = async function(assert) {
 
 exports[
   "test indexed source map errors when sections are out of order by line"
-] = async function(assert) {
+] = async function (assert) {
   // Make a deep copy of the indexedTestMap
   const misorderedIndexedTestMap = JSON.parse(
     JSON.stringify(util.indexedTestMap)
@@ -1587,7 +1633,7 @@ exports[
 
   misorderedIndexedTestMap.sections[0].offset = {
     line: 2,
-    column: 0
+    column: 0,
   };
 
   let error;
@@ -1599,7 +1645,7 @@ exports[
   assert.ok(error instanceof Error);
 };
 
-exports["test github issue #64"] = async function(assert) {
+exports["test github issue #64"] = async function (assert) {
   const map = await new SourceMapConsumer({
     version: 3,
     file: "foo.js",
@@ -1607,7 +1653,7 @@ exports["test github issue #64"] = async function(assert) {
     sources: ["/a"],
     names: [],
     mappings: "AACA",
-    sourcesContent: ["foo"]
+    sourcesContent: ["foo"],
   });
 
   assert.equal(map.sourceContentFor("a"), "foo");
@@ -1616,7 +1662,9 @@ exports["test github issue #64"] = async function(assert) {
   map.destroy();
 };
 
-exports["test full source content with sourceMapURL"] = async function(assert) {
+exports["test full source content with sourceMapURL"] = async function (
+  assert
+) {
   const map = await new SourceMapConsumer(
     {
       version: 3,
@@ -1625,7 +1673,7 @@ exports["test full source content with sourceMapURL"] = async function(assert) {
       sources: ["original.js"],
       names: [],
       mappings: "AACA",
-      sourcesContent: ["yellow warbler"]
+      sourcesContent: ["yellow warbler"],
     },
     "http://cdn.example.com"
   );
@@ -1639,7 +1687,7 @@ exports["test full source content with sourceMapURL"] = async function(assert) {
   map.destroy();
 };
 
-exports["test bug 885597"] = async function(assert) {
+exports["test bug 885597"] = async function (assert) {
   const map = await new SourceMapConsumer({
     version: 3,
     file: "foo.js",
@@ -1647,7 +1695,7 @@ exports["test bug 885597"] = async function(assert) {
     sources: ["/a"],
     names: [],
     mappings: "AACA",
-    sourcesContent: ["foo"]
+    sourcesContent: ["foo"],
   });
 
   const s = map.sources[0];
@@ -1656,19 +1704,19 @@ exports["test bug 885597"] = async function(assert) {
   map.destroy();
 };
 
-exports["test github issue #72, duplicate sources"] = async function(assert) {
+exports["test github issue #72, duplicate sources"] = async function (assert) {
   const map = await new SourceMapConsumer({
     version: 3,
     file: "foo.js",
     sources: ["source1.js", "source1.js", "source3.js"],
     names: [],
     mappings: ";EAAC;;IAEE;;MEEE",
-    sourceRoot: "http://example.com"
+    sourceRoot: "http://example.com",
   });
 
   let pos = map.originalPositionFor({
     line: 2,
-    column: 2
+    column: 2,
   });
   assert.equal(pos.source, "http://example.com/source1.js");
   assert.equal(pos.line, 1);
@@ -1676,7 +1724,7 @@ exports["test github issue #72, duplicate sources"] = async function(assert) {
 
   pos = map.originalPositionFor({
     line: 4,
-    column: 4
+    column: 4,
   });
   assert.equal(pos.source, "http://example.com/source1.js");
   assert.equal(pos.line, 3);
@@ -1684,7 +1732,7 @@ exports["test github issue #72, duplicate sources"] = async function(assert) {
 
   pos = map.originalPositionFor({
     line: 6,
-    column: 6
+    column: 6,
   });
   assert.equal(pos.source, "http://example.com/source3.js");
   assert.equal(pos.line, 5);
@@ -1693,19 +1741,19 @@ exports["test github issue #72, duplicate sources"] = async function(assert) {
   map.destroy();
 };
 
-exports["test github issue #72, duplicate names"] = async function(assert) {
+exports["test github issue #72, duplicate names"] = async function (assert) {
   const map = await new SourceMapConsumer({
     version: 3,
     file: "foo.js",
     sources: ["source.js"],
     names: ["name1", "name1", "name3"],
     mappings: ";EAACA;;IAEEA;;MAEEE",
-    sourceRoot: "http://example.com"
+    sourceRoot: "http://example.com",
   });
 
   let pos = map.originalPositionFor({
     line: 2,
-    column: 2
+    column: 2,
   });
   assert.equal(pos.name, "name1");
   assert.equal(pos.line, 1);
@@ -1713,7 +1761,7 @@ exports["test github issue #72, duplicate names"] = async function(assert) {
 
   pos = map.originalPositionFor({
     line: 4,
-    column: 4
+    column: 4,
   });
   assert.equal(pos.name, "name1");
   assert.equal(pos.line, 3);
@@ -1721,7 +1769,7 @@ exports["test github issue #72, duplicate names"] = async function(assert) {
 
   pos = map.originalPositionFor({
     line: 6,
-    column: 6
+    column: 6,
   });
   assert.equal(pos.name, "name3");
   assert.equal(pos.line, 5);
@@ -1730,21 +1778,21 @@ exports["test github issue #72, duplicate names"] = async function(assert) {
   map.destroy();
 };
 
-exports["test SourceMapConsumer.fromSourceMap"] = async function(assert) {
+exports["test SourceMapConsumer.fromSourceMap"] = async function (assert) {
   const smg = new SourceMapGenerator({
     sourceRoot: "http://example.com/",
-    file: "foo.js"
+    file: "foo.js",
   });
   smg.addMapping({
     original: { line: 1, column: 1 },
     generated: { line: 2, column: 2 },
-    source: "bar.js"
+    source: "bar.js",
   });
   smg.addMapping({
     original: { line: 2, column: 2 },
     generated: { line: 4, column: 4 },
     source: "baz.js",
-    name: "dirtMcGirt"
+    name: "dirtMcGirt",
   });
   smg.setSourceContent("baz.js", "baz.js content");
 
@@ -1758,7 +1806,7 @@ exports["test SourceMapConsumer.fromSourceMap"] = async function(assert) {
 
   let pos = smc.originalPositionFor({
     line: 2,
-    column: 2
+    column: 2,
   });
   assert.equal(pos.line, 1);
   assert.equal(pos.column, 1);
@@ -1768,14 +1816,14 @@ exports["test SourceMapConsumer.fromSourceMap"] = async function(assert) {
   pos = smc.generatedPositionFor({
     line: 1,
     column: 1,
-    source: "http://example.com/bar.js"
+    source: "http://example.com/bar.js",
   });
   assert.equal(pos.line, 2);
   assert.equal(pos.column, 2);
 
   pos = smc.originalPositionFor({
     line: 4,
-    column: 4
+    column: 4,
   });
   assert.equal(pos.line, 2);
   assert.equal(pos.column, 2);
@@ -1785,7 +1833,7 @@ exports["test SourceMapConsumer.fromSourceMap"] = async function(assert) {
   pos = smc.generatedPositionFor({
     line: 2,
     column: 2,
-    source: "http://example.com/baz.js"
+    source: "http://example.com/baz.js",
   });
   assert.equal(pos.line, 4);
   assert.equal(pos.column, 4);
@@ -1793,18 +1841,18 @@ exports["test SourceMapConsumer.fromSourceMap"] = async function(assert) {
   smc.destroy();
 };
 
-exports["test issue #191"] = async function(assert) {
+exports["test issue #191"] = async function (assert) {
   const generator = new SourceMapGenerator({ file: "a.css" });
   generator.addMapping({
     source: "b.css",
     original: {
       line: 1,
-      column: 0
+      column: 0,
     },
     generated: {
       line: 1,
-      column: 0
-    }
+      column: 0,
+    },
   });
 
   // Create a SourceMapConsumer from the SourceMapGenerator, ...
@@ -1821,41 +1869,40 @@ exports["test issue #191"] = async function(assert) {
   consumer.destroy();
 };
 
-exports[
-  "test sources where their prefix is the source root: issue #199"
-] = async function(assert) {
-  const testSourceMap = {
-    version: 3,
-    sources: ["/source/app/app/app.js"],
-    names: ["System"],
-    mappings: "AAAAA",
-    file: "app/app.js",
-    sourcesContent: ["'use strict';"],
-    sourceRoot: "/source/"
+exports["test sources where their prefix is the source root: issue #199"] =
+  async function (assert) {
+    const testSourceMap = {
+      version: 3,
+      sources: ["/source/app/app/app.js"],
+      names: ["System"],
+      mappings: "AAAAA",
+      file: "app/app.js",
+      sourcesContent: ["'use strict';"],
+      sourceRoot: "/source/",
+    };
+
+    const consumer = await new SourceMapConsumer(testSourceMap);
+
+    function consumerHasSource(s) {
+      assert.ok(consumer.sourceContentFor(s));
+    }
+
+    consumer.sources.forEach(consumerHasSource);
+    testSourceMap.sources.forEach(consumerHasSource);
+
+    consumer.destroy();
   };
-
-  const consumer = await new SourceMapConsumer(testSourceMap);
-
-  function consumerHasSource(s) {
-    assert.ok(consumer.sourceContentFor(s));
-  }
-
-  consumer.sources.forEach(consumerHasSource);
-  testSourceMap.sources.forEach(consumerHasSource);
-
-  consumer.destroy();
-};
 
 exports[
   "test sources where their prefix is the source root and the source root is a url: issue #199"
-] = async function(assert) {
+] = async function (assert) {
   const testSourceMap = {
     version: 3,
     sources: ["http://example.com/source/app/app/app.js"],
     names: ["System"],
     mappings: "AAAAA",
     sourcesContent: ["'use strict';"],
-    sourceRoot: "http://example.com/source/"
+    sourceRoot: "http://example.com/source/",
   };
 
   const consumer = await new SourceMapConsumer(testSourceMap);
@@ -1870,14 +1917,14 @@ exports[
   consumer.destroy();
 };
 
-exports["test consuming names and sources that are numbers"] = async function(
+exports["test consuming names and sources that are numbers"] = async function (
   assert
 ) {
   const testSourceMap = {
     version: 3,
     sources: [0],
     names: [1],
-    mappings: "AAAAA"
+    mappings: "AAAAA",
   };
 
   const consumer = await new SourceMapConsumer(testSourceMap);
@@ -1886,7 +1933,7 @@ exports["test consuming names and sources that are numbers"] = async function(
   assert.equal(consumer.sources[0], "0");
 
   let i = 0;
-  consumer.eachMapping(function(m) {
+  consumer.eachMapping(function (m) {
     i++;
     assert.equal(m.name, "1");
   });
@@ -1895,7 +1942,7 @@ exports["test consuming names and sources that are numbers"] = async function(
   consumer.destroy();
 };
 
-exports["test non-normalized sourceRoot (from issue #227)"] = async function(
+exports["test non-normalized sourceRoot (from issue #227)"] = async function (
   assert
 ) {
   const consumer = await new SourceMapConsumer({
@@ -1905,7 +1952,7 @@ exports["test non-normalized sourceRoot (from issue #227)"] = async function(
     mappings: ";;AAAA,IAAI,OAAO,MAAP",
     file: "index.js",
     sourceRoot: "./src/",
-    sourcesContent: ['var name = "Mark"\n']
+    sourcesContent: ['var name = "Mark"\n'],
   });
   assert.doesNotThrow(() => {
     // Before the fix, this threw an exception.
@@ -1915,14 +1962,14 @@ exports["test non-normalized sourceRoot (from issue #227)"] = async function(
   consumer.destroy();
 };
 
-exports["test webpack URL resolution"] = async function(assert) {
+exports["test webpack URL resolution"] = async function (assert) {
   const map = {
     version: 3,
     sources: ["webpack:///webpack/bootstrap 67e184f9679733298d44"],
     names: [],
     mappings: "CAAS",
     file: "static/js/manifest.b7cf97680f7a50fa150f.js",
-    sourceRoot: ""
+    sourceRoot: "",
   };
   const consumer = await new SourceMapConsumer(map);
 
@@ -1935,7 +1982,7 @@ exports["test webpack URL resolution"] = async function(assert) {
   consumer.destroy();
 };
 
-exports["test webpack URL resolution with sourceMapURL"] = async function(
+exports["test webpack URL resolution with sourceMapURL"] = async function (
   assert
 ) {
   const map = {
@@ -1944,7 +1991,7 @@ exports["test webpack URL resolution with sourceMapURL"] = async function(
     names: [],
     mappings: "CAAS",
     file: "static/js/manifest.b7cf97680f7a50fa150f.js",
-    sourceRoot: ""
+    sourceRoot: "",
   };
   const consumer = await new SourceMapConsumer(
     map,
@@ -1960,29 +2007,28 @@ exports["test webpack URL resolution with sourceMapURL"] = async function(
   consumer.destroy();
 };
 
-exports[
-  "test relative webpack URL resolution with sourceMapURL"
-] = async function(assert) {
-  const map = {
-    version: 3,
-    sources: ["webpack/bootstrap.js"],
-    names: [],
-    mappings: "CAAS",
-    file: "static/js/manifest.b7cf97680f7a50fa150f.js",
-    sourceRoot: "webpack:///"
+exports["test relative webpack URL resolution with sourceMapURL"] =
+  async function (assert) {
+    const map = {
+      version: 3,
+      sources: ["webpack/bootstrap.js"],
+      names: [],
+      mappings: "CAAS",
+      file: "static/js/manifest.b7cf97680f7a50fa150f.js",
+      sourceRoot: "webpack:///",
+    };
+    const consumer = await new SourceMapConsumer(
+      map,
+      "http://www.example.com/q.js.map"
+    );
+
+    assert.equal(consumer.sources.length, 1);
+    assert.equal(consumer.sources[0], "webpack:///webpack/bootstrap.js");
+
+    consumer.destroy();
   };
-  const consumer = await new SourceMapConsumer(
-    map,
-    "http://www.example.com/q.js.map"
-  );
 
-  assert.equal(consumer.sources.length, 1);
-  assert.equal(consumer.sources[0], "webpack:///webpack/bootstrap.js");
-
-  consumer.destroy();
-};
-
-exports["test basic URL resolution with sourceMapURL"] = async function(
+exports["test basic URL resolution with sourceMapURL"] = async function (
   assert
 ) {
   const map = {
@@ -1991,7 +2037,7 @@ exports["test basic URL resolution with sourceMapURL"] = async function(
     names: [],
     mappings: "CAAS",
     file: "static/js/manifest.b7cf97680f7a50fa150f.js",
-    sourceRoot: "src"
+    sourceRoot: "src",
   };
   const consumer = await new SourceMapConsumer(
     map,
@@ -2007,35 +2053,37 @@ exports["test basic URL resolution with sourceMapURL"] = async function(
   consumer.destroy();
 };
 
-exports[
-  "test absolute sourceURL resolution with sourceMapURL"
-] = async function(assert) {
-  const map = {
-    version: 3,
-    sources: ["something.js"],
-    names: [],
-    mappings: "CAAS",
-    file: "static/js/manifest.b7cf97680f7a50fa150f.js",
-    sourceRoot: "http://www.example.com/src"
+exports["test absolute sourceURL resolution with sourceMapURL"] =
+  async function (assert) {
+    const map = {
+      version: 3,
+      sources: ["something.js"],
+      names: [],
+      mappings: "CAAS",
+      file: "static/js/manifest.b7cf97680f7a50fa150f.js",
+      sourceRoot: "http://www.example.com/src",
+    };
+    const consumer = await new SourceMapConsumer(
+      map,
+      "http://www.example.com/x/q.js.map"
+    );
+
+    assert.equal(consumer.sources.length, 1);
+    assert.equal(
+      consumer.sources[0],
+      "http://www.example.com/src/something.js"
+    );
+
+    consumer.destroy();
   };
-  const consumer = await new SourceMapConsumer(
-    map,
-    "http://www.example.com/x/q.js.map"
-  );
 
-  assert.equal(consumer.sources.length, 1);
-  assert.equal(consumer.sources[0], "http://www.example.com/src/something.js");
-
-  consumer.destroy();
-};
-
-exports["test line numbers > 2**32"] = async function(assert) {
+exports["test line numbers > 2**32"] = async function (assert) {
   const map = await new SourceMapConsumer({
     version: 3,
     sources: ["something.js"],
     names: [],
     mappings: "C+/////DAS",
-    file: "foo.js"
+    file: "foo.js",
   });
 
   let error;
@@ -2050,13 +2098,13 @@ exports["test line numbers > 2**32"] = async function(assert) {
   map.destroy();
 };
 
-exports["test line numbers < 0"] = async function(assert) {
+exports["test line numbers < 0"] = async function (assert) {
   const map = await new SourceMapConsumer({
     version: 3,
     sources: ["something.js"],
     names: [],
     mappings: "CDAS",
-    file: "foo.js"
+    file: "foo.js",
   });
 
   let error;
@@ -2071,26 +2119,28 @@ exports["test line numbers < 0"] = async function(assert) {
   map.destroy();
 };
 
-exports["test SourceMapConsumer.with"] = async function(assert) {
+exports["test SourceMapConsumer.with"] = async function (assert) {
   let consumer = null;
-  const six = await SourceMapConsumer.with(util.testMap, null, async function(
-    c
-  ) {
-    // Don't keep references to the consumer around at home, kids.
-    consumer = c;
+  const six = await SourceMapConsumer.with(
+    util.testMap,
+    null,
+    async function (c) {
+      // Don't keep references to the consumer around at home, kids.
+      consumer = c;
 
-    // We should properly treat the with callback as an async function.
-    await new Promise(r => setTimeout(r, 1));
+      // We should properly treat the with callback as an async function.
+      await new Promise(r => setTimeout(r, 1));
 
-    // Should not have parsed and allocated mappings yet.
-    assert.equal(c._mappingsPtr, 0);
+      // Should not have parsed and allocated mappings yet.
+      assert.equal(c._mappingsPtr, 0);
 
-    // Force the mappings to be parsed and assert that we allocated mappings.
-    c.eachMapping(_ => {});
-    assert.ok(c._mappingsPtr != 0);
+      // Force the mappings to be parsed and assert that we allocated mappings.
+      c.eachMapping(_ => {});
+      assert.ok(c._mappingsPtr != 0);
 
-    return 6;
-  });
+      return 6;
+    }
+  );
 
   // Yes, we can return values.
   assert.equal(six, 6);
@@ -2099,12 +2149,14 @@ exports["test SourceMapConsumer.with"] = async function(assert) {
   assert.equal(consumer._mappingsPtr, 0);
 };
 
-exports["test SourceMapConsumer.with and exceptions"] = async function(assert) {
+exports["test SourceMapConsumer.with and exceptions"] = async function (
+  assert
+) {
   let consumer = null;
   let error = null;
 
   try {
-    await SourceMapConsumer.with(util.testMap, null, async function(c) {
+    await SourceMapConsumer.with(util.testMap, null, async function (c) {
       consumer = c;
       assert.equal(c._mappingsPtr, 0);
 

--- a/test/test-source-map-generator.js
+++ b/test/test-source-map-generator.js
@@ -5,17 +5,17 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
-const SourceMapGenerator = require("../lib/source-map-generator")
-  .SourceMapGenerator;
-const SourceMapConsumer = require("../lib/source-map-consumer")
-  .SourceMapConsumer;
+const SourceMapGenerator =
+  require("../lib/source-map-generator").SourceMapGenerator;
+const SourceMapConsumer =
+  require("../lib/source-map-consumer").SourceMapConsumer;
 const SourceNode = require("../lib/source-node").SourceNode;
 const util = require("./util");
 
-exports["test some simple stuff"] = function(assert) {
+exports["test some simple stuff"] = function (assert) {
   let map = new SourceMapGenerator({
     file: "foo.js",
-    sourceRoot: "."
+    sourceRoot: ".",
   }).toJSON();
   assert.ok("file" in map);
   assert.ok("sourceRoot" in map);
@@ -25,177 +25,177 @@ exports["test some simple stuff"] = function(assert) {
   assert.ok(!("sourceRoot" in map));
 };
 
-exports["test JSON serialization"] = function(assert) {
+exports["test JSON serialization"] = function (assert) {
   const map = new SourceMapGenerator({
     file: "foo.js",
-    sourceRoot: "."
+    sourceRoot: ".",
   });
   assert.equal(map.toString(), JSON.stringify(map));
 };
 
-exports["test adding mappings (case 1)"] = function(assert) {
+exports["test adding mappings (case 1)"] = function (assert) {
   const map = new SourceMapGenerator({
     file: "generated-foo.js",
-    sourceRoot: "."
+    sourceRoot: ".",
   });
 
-  assert.doesNotThrow(function() {
-    map.addMapping({
-      generated: { line: 1, column: 1 }
-    });
-  });
-};
-
-exports["test adding mappings (case 2)"] = function(assert) {
-  const map = new SourceMapGenerator({
-    file: "generated-foo.js",
-    sourceRoot: "."
-  });
-
-  assert.doesNotThrow(function() {
+  assert.doesNotThrow(function () {
     map.addMapping({
       generated: { line: 1, column: 1 },
-      source: "bar.js",
-      original: { line: 1, column: 1 }
     });
   });
 };
 
-exports["test adding mappings (case 3)"] = function(assert) {
+exports["test adding mappings (case 2)"] = function (assert) {
   const map = new SourceMapGenerator({
     file: "generated-foo.js",
-    sourceRoot: "."
+    sourceRoot: ".",
   });
 
-  assert.doesNotThrow(function() {
+  assert.doesNotThrow(function () {
     map.addMapping({
       generated: { line: 1, column: 1 },
       source: "bar.js",
       original: { line: 1, column: 1 },
-      name: "someToken"
     });
   });
 };
 
-exports["test adding mappings (invalid)"] = function(assert) {
+exports["test adding mappings (case 3)"] = function (assert) {
   const map = new SourceMapGenerator({
     file: "generated-foo.js",
-    sourceRoot: "."
+    sourceRoot: ".",
+  });
+
+  assert.doesNotThrow(function () {
+    map.addMapping({
+      generated: { line: 1, column: 1 },
+      source: "bar.js",
+      original: { line: 1, column: 1 },
+      name: "someToken",
+    });
+  });
+};
+
+exports["test adding mappings (invalid)"] = function (assert) {
+  const map = new SourceMapGenerator({
+    file: "generated-foo.js",
+    sourceRoot: ".",
   });
 
   // Not enough info.
-  assert.throws(function() {
+  assert.throws(function () {
     map.addMapping({});
   }, /"generated" is a required argument/);
 
   // Original file position, but no source.
-  assert.throws(function() {
+  assert.throws(function () {
     map.addMapping({
       generated: { line: 1, column: 1 },
-      original: { line: 1, column: 1 }
+      original: { line: 1, column: 1 },
     });
   }, /Invalid mapping/);
 };
 
-exports["test adding mappings with skipValidation"] = function(assert) {
+exports["test adding mappings with skipValidation"] = function (assert) {
   const map = new SourceMapGenerator({
     file: "generated-foo.js",
     sourceRoot: ".",
-    skipValidation: true
+    skipValidation: true,
   });
 
   // Not enough info, caught by `util.getArgs`
-  assert.throws(function() {
+  assert.throws(function () {
     map.addMapping({});
   }, /"generated" is a required argument/);
 
   // Original file position, but no source. Not checked.
-  assert.doesNotThrow(function() {
+  assert.doesNotThrow(function () {
     map.addMapping({
       generated: { line: 1, column: 1 },
-      original: { line: 1, column: 1 }
+      original: { line: 1, column: 1 },
     });
   }, /Invalid mapping/);
 };
 
-exports["test that the correct mappings are being generated"] = function(
+exports["test that the correct mappings are being generated"] = function (
   assert
 ) {
   let map = new SourceMapGenerator({
     file: "min.js",
-    sourceRoot: "/the/root"
+    sourceRoot: "/the/root",
   });
 
   map.addMapping({
     generated: { line: 1, column: 1 },
     original: { line: 1, column: 1 },
-    source: "one.js"
+    source: "one.js",
   });
   map.addMapping({
     generated: { line: 1, column: 5 },
     original: { line: 1, column: 5 },
-    source: "one.js"
+    source: "one.js",
   });
   map.addMapping({
     generated: { line: 1, column: 9 },
     original: { line: 1, column: 11 },
-    source: "one.js"
+    source: "one.js",
   });
   map.addMapping({
     generated: { line: 1, column: 18 },
     original: { line: 1, column: 21 },
     source: "one.js",
-    name: "bar"
+    name: "bar",
   });
   map.addMapping({
     generated: { line: 1, column: 21 },
     original: { line: 2, column: 3 },
-    source: "one.js"
+    source: "one.js",
   });
   map.addMapping({
     generated: { line: 1, column: 28 },
     original: { line: 2, column: 10 },
     source: "one.js",
-    name: "baz"
+    name: "baz",
   });
   map.addMapping({
     generated: { line: 1, column: 32 },
     original: { line: 2, column: 14 },
     source: "one.js",
-    name: "bar"
+    name: "bar",
   });
 
   map.addMapping({
     generated: { line: 2, column: 1 },
     original: { line: 1, column: 1 },
-    source: "two.js"
+    source: "two.js",
   });
   map.addMapping({
     generated: { line: 2, column: 5 },
     original: { line: 1, column: 5 },
-    source: "two.js"
+    source: "two.js",
   });
   map.addMapping({
     generated: { line: 2, column: 9 },
     original: { line: 1, column: 11 },
-    source: "two.js"
+    source: "two.js",
   });
   map.addMapping({
     generated: { line: 2, column: 18 },
     original: { line: 1, column: 21 },
     source: "two.js",
-    name: "n"
+    name: "n",
   });
   map.addMapping({
     generated: { line: 2, column: 21 },
     original: { line: 2, column: 3 },
-    source: "two.js"
+    source: "two.js",
   });
   map.addMapping({
     generated: { line: 2, column: 28 },
     original: { line: 2, column: 10 },
     source: "two.js",
-    name: "n"
+    name: "n",
   });
 
   map = JSON.parse(map.toString());
@@ -205,38 +205,38 @@ exports["test that the correct mappings are being generated"] = function(
 
 exports[
   "test that adding a mapping with an empty string name does not break generation"
-] = function(assert) {
+] = function (assert) {
   const map = new SourceMapGenerator({
     file: "generated-foo.js",
-    sourceRoot: "."
+    sourceRoot: ".",
   });
 
   map.addMapping({
     generated: { line: 1, column: 1 },
     source: "bar.js",
     original: { line: 1, column: 1 },
-    name: ""
+    name: "",
   });
 
-  assert.doesNotThrow(function() {
+  assert.doesNotThrow(function () {
     JSON.parse(map.toString());
   });
 };
 
-exports["test that source content can be set"] = function(assert) {
+exports["test that source content can be set"] = function (assert) {
   let map = new SourceMapGenerator({
     file: "min.js",
-    sourceRoot: "/the/root"
+    sourceRoot: "/the/root",
   });
   map.addMapping({
     generated: { line: 1, column: 1 },
     original: { line: 1, column: 1 },
-    source: "one.js"
+    source: "one.js",
   });
   map.addMapping({
     generated: { line: 2, column: 1 },
     original: { line: 1, column: 1 },
-    source: "two.js"
+    source: "two.js",
   });
   map.setSourceContent("one.js", "one file content");
 
@@ -247,52 +247,51 @@ exports["test that source content can be set"] = function(assert) {
   assert.equal(map.sourcesContent[1], null);
 };
 
-exports["test .fromSourceMap"] = async function(assert) {
+exports["test .fromSourceMap"] = async function (assert) {
   const smc = await new SourceMapConsumer(util.testMap);
   const map = SourceMapGenerator.fromSourceMap(smc);
   smc.destroy();
   util.assertEqualMaps(assert, map.toJSON(), util.testMap);
 };
 
-exports["test .fromSourceMap with sourcesContent"] = async function(assert) {
+exports["test .fromSourceMap with sourcesContent"] = async function (assert) {
   const smc = await new SourceMapConsumer(util.testMapWithSourcesContent);
   const map = SourceMapGenerator.fromSourceMap(smc);
   smc.destroy();
   util.assertEqualMaps(assert, map.toJSON(), util.testMapWithSourcesContent);
 };
 
-exports["test .fromSourceMap with single source"] = async function(assert) {
+exports["test .fromSourceMap with single source"] = async function (assert) {
   const smc = await new SourceMapConsumer(util.testMapSingleSource);
   const map = SourceMapGenerator.fromSourceMap(smc);
   smc.destroy();
   util.assertEqualMaps(assert, map.toJSON(), util.testMapSingleSource);
 };
 
-exports["test .fromSourceMap with empty mappings"] = async function(assert) {
+exports["test .fromSourceMap with empty mappings"] = async function (assert) {
   const smc = await new SourceMapConsumer(util.testMapEmptyMappings);
   const map = SourceMapGenerator.fromSourceMap(smc);
   smc.destroy();
   util.assertEqualMaps(assert, map.toJSON(), util.testMapEmptyMappings);
 };
 
-exports[
-  "test .fromSourceMap with empty mappings and relative sources"
-] = async function(assert) {
-  const smc = await new SourceMapConsumer(
-    util.testMapEmptyMappingsRelativeSources
-  );
-  const map = SourceMapGenerator.fromSourceMap(smc);
-  smc.destroy();
-  util.assertEqualMaps(
-    assert,
-    map.toJSON(),
-    util.testMapEmptyMappingsRelativeSources_generatedExpected
-  );
-};
+exports["test .fromSourceMap with empty mappings and relative sources"] =
+  async function (assert) {
+    const smc = await new SourceMapConsumer(
+      util.testMapEmptyMappingsRelativeSources
+    );
+    const map = SourceMapGenerator.fromSourceMap(smc);
+    smc.destroy();
+    util.assertEqualMaps(
+      assert,
+      map.toJSON(),
+      util.testMapEmptyMappingsRelativeSources_generatedExpected
+    );
+  };
 
 exports[
   "test .fromSourceMap with multiple sources where mappings refers only to single source"
-] = async function(assert) {
+] = async function (assert) {
   const smc = await new SourceMapConsumer(
     util.testMapMultiSourcesMappingRefersSingleSourceOnly
   );
@@ -305,7 +304,7 @@ exports[
   );
 };
 
-exports["test applySourceMap"] = async function(assert) {
+exports["test applySourceMap"] = async function (assert) {
   let node = new SourceNode(null, null, null, [
     new SourceNode(2, 0, "fileX", "lineX2\n"),
     "genA1\n",
@@ -313,10 +312,10 @@ exports["test applySourceMap"] = async function(assert) {
     "genA2\n",
     new SourceNode(1, 0, "fileX", "lineX1\n"),
     "genA3\n",
-    new SourceNode(1, 0, "fileY", "lineY1\n")
+    new SourceNode(1, 0, "fileY", "lineY1\n"),
   ]);
   let mapStep1 = node.toStringWithSourceMap({
-    file: "fileA"
+    file: "fileA",
   }).map;
   mapStep1.setSourceContent("fileX", "lineX1\nlineX2\n");
   mapStep1 = mapStep1.toJSON();
@@ -329,10 +328,10 @@ exports["test applySourceMap"] = async function(assert) {
     new SourceNode(4, 0, "fileA", "lineA4\n"),
     new SourceNode(1, 0, "fileB", "lineB1\n"),
     new SourceNode(2, 0, "fileB", "lineB2\n"),
-    "gen2\n"
+    "gen2\n",
   ]);
   let mapStep2 = node.toStringWithSourceMap({
-    file: "fileGen"
+    file: "fileGen",
   }).map;
   mapStep2.setSourceContent("fileB", "lineB1\nlineB2\n");
   mapStep2 = mapStep2.toJSON();
@@ -345,10 +344,10 @@ exports["test applySourceMap"] = async function(assert) {
     new SourceNode(4, 0, "fileA", "lineA4\n"),
     new SourceNode(1, 0, "fileB", "lineB1\n"),
     new SourceNode(2, 0, "fileB", "lineB2\n"),
-    "gen2\n"
+    "gen2\n",
   ]);
   let expectedMap = node.toStringWithSourceMap({
-    file: "fileGen"
+    file: "fileGen",
   }).map;
   expectedMap.setSourceContent("fileX", "lineX1\nlineX2\n");
   expectedMap.setSourceContent("fileB", "lineB1\nlineB2\n");
@@ -367,11 +366,11 @@ exports["test applySourceMap"] = async function(assert) {
   util.assertEqualMaps(assert, actualMap, expectedMap);
 };
 
-exports["test applySourceMap throws when file is missing"] = async function(
+exports["test applySourceMap throws when file is missing"] = async function (
   assert
 ) {
   const map = new SourceMapGenerator({
-    file: "test.js"
+    file: "test.js",
   });
   const map2 = new SourceMapGenerator();
 
@@ -387,205 +386,207 @@ exports["test applySourceMap throws when file is missing"] = async function(
   assert.ok(error instanceof Error);
 };
 
-exports[
-  "test the two additional parameters of applySourceMap"
-] = async function(assert) {
-  // Assume the following directory structure:
-  //
-  // http://foo.org/
-  //   bar.coffee
-  //   app/
-  //     coffee/
-  //       foo.coffee
-  //     temp/
-  //       bundle.js
-  //       temp_maps/
-  //         bundle.js.map
-  //     public/
-  //       bundle.min.js
-  //       bundle.min.js.map
-  //
-  // http://www.example.com/
-  //   baz.coffee
+exports["test the two additional parameters of applySourceMap"] =
+  async function (assert) {
+    // Assume the following directory structure:
+    //
+    // http://foo.org/
+    //   bar.coffee
+    //   app/
+    //     coffee/
+    //       foo.coffee
+    //     temp/
+    //       bundle.js
+    //       temp_maps/
+    //         bundle.js.map
+    //     public/
+    //       bundle.min.js
+    //       bundle.min.js.map
+    //
+    // http://www.example.com/
+    //   baz.coffee
 
-  let bundleMap = new SourceMapGenerator({
-    file: "bundle.js"
-  });
-  bundleMap.addMapping({
-    generated: { line: 3, column: 3 },
-    original: { line: 2, column: 2 },
-    source: "../../coffee/foo.coffee"
-  });
-  bundleMap.setSourceContent("../../coffee/foo.coffee", "foo coffee");
-  bundleMap.addMapping({
-    generated: { line: 13, column: 13 },
-    original: { line: 12, column: 12 },
-    source: "/bar.coffee"
-  });
-  bundleMap.setSourceContent("/bar.coffee", "bar coffee");
-  bundleMap.addMapping({
-    generated: { line: 23, column: 23 },
-    original: { line: 22, column: 22 },
-    source: "http://www.example.com/baz.coffee"
-  });
-  bundleMap.setSourceContent("http://www.example.com/baz.coffee", "baz coffee");
-  bundleMap = await new SourceMapConsumer(bundleMap.toJSON());
-
-  let minifiedMap = new SourceMapGenerator({
-    file: "bundle.min.js",
-    sourceRoot: ".."
-  });
-  minifiedMap.addMapping({
-    generated: { line: 1, column: 1 },
-    original: { line: 3, column: 3 },
-    source: "temp/bundle.js"
-  });
-  minifiedMap.addMapping({
-    generated: { line: 11, column: 11 },
-    original: { line: 13, column: 13 },
-    source: "temp/bundle.js"
-  });
-  minifiedMap.addMapping({
-    generated: { line: 21, column: 21 },
-    original: { line: 23, column: 23 },
-    source: "temp/bundle.js"
-  });
-  minifiedMap = await new SourceMapConsumer(minifiedMap.toJSON());
-
-  const expectedMap = function(sources) {
-    const map = new SourceMapGenerator({
-      file: "bundle.min.js",
-      sourceRoot: ".."
+    let bundleMap = new SourceMapGenerator({
+      file: "bundle.js",
     });
-    map.addMapping({
-      generated: { line: 1, column: 1 },
+    bundleMap.addMapping({
+      generated: { line: 3, column: 3 },
       original: { line: 2, column: 2 },
-      source: sources[0]
+      source: "../../coffee/foo.coffee",
     });
-    map.setSourceContent(sources[0], "foo coffee");
-    map.addMapping({
-      generated: { line: 11, column: 11 },
+    bundleMap.setSourceContent("../../coffee/foo.coffee", "foo coffee");
+    bundleMap.addMapping({
+      generated: { line: 13, column: 13 },
       original: { line: 12, column: 12 },
-      source: sources[1]
+      source: "/bar.coffee",
     });
-    map.setSourceContent(sources[1], "bar coffee");
-    map.addMapping({
-      generated: { line: 21, column: 21 },
+    bundleMap.setSourceContent("/bar.coffee", "bar coffee");
+    bundleMap.addMapping({
+      generated: { line: 23, column: 23 },
       original: { line: 22, column: 22 },
-      source: sources[2]
+      source: "http://www.example.com/baz.coffee",
     });
-    map.setSourceContent(sources[2], "baz coffee");
-    return map.toJSON();
+    bundleMap.setSourceContent(
+      "http://www.example.com/baz.coffee",
+      "baz coffee"
+    );
+    bundleMap = await new SourceMapConsumer(bundleMap.toJSON());
+
+    let minifiedMap = new SourceMapGenerator({
+      file: "bundle.min.js",
+      sourceRoot: "..",
+    });
+    minifiedMap.addMapping({
+      generated: { line: 1, column: 1 },
+      original: { line: 3, column: 3 },
+      source: "temp/bundle.js",
+    });
+    minifiedMap.addMapping({
+      generated: { line: 11, column: 11 },
+      original: { line: 13, column: 13 },
+      source: "temp/bundle.js",
+    });
+    minifiedMap.addMapping({
+      generated: { line: 21, column: 21 },
+      original: { line: 23, column: 23 },
+      source: "temp/bundle.js",
+    });
+    minifiedMap = await new SourceMapConsumer(minifiedMap.toJSON());
+
+    const expectedMap = function (sources) {
+      const map = new SourceMapGenerator({
+        file: "bundle.min.js",
+        sourceRoot: "..",
+      });
+      map.addMapping({
+        generated: { line: 1, column: 1 },
+        original: { line: 2, column: 2 },
+        source: sources[0],
+      });
+      map.setSourceContent(sources[0], "foo coffee");
+      map.addMapping({
+        generated: { line: 11, column: 11 },
+        original: { line: 12, column: 12 },
+        source: sources[1],
+      });
+      map.setSourceContent(sources[1], "bar coffee");
+      map.addMapping({
+        generated: { line: 21, column: 21 },
+        original: { line: 22, column: 22 },
+        source: sources[2],
+      });
+      map.setSourceContent(sources[2], "baz coffee");
+      return map.toJSON();
+    };
+
+    const actualMap = function (aSourceMapPath) {
+      const map = SourceMapGenerator.fromSourceMap(minifiedMap);
+      // Note that relying on `bundleMap.file` (which is simply 'bundle.js')
+      // instead of supplying the second parameter wouldn't work here.
+      map.applySourceMap(bundleMap, "../temp/bundle.js", aSourceMapPath);
+      return map.toJSON();
+    };
+
+    util.assertEqualMaps(
+      assert,
+      actualMap("../temp/temp_maps"),
+      expectedMap([
+        "coffee/foo.coffee",
+        "/bar.coffee",
+        "http://www.example.com/baz.coffee",
+      ])
+    );
+
+    util.assertEqualMaps(
+      assert,
+      actualMap("/app/temp/temp_maps"),
+      expectedMap([
+        "/app/coffee/foo.coffee",
+        "/bar.coffee",
+        "http://www.example.com/baz.coffee",
+      ])
+    );
+
+    util.assertEqualMaps(
+      assert,
+      actualMap("http://foo.org/app/temp/temp_maps"),
+      expectedMap([
+        "http://foo.org/app/coffee/foo.coffee",
+        "http://foo.org/bar.coffee",
+        "http://www.example.com/baz.coffee",
+      ])
+    );
+
+    // If the third parameter is omitted or set to the current working
+    // directory we get incorrect source paths:
+
+    util.assertEqualMaps(
+      assert,
+      actualMap(),
+      expectedMap([
+        "../coffee/foo.coffee",
+        "/bar.coffee",
+        "http://www.example.com/baz.coffee",
+      ])
+    );
+
+    util.assertEqualMaps(
+      assert,
+      actualMap(""),
+      expectedMap([
+        "../coffee/foo.coffee",
+        "/bar.coffee",
+        "http://www.example.com/baz.coffee",
+      ])
+    );
+
+    util.assertEqualMaps(
+      assert,
+      actualMap("."),
+      expectedMap([
+        "../coffee/foo.coffee",
+        "/bar.coffee",
+        "http://www.example.com/baz.coffee",
+      ])
+    );
+
+    util.assertEqualMaps(
+      assert,
+      actualMap("./"),
+      expectedMap([
+        "../coffee/foo.coffee",
+        "/bar.coffee",
+        "http://www.example.com/baz.coffee",
+      ])
+    );
+
+    bundleMap.destroy();
+    minifiedMap.destroy();
   };
 
-  const actualMap = function(aSourceMapPath) {
-    const map = SourceMapGenerator.fromSourceMap(minifiedMap);
-    // Note that relying on `bundleMap.file` (which is simply 'bundle.js')
-    // instead of supplying the second parameter wouldn't work here.
-    map.applySourceMap(bundleMap, "../temp/bundle.js", aSourceMapPath);
-    return map.toJSON();
-  };
-
-  util.assertEqualMaps(
-    assert,
-    actualMap("../temp/temp_maps"),
-    expectedMap([
-      "coffee/foo.coffee",
-      "/bar.coffee",
-      "http://www.example.com/baz.coffee"
-    ])
-  );
-
-  util.assertEqualMaps(
-    assert,
-    actualMap("/app/temp/temp_maps"),
-    expectedMap([
-      "/app/coffee/foo.coffee",
-      "/bar.coffee",
-      "http://www.example.com/baz.coffee"
-    ])
-  );
-
-  util.assertEqualMaps(
-    assert,
-    actualMap("http://foo.org/app/temp/temp_maps"),
-    expectedMap([
-      "http://foo.org/app/coffee/foo.coffee",
-      "http://foo.org/bar.coffee",
-      "http://www.example.com/baz.coffee"
-    ])
-  );
-
-  // If the third parameter is omitted or set to the current working
-  // directory we get incorrect source paths:
-
-  util.assertEqualMaps(
-    assert,
-    actualMap(),
-    expectedMap([
-      "../coffee/foo.coffee",
-      "/bar.coffee",
-      "http://www.example.com/baz.coffee"
-    ])
-  );
-
-  util.assertEqualMaps(
-    assert,
-    actualMap(""),
-    expectedMap([
-      "../coffee/foo.coffee",
-      "/bar.coffee",
-      "http://www.example.com/baz.coffee"
-    ])
-  );
-
-  util.assertEqualMaps(
-    assert,
-    actualMap("."),
-    expectedMap([
-      "../coffee/foo.coffee",
-      "/bar.coffee",
-      "http://www.example.com/baz.coffee"
-    ])
-  );
-
-  util.assertEqualMaps(
-    assert,
-    actualMap("./"),
-    expectedMap([
-      "../coffee/foo.coffee",
-      "/bar.coffee",
-      "http://www.example.com/baz.coffee"
-    ])
-  );
-
-  bundleMap.destroy();
-  minifiedMap.destroy();
-};
-
-exports["test applySourceMap name handling"] = async function(assert) {
+exports["test applySourceMap name handling"] = async function (assert) {
   // Imagine some CoffeeScript code being compiled into JavaScript and then
   // minified.
 
-  const assertName = async function(coffeeName, jsName, expectedName) {
+  const assertName = async function (coffeeName, jsName, expectedName) {
     const minifiedMap = new SourceMapGenerator({
-      file: "test.js.min"
+      file: "test.js.min",
     });
     minifiedMap.addMapping({
       generated: { line: 1, column: 4 },
       original: { line: 1, column: 4 },
       source: "test.js",
-      name: jsName
+      name: jsName,
     });
 
     const coffeeMap = new SourceMapGenerator({
-      file: "test.js"
+      file: "test.js",
     });
     coffeeMap.addMapping({
       generated: { line: 1, column: 4 },
       original: { line: 1, column: 0 },
       source: "test.coffee",
-      name: coffeeName
+      name: coffeeName,
     });
 
     let consumer = await new SourceMapConsumer(coffeeMap.toJSON());
@@ -593,7 +594,7 @@ exports["test applySourceMap name handling"] = async function(assert) {
     consumer.destroy();
 
     consumer = await new SourceMapConsumer(minifiedMap.toJSON());
-    consumer.eachMapping(function(mapping) {
+    consumer.eachMapping(function (mapping) {
       assert.equal(mapping.name, expectedName);
     });
     consumer.destroy();
@@ -623,25 +624,25 @@ exports["test applySourceMap name handling"] = async function(assert) {
   await assertName(null, null, null);
 };
 
-exports["test sorting with duplicate generated mappings"] = function(assert) {
+exports["test sorting with duplicate generated mappings"] = function (assert) {
   const map = new SourceMapGenerator({
-    file: "test.js"
+    file: "test.js",
   });
   map.addMapping({
     generated: { line: 3, column: 0 },
     original: { line: 2, column: 0 },
-    source: "a.js"
+    source: "a.js",
   });
   map.addMapping({
-    generated: { line: 2, column: 0 }
+    generated: { line: 2, column: 0 },
   });
   map.addMapping({
-    generated: { line: 2, column: 0 }
+    generated: { line: 2, column: 0 },
   });
   map.addMapping({
     generated: { line: 1, column: 0 },
     original: { line: 1, column: 0 },
-    source: "a.js"
+    source: "a.js",
   });
 
   util.assertEqualMaps(assert, map.toJSON(), {
@@ -649,20 +650,20 @@ exports["test sorting with duplicate generated mappings"] = function(assert) {
     file: "test.js",
     sources: ["a.js"],
     names: [],
-    mappings: "AAAA;A;AACA"
+    mappings: "AAAA;A;AACA",
   });
 };
 
-exports["test ignore duplicate mappings."] = function(assert) {
+exports["test ignore duplicate mappings."] = function (assert) {
   const init = { file: "min.js", sourceRoot: "/the/root" };
   let map1, map2;
 
   // null original source location
   const nullMapping1 = {
-    generated: { line: 1, column: 0 }
+    generated: { line: 1, column: 0 },
   };
   const nullMapping2 = {
-    generated: { line: 2, column: 2 }
+    generated: { line: 2, column: 2 },
   };
 
   map1 = new SourceMapGenerator(init);
@@ -686,12 +687,12 @@ exports["test ignore duplicate mappings."] = function(assert) {
   const srcMapping1 = {
     generated: { line: 1, column: 0 },
     original: { line: 11, column: 0 },
-    source: "srcMapping1.js"
+    source: "srcMapping1.js",
   };
   const srcMapping2 = {
     generated: { line: 2, column: 2 },
     original: { line: 11, column: 0 },
-    source: "srcMapping2.js"
+    source: "srcMapping2.js",
   };
 
   map1 = new SourceMapGenerator(init);
@@ -716,13 +717,13 @@ exports["test ignore duplicate mappings."] = function(assert) {
     generated: { line: 1, column: 0 },
     original: { line: 11, column: 0 },
     source: "fullMapping1.js",
-    name: "fullMapping1"
+    name: "fullMapping1",
   };
   const fullMapping2 = {
     generated: { line: 2, column: 2 },
     original: { line: 11, column: 0 },
     source: "fullMapping2.js",
-    name: "fullMapping2"
+    name: "fullMapping2",
   };
 
   map1 = new SourceMapGenerator(init);
@@ -743,78 +744,77 @@ exports["test ignore duplicate mappings."] = function(assert) {
   util.assertEqualMaps(assert, map1.toJSON(), map2.toJSON());
 };
 
-exports[
-  "test github issue #72, check for duplicate names or sources"
-] = function(assert) {
-  const map = new SourceMapGenerator({
-    file: "test.js"
-  });
-  map.addMapping({
-    generated: { line: 1, column: 1 },
-    original: { line: 2, column: 2 },
-    source: "a.js",
-    name: "foo"
-  });
-  map.addMapping({
-    generated: { line: 3, column: 3 },
-    original: { line: 4, column: 4 },
-    source: "a.js",
-    name: "foo"
-  });
-  util.assertEqualMaps(assert, map.toJSON(), {
-    version: 3,
-    file: "test.js",
-    sources: ["a.js"],
-    names: ["foo"],
-    mappings: "CACEA;;GAEEA"
-  });
-};
+exports["test github issue #72, check for duplicate names or sources"] =
+  function (assert) {
+    const map = new SourceMapGenerator({
+      file: "test.js",
+    });
+    map.addMapping({
+      generated: { line: 1, column: 1 },
+      original: { line: 2, column: 2 },
+      source: "a.js",
+      name: "foo",
+    });
+    map.addMapping({
+      generated: { line: 3, column: 3 },
+      original: { line: 4, column: 4 },
+      source: "a.js",
+      name: "foo",
+    });
+    util.assertEqualMaps(assert, map.toJSON(), {
+      version: 3,
+      file: "test.js",
+      sources: ["a.js"],
+      names: ["foo"],
+      mappings: "CACEA;;GAEEA",
+    });
+  };
 
-exports["test setting sourcesContent to null when already null"] = function(
+exports["test setting sourcesContent to null when already null"] = function (
   assert
 ) {
   const smg = new SourceMapGenerator({ file: "foo.js" });
-  assert.doesNotThrow(function() {
+  assert.doesNotThrow(function () {
     smg.setSourceContent("bar.js", null);
   });
 };
 
-exports["test applySourceMap with unexact match"] = async function(assert) {
+exports["test applySourceMap with unexact match"] = async function (assert) {
   const map1 = new SourceMapGenerator({
-    file: "bundled-source"
+    file: "bundled-source",
   });
   map1.addMapping({
     generated: { line: 1, column: 4 },
     original: { line: 1, column: 4 },
-    source: "transformed-source"
+    source: "transformed-source",
   });
   map1.addMapping({
     generated: { line: 2, column: 4 },
     original: { line: 2, column: 4 },
-    source: "transformed-source"
+    source: "transformed-source",
   });
 
   const map2 = new SourceMapGenerator({
-    file: "transformed-source"
+    file: "transformed-source",
   });
   map2.addMapping({
     generated: { line: 2, column: 0 },
     original: { line: 1, column: 0 },
-    source: "original-source"
+    source: "original-source",
   });
 
   const expectedMap = new SourceMapGenerator({
-    file: "bundled-source"
+    file: "bundled-source",
   });
   expectedMap.addMapping({
     generated: { line: 1, column: 4 },
     original: { line: 1, column: 4 },
-    source: "transformed-source"
+    source: "transformed-source",
   });
   expectedMap.addMapping({
     generated: { line: 2, column: 4 },
     original: { line: 1, column: 0 },
-    source: "original-source"
+    source: "original-source",
   });
 
   const consumer = await new SourceMapConsumer(map2.toJSON());
@@ -824,7 +824,7 @@ exports["test applySourceMap with unexact match"] = async function(assert) {
   util.assertEqualMaps(assert, map1.toJSON(), expectedMap.toJSON());
 };
 
-exports["test applySourceMap with empty mappings"] = async function(assert) {
+exports["test applySourceMap with empty mappings"] = async function (assert) {
   let consumer = await new SourceMapConsumer(util.testMapEmptyMappings);
   const generator = SourceMapGenerator.fromSourceMap(consumer);
   consumer.destroy();
@@ -836,45 +836,44 @@ exports["test applySourceMap with empty mappings"] = async function(assert) {
   util.assertEqualMaps(assert, generator.toJSON(), util.testMapEmptyMappings);
 };
 
-exports[
-  "test applySourceMap with empty mappings and relative sources"
-] = async function(assert) {
-  let consumer = await new SourceMapConsumer(
-    util.testMapEmptyMappingsRelativeSources
-  );
-  const generator = SourceMapGenerator.fromSourceMap(consumer);
-  consumer.destroy();
+exports["test applySourceMap with empty mappings and relative sources"] =
+  async function (assert) {
+    let consumer = await new SourceMapConsumer(
+      util.testMapEmptyMappingsRelativeSources
+    );
+    const generator = SourceMapGenerator.fromSourceMap(consumer);
+    consumer.destroy();
 
-  consumer = await new SourceMapConsumer(
-    util.testMapEmptyMappingsRelativeSources
-  );
-  generator.applySourceMap(consumer);
-  consumer.destroy();
+    consumer = await new SourceMapConsumer(
+      util.testMapEmptyMappingsRelativeSources
+    );
+    generator.applySourceMap(consumer);
+    consumer.destroy();
 
-  util.assertEqualMaps(
-    assert,
-    generator.toJSON(),
-    util.testMapEmptyMappingsRelativeSources_generatedExpected
-  );
-};
+    util.assertEqualMaps(
+      assert,
+      generator.toJSON(),
+      util.testMapEmptyMappingsRelativeSources_generatedExpected
+    );
+  };
 
-exports["test issue #192"] = async function(assert) {
+exports["test issue #192"] = async function (assert) {
   const generator = new SourceMapGenerator();
   generator.addMapping({
     source: "a.js",
     generated: { line: 1, column: 10 },
-    original: { line: 1, column: 10 }
+    original: { line: 1, column: 10 },
   });
   generator.addMapping({
     source: "b.js",
     generated: { line: 1, column: 10 },
-    original: { line: 2, column: 20 }
+    original: { line: 2, column: 20 },
   });
 
   const consumer = await new SourceMapConsumer(generator.toJSON());
 
   let n = 0;
-  consumer.eachMapping(function() {
+  consumer.eachMapping(function () {
     n++;
   });
 
@@ -887,13 +886,13 @@ exports["test issue #192"] = async function(assert) {
   consumer.destroy();
 };
 
-exports["test numeric names #231"] = function(assert) {
+exports["test numeric names #231"] = function (assert) {
   const generator = new SourceMapGenerator();
   generator.addMapping({
     source: "a.js",
     generated: { line: 1, column: 10 },
     original: { line: 1, column: 10 },
-    name: 8
+    name: 8,
   });
   const map = generator.toJSON();
   assert.ok(map, "Adding a mapping with a numeric name did not throw");

--- a/test/test-source-node.js
+++ b/test/test-source-node.js
@@ -6,20 +6,20 @@
  */
 
 const util = require("./util");
-const SourceMapGenerator = require("../lib/source-map-generator")
-  .SourceMapGenerator;
-const SourceMapConsumer = require("../lib/source-map-consumer")
-  .SourceMapConsumer;
+const SourceMapGenerator =
+  require("../lib/source-map-generator").SourceMapGenerator;
+const SourceMapConsumer =
+  require("../lib/source-map-consumer").SourceMapConsumer;
 const SourceNode = require("../lib/source-node").SourceNode;
 
 function forEachNewline(fn) {
-  return async function(assert) {
+  return async function (assert) {
     await fn(assert, "\n");
     await fn(assert, "\r\n");
   };
 }
 
-exports["test .add()"] = function(assert) {
+exports["test .add()"] = function (assert) {
   const node = new SourceNode(null, null, null);
 
   // Adding a string works.
@@ -32,19 +32,19 @@ exports["test .add()"] = function(assert) {
   node.add([
     "function foo() {",
     new SourceNode(null, null, null, "return 10;"),
-    "}"
+    "}",
   ]);
 
   // Adding other stuff doesn't.
-  assert.throws(function() {
+  assert.throws(function () {
     node.add({});
   }, /TypeError: Expected a SourceNode, string, or an array of SourceNodes and strings/);
-  assert.throws(function() {
-    node.add(function() {});
+  assert.throws(function () {
+    node.add(function () {});
   }, /TypeError: Expected a SourceNode, string, or an array of SourceNodes and strings/);
 };
 
-exports["test .prepend()"] = function(assert) {
+exports["test .prepend()"] = function (assert) {
   const node = new SourceNode(null, null, null);
 
   // Prepending a string works.
@@ -62,7 +62,7 @@ exports["test .prepend()"] = function(assert) {
   node.prepend([
     "function foo() {",
     new SourceNode(null, null, null, "return 10;"),
-    "}"
+    "}",
   ]);
   assert.equal(node.children[0], "function foo() {");
   assert.equal(node.children[1], "return 10;");
@@ -72,26 +72,26 @@ exports["test .prepend()"] = function(assert) {
   assert.equal(node.children.length, 5);
 
   // Prepending other stuff doesn't.
-  assert.throws(function() {
+  assert.throws(function () {
     node.prepend({});
   }, /TypeError: Expected a SourceNode, string, or an array of SourceNodes and strings/);
-  assert.throws(function() {
-    node.prepend(function() {});
+  assert.throws(function () {
+    node.prepend(function () {});
   }, /TypeError: Expected a SourceNode, string, or an array of SourceNodes and strings/);
 };
 
-exports["test .toString()"] = function(assert) {
+exports["test .toString()"] = function (assert) {
   assert.equal(
     new SourceNode(null, null, null, [
       "function foo() {",
       new SourceNode(null, null, null, "return 10;"),
-      "}"
+      "}",
     ]).toString(),
     "function foo() {return 10;}"
   );
 };
 
-exports["test .join()"] = function(assert) {
+exports["test .join()"] = function (assert) {
   assert.equal(
     new SourceNode(null, null, null, ["a", "b", "c", "d"])
       .join(", ")
@@ -100,7 +100,7 @@ exports["test .join()"] = function(assert) {
   );
 };
 
-exports["test .walk()"] = function(assert) {
+exports["test .walk()"] = function (assert) {
   const node = new SourceNode(null, null, null, [
     "(function () {\n",
     "  ",
@@ -109,7 +109,7 @@ exports["test .walk()"] = function(assert) {
     "  ",
     new SourceNode(2, 0, "b.js", ["if (foo) bar()"]),
     ";\n",
-    "}());"
+    "}());",
   ]);
   const expected = [
     { str: "(function () {\n", source: null, line: null, column: null },
@@ -119,10 +119,10 @@ exports["test .walk()"] = function(assert) {
     { str: "  ", source: null, line: null, column: null },
     { str: "if (foo) bar()", source: "b.js", line: 2, column: 0 },
     { str: ";\n", source: null, line: null, column: null },
-    { str: "}());", source: null, line: null, column: null }
+    { str: "}());", source: null, line: null, column: null },
   ];
   let i = 0;
-  node.walk(function(chunk, loc) {
+  node.walk(function (chunk, loc) {
     assert.equal(expected[i].str, chunk);
     assert.equal(expected[i].source, loc.source);
     assert.equal(expected[i].line, loc.line);
@@ -131,7 +131,7 @@ exports["test .walk()"] = function(assert) {
   });
 };
 
-exports["test .replaceRight"] = function(assert) {
+exports["test .replaceRight"] = function (assert) {
   let node;
 
   // Not nested
@@ -142,13 +142,13 @@ exports["test .replaceRight"] = function(assert) {
   // Nested
   node = new SourceNode(null, null, null, [
     new SourceNode(null, null, null, "hey sexy mama, "),
-    new SourceNode(null, null, null, "want to kill all humans?")
+    new SourceNode(null, null, null, "want to kill all humans?"),
   ]);
   node.replaceRight(/kill all humans/, "watch Futurama");
   assert.equal(node.toString(), "hey sexy mama, want to watch Futurama?");
 };
 
-exports["test .toStringWithSourceMap()"] = forEachNewline(async function(
+exports["test .toStringWithSourceMap()"] = forEachNewline(async function (
   assert,
   nl
 ) {
@@ -161,10 +161,10 @@ exports["test .toStringWithSourceMap()"] = forEachNewline(async function(
     "  ",
     new SourceNode(2, 0, "b.js", ["if (foo) bar()"]),
     ";" + nl,
-    "}());"
+    "}());",
   ]);
   const result = node.toStringWithSourceMap({
-    file: "foo.js"
+    file: "foo.js",
   });
 
   assert.equal(
@@ -193,7 +193,7 @@ exports["test .toStringWithSourceMap()"] = forEachNewline(async function(
 
   actual = map.originalPositionFor({
     line: 1,
-    column: 4
+    column: 4,
   });
   assert.equal(actual.source, null);
   assert.equal(actual.line, null);
@@ -201,7 +201,7 @@ exports["test .toStringWithSourceMap()"] = forEachNewline(async function(
 
   actual = map.originalPositionFor({
     line: 2,
-    column: 2
+    column: 2,
   });
   assert.equal(actual.source, "a.js");
   assert.equal(actual.line, 1);
@@ -210,7 +210,7 @@ exports["test .toStringWithSourceMap()"] = forEachNewline(async function(
 
   actual = map.originalPositionFor({
     line: 3,
-    column: 2
+    column: 2,
   });
   assert.equal(actual.source, "b.js");
   assert.equal(actual.line, 2);
@@ -218,7 +218,7 @@ exports["test .toStringWithSourceMap()"] = forEachNewline(async function(
 
   actual = map.originalPositionFor({
     line: 3,
-    column: 16
+    column: 16,
   });
   assert.equal(actual.source, null);
   assert.equal(actual.line, null);
@@ -226,7 +226,7 @@ exports["test .toStringWithSourceMap()"] = forEachNewline(async function(
 
   actual = map.originalPositionFor({
     line: 4,
-    column: 2
+    column: 2,
   });
   assert.equal(actual.source, null);
   assert.equal(actual.line, null);
@@ -235,7 +235,7 @@ exports["test .toStringWithSourceMap()"] = forEachNewline(async function(
   map.destroy();
 });
 
-exports["test .fromStringWithSourceMap()"] = forEachNewline(async function(
+exports["test .fromStringWithSourceMap()"] = forEachNewline(async function (
   assert,
   nl
 ) {
@@ -245,7 +245,7 @@ exports["test .fromStringWithSourceMap()"] = forEachNewline(async function(
   map.destroy();
 
   const result = node.toStringWithSourceMap({
-    file: "min.js"
+    file: "min.js",
   });
   map = result.map;
   const code = result.code;
@@ -262,7 +262,7 @@ exports["test .fromStringWithSourceMap()"] = forEachNewline(async function(
 });
 
 exports["test .fromStringWithSourceMap() empty map"] = forEachNewline(
-  async function(assert, nl) {
+  async function (assert, nl) {
     let map = await new SourceMapConsumer(util.emptyMap);
     const node = SourceNode.fromStringWithSourceMap(
       util.testGeneratedCode.replace(/\n/g, nl),
@@ -271,7 +271,7 @@ exports["test .fromStringWithSourceMap() empty map"] = forEachNewline(
     map.destroy();
 
     const result = node.toStringWithSourceMap({
-      file: "min.js"
+      file: "min.js",
     });
     map = result.map;
     const code = result.code;
@@ -290,7 +290,7 @@ exports["test .fromStringWithSourceMap() empty map"] = forEachNewline(
 );
 
 exports["test .fromStringWithSourceMap() complex version"] = forEachNewline(
-  async function(assert, nl) {
+  async function (assert, nl) {
     let input = new SourceNode(null, null, null, [
       "(function() {" + nl,
       "  var Test = {};" + nl,
@@ -300,10 +300,10 @@ exports["test .fromStringWithSourceMap() complex version"] = forEachNewline(
       new SourceNode(2, 0, "a.js", "Test.A.x = 'xyz';"),
       nl,
       "}());" + nl,
-      "/* Generated Source */"
+      "/* Generated Source */",
     ]);
     input = input.toStringWithSourceMap({
-      file: "foo.js"
+      file: "foo.js",
     });
 
     let map = await new SourceMapConsumer(input.map.toString());
@@ -311,7 +311,7 @@ exports["test .fromStringWithSourceMap() complex version"] = forEachNewline(
     map.destroy();
 
     const result = node.toStringWithSourceMap({
-      file: "foo.js"
+      file: "foo.js",
     });
     map = result.map;
     const code = result.code;
@@ -327,7 +327,7 @@ exports["test .fromStringWithSourceMap() complex version"] = forEachNewline(
   }
 );
 
-exports["test .fromStringWithSourceMap() third argument"] = async function(
+exports["test .fromStringWithSourceMap() third argument"] = async function (
   assert
 ) {
   // Assume the following directory structure:
@@ -349,12 +349,12 @@ exports["test .fromStringWithSourceMap() third argument"] = async function(
   coffeeBundle.setSourceContent("foo.coffee", "foo coffee");
   coffeeBundle = coffeeBundle.toStringWithSourceMap({
     file: "foo.js",
-    sourceRoot: ".."
+    sourceRoot: "..",
   });
 
   const foo = new SourceNode(1, 0, "foo.js", "foo(js);");
 
-  const test = async function(relativePath, expectedSources) {
+  const test = async function (relativePath, expectedSources) {
     const app = new SourceNode();
 
     const map = await new SourceMapConsumer(coffeeBundle.map.toString());
@@ -365,11 +365,11 @@ exports["test .fromStringWithSourceMap() third argument"] = async function(
 
     app.add(foo);
     let i = 0;
-    app.walk(function(chunk, loc) {
+    app.walk(function (chunk, loc) {
       assert.equal(loc.source, expectedSources[i]);
       i++;
     });
-    app.walkSourceContents(function(sourceFile, sourceContent) {
+    app.walkSourceContents(function (sourceFile, sourceContent) {
       assert.equal(sourceFile, expectedSources[0]);
       assert.equal(sourceContent, "foo coffee");
     });
@@ -389,220 +389,217 @@ exports["test .fromStringWithSourceMap() third argument"] = async function(
   await test("./", ["../foo.coffee", "foo.js"]);
 };
 
-exports[
-  "test .toStringWithSourceMap() merging duplicate mappings"
-] = forEachNewline(function(assert, nl) {
-  let input = new SourceNode(null, null, null, [
-    new SourceNode(1, 0, "a.js", "(function"),
-    new SourceNode(1, 0, "a.js", "() {" + nl),
-    "  ",
-    new SourceNode(1, 0, "a.js", "var Test = "),
-    new SourceNode(1, 0, "b.js", "{};" + nl),
-    new SourceNode(2, 0, "b.js", "Test"),
-    new SourceNode(2, 0, "b.js", ".A", "A"),
-    new SourceNode(2, 20, "b.js", " = { value: ", "A"),
-    "1234",
-    new SourceNode(2, 40, "b.js", " };" + nl, "A"),
-    "}());" + nl,
-    "/* Generated Source */"
-  ]);
-  input = input.toStringWithSourceMap({
-    file: "foo.js"
+exports["test .toStringWithSourceMap() merging duplicate mappings"] =
+  forEachNewline(function (assert, nl) {
+    let input = new SourceNode(null, null, null, [
+      new SourceNode(1, 0, "a.js", "(function"),
+      new SourceNode(1, 0, "a.js", "() {" + nl),
+      "  ",
+      new SourceNode(1, 0, "a.js", "var Test = "),
+      new SourceNode(1, 0, "b.js", "{};" + nl),
+      new SourceNode(2, 0, "b.js", "Test"),
+      new SourceNode(2, 0, "b.js", ".A", "A"),
+      new SourceNode(2, 20, "b.js", " = { value: ", "A"),
+      "1234",
+      new SourceNode(2, 40, "b.js", " };" + nl, "A"),
+      "}());" + nl,
+      "/* Generated Source */",
+    ]);
+    input = input.toStringWithSourceMap({
+      file: "foo.js",
+    });
+
+    assert.equal(
+      input.code,
+      [
+        "(function() {",
+        "  var Test = {};",
+        "Test.A = { value: 1234 };",
+        "}());",
+        "/* Generated Source */",
+      ].join(nl)
+    );
+
+    let correctMap = new SourceMapGenerator({
+      file: "foo.js",
+    });
+    correctMap.addMapping({
+      generated: { line: 1, column: 0 },
+      source: "a.js",
+      original: { line: 1, column: 0 },
+    });
+    // Here is no need for a empty mapping,
+    // because mappings ends at eol
+    correctMap.addMapping({
+      generated: { line: 2, column: 2 },
+      source: "a.js",
+      original: { line: 1, column: 0 },
+    });
+    correctMap.addMapping({
+      generated: { line: 2, column: 13 },
+      source: "b.js",
+      original: { line: 1, column: 0 },
+    });
+    correctMap.addMapping({
+      generated: { line: 3, column: 0 },
+      source: "b.js",
+      original: { line: 2, column: 0 },
+    });
+    correctMap.addMapping({
+      generated: { line: 3, column: 4 },
+      source: "b.js",
+      name: "A",
+      original: { line: 2, column: 0 },
+    });
+    correctMap.addMapping({
+      generated: { line: 3, column: 6 },
+      source: "b.js",
+      name: "A",
+      original: { line: 2, column: 20 },
+    });
+    // This empty mapping is required,
+    // because there is a hole in the middle of the line
+    correctMap.addMapping({
+      generated: { line: 3, column: 18 },
+    });
+    correctMap.addMapping({
+      generated: { line: 3, column: 22 },
+      source: "b.js",
+      name: "A",
+      original: { line: 2, column: 40 },
+    });
+    // Here is no need for a empty mapping,
+    // because mappings ends at eol
+
+    const inputMap = input.map.toJSON();
+    correctMap = correctMap.toJSON();
+    util.assertEqualMaps(assert, inputMap, correctMap);
   });
 
-  assert.equal(
-    input.code,
-    [
-      "(function() {",
-      "  var Test = {};",
-      "Test.A = { value: 1234 };",
-      "}());",
-      "/* Generated Source */"
-    ].join(nl)
-  );
+exports["test .toStringWithSourceMap() multi-line SourceNodes"] =
+  forEachNewline(function (assert, nl) {
+    let input = new SourceNode(null, null, null, [
+      new SourceNode(
+        1,
+        0,
+        "a.js",
+        "(function() {" + nl + "var nextLine = 1;" + nl + "anotherLine();" + nl
+      ),
+      new SourceNode(2, 2, "b.js", "Test.call(this, 123);" + nl),
+      new SourceNode(2, 2, "b.js", "this['stuff'] = 'v';" + nl),
+      new SourceNode(2, 2, "b.js", "anotherLine();" + nl),
+      "/*" + nl + "Generated" + nl + "Source" + nl + "*/" + nl,
+      new SourceNode(3, 4, "c.js", "anotherLine();" + nl),
+      "/*" + nl + "Generated" + nl + "Source" + nl + "*/",
+    ]);
+    input = input.toStringWithSourceMap({
+      file: "foo.js",
+    });
 
-  let correctMap = new SourceMapGenerator({
-    file: "foo.js"
-  });
-  correctMap.addMapping({
-    generated: { line: 1, column: 0 },
-    source: "a.js",
-    original: { line: 1, column: 0 }
-  });
-  // Here is no need for a empty mapping,
-  // because mappings ends at eol
-  correctMap.addMapping({
-    generated: { line: 2, column: 2 },
-    source: "a.js",
-    original: { line: 1, column: 0 }
-  });
-  correctMap.addMapping({
-    generated: { line: 2, column: 13 },
-    source: "b.js",
-    original: { line: 1, column: 0 }
-  });
-  correctMap.addMapping({
-    generated: { line: 3, column: 0 },
-    source: "b.js",
-    original: { line: 2, column: 0 }
-  });
-  correctMap.addMapping({
-    generated: { line: 3, column: 4 },
-    source: "b.js",
-    name: "A",
-    original: { line: 2, column: 0 }
-  });
-  correctMap.addMapping({
-    generated: { line: 3, column: 6 },
-    source: "b.js",
-    name: "A",
-    original: { line: 2, column: 20 }
-  });
-  // This empty mapping is required,
-  // because there is a hole in the middle of the line
-  correctMap.addMapping({
-    generated: { line: 3, column: 18 }
-  });
-  correctMap.addMapping({
-    generated: { line: 3, column: 22 },
-    source: "b.js",
-    name: "A",
-    original: { line: 2, column: 40 }
-  });
-  // Here is no need for a empty mapping,
-  // because mappings ends at eol
+    assert.equal(
+      input.code,
+      [
+        "(function() {",
+        "var nextLine = 1;",
+        "anotherLine();",
+        "Test.call(this, 123);",
+        "this['stuff'] = 'v';",
+        "anotherLine();",
+        "/*",
+        "Generated",
+        "Source",
+        "*/",
+        "anotherLine();",
+        "/*",
+        "Generated",
+        "Source",
+        "*/",
+      ].join(nl)
+    );
 
-  const inputMap = input.map.toJSON();
-  correctMap = correctMap.toJSON();
-  util.assertEqualMaps(assert, inputMap, correctMap);
-});
+    let correctMap = new SourceMapGenerator({
+      file: "foo.js",
+    });
+    correctMap.addMapping({
+      generated: { line: 1, column: 0 },
+      source: "a.js",
+      original: { line: 1, column: 0 },
+    });
+    correctMap.addMapping({
+      generated: { line: 2, column: 0 },
+      source: "a.js",
+      original: { line: 1, column: 0 },
+    });
+    correctMap.addMapping({
+      generated: { line: 3, column: 0 },
+      source: "a.js",
+      original: { line: 1, column: 0 },
+    });
+    correctMap.addMapping({
+      generated: { line: 4, column: 0 },
+      source: "b.js",
+      original: { line: 2, column: 2 },
+    });
+    correctMap.addMapping({
+      generated: { line: 5, column: 0 },
+      source: "b.js",
+      original: { line: 2, column: 2 },
+    });
+    correctMap.addMapping({
+      generated: { line: 6, column: 0 },
+      source: "b.js",
+      original: { line: 2, column: 2 },
+    });
+    correctMap.addMapping({
+      generated: { line: 11, column: 0 },
+      source: "c.js",
+      original: { line: 3, column: 4 },
+    });
 
-exports[
-  "test .toStringWithSourceMap() multi-line SourceNodes"
-] = forEachNewline(function(assert, nl) {
-  let input = new SourceNode(null, null, null, [
-    new SourceNode(
-      1,
-      0,
-      "a.js",
-      "(function() {" + nl + "var nextLine = 1;" + nl + "anotherLine();" + nl
-    ),
-    new SourceNode(2, 2, "b.js", "Test.call(this, 123);" + nl),
-    new SourceNode(2, 2, "b.js", "this['stuff'] = 'v';" + nl),
-    new SourceNode(2, 2, "b.js", "anotherLine();" + nl),
-    "/*" + nl + "Generated" + nl + "Source" + nl + "*/" + nl,
-    new SourceNode(3, 4, "c.js", "anotherLine();" + nl),
-    "/*" + nl + "Generated" + nl + "Source" + nl + "*/"
-  ]);
-  input = input.toStringWithSourceMap({
-    file: "foo.js"
+    const inputMap = input.map.toJSON();
+    correctMap = correctMap.toJSON();
+    util.assertEqualMaps(assert, inputMap, correctMap);
   });
 
-  assert.equal(
-    input.code,
-    [
-      "(function() {",
-      "var nextLine = 1;",
-      "anotherLine();",
-      "Test.call(this, 123);",
-      "this['stuff'] = 'v';",
-      "anotherLine();",
-      "/*",
-      "Generated",
-      "Source",
-      "*/",
-      "anotherLine();",
-      "/*",
-      "Generated",
-      "Source",
-      "*/"
-    ].join(nl)
-  );
-
-  let correctMap = new SourceMapGenerator({
-    file: "foo.js"
-  });
-  correctMap.addMapping({
-    generated: { line: 1, column: 0 },
-    source: "a.js",
-    original: { line: 1, column: 0 }
-  });
-  correctMap.addMapping({
-    generated: { line: 2, column: 0 },
-    source: "a.js",
-    original: { line: 1, column: 0 }
-  });
-  correctMap.addMapping({
-    generated: { line: 3, column: 0 },
-    source: "a.js",
-    original: { line: 1, column: 0 }
-  });
-  correctMap.addMapping({
-    generated: { line: 4, column: 0 },
-    source: "b.js",
-    original: { line: 2, column: 2 }
-  });
-  correctMap.addMapping({
-    generated: { line: 5, column: 0 },
-    source: "b.js",
-    original: { line: 2, column: 2 }
-  });
-  correctMap.addMapping({
-    generated: { line: 6, column: 0 },
-    source: "b.js",
-    original: { line: 2, column: 2 }
-  });
-  correctMap.addMapping({
-    generated: { line: 11, column: 0 },
-    source: "c.js",
-    original: { line: 3, column: 4 }
-  });
-
-  const inputMap = input.map.toJSON();
-  correctMap = correctMap.toJSON();
-  util.assertEqualMaps(assert, inputMap, correctMap);
-});
-
-exports["test .toStringWithSourceMap() with empty string"] = function(assert) {
+exports["test .toStringWithSourceMap() with empty string"] = function (assert) {
   const node = new SourceNode(1, 0, "empty.js", "");
   const result = node.toStringWithSourceMap();
   assert.equal(result.code, "");
 };
 
-exports[
-  "test .toStringWithSourceMap() with consecutive newlines"
-] = forEachNewline(function(assert, nl) {
-  let input = new SourceNode(null, null, null, [
-    "/***/" + nl + nl,
-    new SourceNode(1, 0, "a.js", "'use strict';" + nl),
-    new SourceNode(2, 0, "a.js", "a();")
-  ]);
-  input = input.toStringWithSourceMap({
-    file: "foo.js"
+exports["test .toStringWithSourceMap() with consecutive newlines"] =
+  forEachNewline(function (assert, nl) {
+    let input = new SourceNode(null, null, null, [
+      "/***/" + nl + nl,
+      new SourceNode(1, 0, "a.js", "'use strict';" + nl),
+      new SourceNode(2, 0, "a.js", "a();"),
+    ]);
+    input = input.toStringWithSourceMap({
+      file: "foo.js",
+    });
+
+    assert.equal(input.code, ["/***/", "", "'use strict';", "a();"].join(nl));
+
+    let correctMap = new SourceMapGenerator({
+      file: "foo.js",
+    });
+    correctMap.addMapping({
+      generated: { line: 3, column: 0 },
+      source: "a.js",
+      original: { line: 1, column: 0 },
+    });
+    correctMap.addMapping({
+      generated: { line: 4, column: 0 },
+      source: "a.js",
+      original: { line: 2, column: 0 },
+    });
+
+    const inputMap = input.map.toJSON();
+    correctMap = correctMap.toJSON();
+    util.assertEqualMaps(assert, inputMap, correctMap);
   });
 
-  assert.equal(input.code, ["/***/", "", "'use strict';", "a();"].join(nl));
-
-  let correctMap = new SourceMapGenerator({
-    file: "foo.js"
-  });
-  correctMap.addMapping({
-    generated: { line: 3, column: 0 },
-    source: "a.js",
-    original: { line: 1, column: 0 }
-  });
-  correctMap.addMapping({
-    generated: { line: 4, column: 0 },
-    source: "a.js",
-    original: { line: 2, column: 0 }
-  });
-
-  const inputMap = input.map.toJSON();
-  correctMap = correctMap.toJSON();
-  util.assertEqualMaps(assert, inputMap, correctMap);
-});
-
-exports["test setSourceContent with toStringWithSourceMap"] = async function(
+exports["test setSourceContent with toStringWithSourceMap"] = async function (
   assert
 ) {
   const aNode = new SourceNode(1, 1, "a.js", "a");
@@ -613,11 +610,11 @@ exports["test setSourceContent with toStringWithSourceMap"] = async function(
     aNode,
     "  ",
     new SourceNode(1, 1, "b.js", "b"),
-    "}());"
+    "}());",
   ]);
   node.setSourceContent("b.js", "otherContent");
   let map = node.toStringWithSourceMap({
-    file: "foo.js"
+    file: "foo.js",
   }).map;
 
   assert.ok(
@@ -636,7 +633,7 @@ exports["test setSourceContent with toStringWithSourceMap"] = async function(
   map.destroy();
 };
 
-exports["test walkSourceContents"] = function(assert) {
+exports["test walkSourceContents"] = function (assert) {
   const aNode = new SourceNode(1, 1, "a.js", "a");
   aNode.setSourceContent("a.js", "someContent");
   const node = new SourceNode(null, null, null, [
@@ -645,11 +642,11 @@ exports["test walkSourceContents"] = function(assert) {
     aNode,
     "  ",
     new SourceNode(1, 1, "b.js", "b"),
-    "}());"
+    "}());",
   ]);
   node.setSourceContent("b.js", "otherContent");
   const results = [];
-  node.walkSourceContents(function(sourceFile, sourceContent) {
+  node.walkSourceContents(function (sourceFile, sourceContent) {
     results.push([sourceFile, sourceContent]);
   });
   assert.equal(results.length, 2);
@@ -659,7 +656,7 @@ exports["test walkSourceContents"] = function(assert) {
   assert.equal(results[1][1], "otherContent");
 };
 
-exports["test from issue 258"] = async function(assert) {
+exports["test from issue 258"] = async function (assert) {
   const node = new SourceNode();
 
   const reactCode =

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -6,7 +6,7 @@
  */
 
 const libUtil = require("../lib/util");
-exports["test normalize()"] = function(assert) {
+exports["test normalize()"] = function (assert) {
   assert.equal(libUtil.normalize("/.."), "/");
   assert.equal(libUtil.normalize("/../"), "/");
   assert.equal(libUtil.normalize("/../../../.."), "/");
@@ -54,7 +54,7 @@ exports["test normalize()"] = function(assert) {
   );
 };
 
-exports["test join()"] = function(assert) {
+exports["test join()"] = function (assert) {
   assert.equal(libUtil.join("a", "b"), "a/b");
   assert.equal(libUtil.join("a/", "b"), "a/b");
   assert.equal(libUtil.join("a//", "b"), "a//b");
@@ -199,7 +199,7 @@ exports["test join()"] = function(assert) {
 };
 
 // TODO Issue #128: Define and test this function properly.
-exports["test relative()"] = function(assert) {
+exports["test relative()"] = function (assert) {
   assert.equal(libUtil.relative("/the/root", "/the/root/one.js"), "one.js");
   assert.equal(
     libUtil.relative("http://the/root", "http://the/root/one.js"),
@@ -231,7 +231,7 @@ exports["test relative()"] = function(assert) {
   assert.equal(libUtil.relative("/", "the/root/one.js"), "the/root/one.js");
 };
 
-exports["test computeSourceURL"] = function(assert) {
+exports["test computeSourceURL"] = function (assert) {
   // Tests with sourceMapURL.
   assert.equal(
     libUtil.computeSourceURL("", "src/test.js", "http://example.com"),

--- a/test/util.js
+++ b/test/util.js
@@ -35,7 +35,7 @@ exports.testMap = {
   sources: ["one.js", "two.js"],
   sourceRoot: "/the/root",
   mappings:
-    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
+    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA",
 };
 exports.testMapNoSourceRoot = {
   version: 3,
@@ -43,7 +43,7 @@ exports.testMapNoSourceRoot = {
   names: ["bar", "baz", "n"],
   sources: ["one.js", "two.js"],
   mappings:
-    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
+    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA",
 };
 exports.testMapEmptySourceRoot = {
   version: 3,
@@ -52,7 +52,7 @@ exports.testMapEmptySourceRoot = {
   sources: ["one.js", "two.js"],
   sourceRoot: "",
   mappings:
-    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
+    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA",
 };
 exports.testMapSingleSource = {
   version: 3,
@@ -60,7 +60,7 @@ exports.testMapSingleSource = {
   names: ["bar", "baz"],
   sources: ["one.js"],
   sourceRoot: "",
-  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID"
+  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID",
 };
 exports.testMapEmptyMappings = {
   version: 3,
@@ -69,7 +69,7 @@ exports.testMapEmptyMappings = {
   sources: ["one.js", "two.js"],
   sourcesContent: [" ONE.foo = 1;", " TWO.inc = 2;"],
   sourceRoot: "",
-  mappings: ""
+  mappings: "",
 };
 exports.testMapEmptyMappingsRelativeSources = {
   version: 3,
@@ -78,7 +78,7 @@ exports.testMapEmptyMappingsRelativeSources = {
   sources: ["./one.js", "./two.js"],
   sourcesContent: [" ONE.foo = 1;", " TWO.inc = 2;"],
   sourceRoot: "/the/root",
-  mappings: ""
+  mappings: "",
 };
 exports.testMapEmptyMappingsRelativeSources_generatedExpected = {
   version: 3,
@@ -87,7 +87,7 @@ exports.testMapEmptyMappingsRelativeSources_generatedExpected = {
   sources: ["one.js", "two.js"],
   sourcesContent: [" ONE.foo = 1;", " TWO.inc = 2;"],
   sourceRoot: "/the/root",
-  mappings: ""
+  mappings: "",
 };
 exports.testMapMultiSourcesMappingRefersSingleSourceOnly = {
   version: 3,
@@ -95,7 +95,7 @@ exports.testMapMultiSourcesMappingRefersSingleSourceOnly = {
   names: ["bar", "baz"],
   sources: ["one.js", "withoutMappings.js"],
   sourceRoot: "",
-  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID"
+  mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID",
 };
 // This mapping is identical to above, but uses the indexed format instead.
 exports.indexedTestMap = {
@@ -105,24 +105,24 @@ exports.indexedTestMap = {
     {
       offset: {
         line: 0,
-        column: 0
+        column: 0,
       },
       map: {
         version: 3,
         sources: ["one.js"],
         sourcesContent: [
-          " ONE.foo = function (bar) {\n   return baz(bar);\n };"
+          " ONE.foo = function (bar) {\n   return baz(bar);\n };",
         ],
         names: ["bar", "baz"],
         mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID",
         file: "min.js",
-        sourceRoot: "/the/root"
-      }
+        sourceRoot: "/the/root",
+      },
     },
     {
       offset: {
         line: 1,
-        column: 0
+        column: 0,
       },
       map: {
         version: 3,
@@ -131,10 +131,10 @@ exports.indexedTestMap = {
         names: ["n"],
         mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOA",
         file: "min.js",
-        sourceRoot: "/the/root"
-      }
-    }
-  ]
+        sourceRoot: "/the/root",
+      },
+    },
+  ],
 };
 exports.indexedTestMapDifferentSourceRoots = {
   version: 3,
@@ -143,24 +143,24 @@ exports.indexedTestMapDifferentSourceRoots = {
     {
       offset: {
         line: 0,
-        column: 0
+        column: 0,
       },
       map: {
         version: 3,
         sources: ["one.js"],
         sourcesContent: [
-          " ONE.foo = function (bar) {\n   return baz(bar);\n };"
+          " ONE.foo = function (bar) {\n   return baz(bar);\n };",
         ],
         names: ["bar", "baz"],
         mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID",
         file: "min.js",
-        sourceRoot: "/the/root"
-      }
+        sourceRoot: "/the/root",
+      },
     },
     {
       offset: {
         line: 1,
-        column: 0
+        column: 0,
       },
       map: {
         version: 3,
@@ -169,10 +169,10 @@ exports.indexedTestMapDifferentSourceRoots = {
         names: ["n"],
         mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOA",
         file: "min.js",
-        sourceRoot: "/different/root"
-      }
-    }
-  ]
+        sourceRoot: "/different/root",
+      },
+    },
+  ],
 };
 exports.indexedTestMapColumnOffset = {
   version: 3,
@@ -181,26 +181,26 @@ exports.indexedTestMapColumnOffset = {
     {
       offset: {
         line: 0,
-        column: 0
+        column: 0,
       },
       map: {
         version: 3,
         sources: ["one.js"],
         sourcesContent: [
-          " ONE.foo = function (bar) {\n   return baz(bar);\n };"
+          " ONE.foo = function (bar) {\n   return baz(bar);\n };",
         ],
         names: ["bar", "baz"],
         mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID",
         file: "min.js",
-        sourceRoot: "/the/root"
-      }
+        sourceRoot: "/the/root",
+      },
     },
     {
       offset: {
         line: 0,
         // Previous section's last generated mapping is [32, Infinity), so
         // we're placing this a bit after that.
-        column: 50
+        column: 50,
       },
       map: {
         version: 3,
@@ -209,10 +209,10 @@ exports.indexedTestMapColumnOffset = {
         names: ["n"],
         mappings: "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOA",
         file: "min.js",
-        sourceRoot: "/the/root"
-      }
-    }
-  ]
+        sourceRoot: "/the/root",
+      },
+    },
+  ],
 };
 exports.testMapWithSourcesContent = {
   version: 3,
@@ -221,11 +221,11 @@ exports.testMapWithSourcesContent = {
   sources: ["one.js", "two.js"],
   sourcesContent: [
     " ONE.foo = function (bar) {\n   return baz(bar);\n };",
-    " TWO.inc = function (n) {\n   return n + 1;\n };"
+    " TWO.inc = function (n) {\n   return n + 1;\n };",
   ],
   sourceRoot: "/the/root",
   mappings:
-    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
+    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA",
 };
 exports.testMapRelativeSources = {
   version: 3,
@@ -234,25 +234,25 @@ exports.testMapRelativeSources = {
   sources: ["./one.js", "./two.js"],
   sourcesContent: [
     " ONE.foo = function (bar) {\n   return baz(bar);\n };",
-    " TWO.inc = function (n) {\n   return n + 1;\n };"
+    " TWO.inc = function (n) {\n   return n + 1;\n };",
   ],
   sourceRoot: "/the/root",
   mappings:
-    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
+    "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA",
 };
 exports.emptyMap = {
   version: 3,
   file: "min.js",
   names: [],
   sources: [],
-  mappings: ""
+  mappings: "",
 };
 exports.mapWithSourcelessMapping = {
   version: 3,
   file: "example.js",
   names: [],
   sources: ["example.js"],
-  mappings: "AAgCA,C"
+  mappings: "AAgCA,C",
 };
 
 function assertMapping(
@@ -272,7 +272,7 @@ function assertMapping(
     const origMapping = map.originalPositionFor({
       line: generatedLine,
       column: generatedColumn,
-      bias
+      bias,
     });
     assert.equal(
       origMapping.name,
@@ -330,7 +330,7 @@ function assertMapping(
       source: originalSource,
       line: originalLine,
       column: originalColumn,
-      bias
+      bias,
     });
     assert.equal(
       genMapping.line,

--- a/wasm-mappings/README.md
+++ b/wasm-mappings/README.md
@@ -8,9 +8,9 @@ source maps library.
 
 [source-map]: https://github.com/mozilla/source-map
 
-* [Documentation](#documentation)
-* [License](#license)
-* [Contributing](#contributing)
+- [Documentation](#documentation)
+- [License](#license)
+- [Contributing](#contributing)
 
 ### Documentation
 
@@ -27,4 +27,3 @@ Licensed under [BSD-3-Clause](http://opensource.org/licenses/BSD-3-Clause).
 See
 [CONTRIBUTING.md](https://github.com/mozilla/source-map-mappings/blob/master/wasm-mappings/CONTRIBUTING.md)
 for hacking.
-


### PR DESCRIPTION
As discussed in #463, this applies the current mozilla-central [Prettier config](https://searchfox.org/mozilla-central/rev/49011d374b626d5f0e7dc751a8a57365878e65f1/.prettierrc) to this repository, and adds a check for it in the CI.