### PR TITLE
Update to doctoc v2 & simplify call pattern

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/setup-node@v3
       - run: npm install --legacy-peer-deps
       - run: npm run lint
+      - run: npm run toc
       - run: npx prettier --check .
       - run: npm run coverage
       - run: npx nyc report --reporter=text

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,6 +32,7 @@ jobs:
       - run: npm install --legacy-peer-deps
       - run: npm run lint
       - run: npm run toc
+      - run: git diff --stat --exit-code
       - run: npx prettier --check .
       - run: npm run coverage
       - run: npx nyc report --reporter=text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,10 @@ and introduce yourself.
 
 ---
 
-<!-- `npm run toc` to regenerate the Table of Contents -->
+## Table of Contents
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-## Table of Contents
 
 - [Filing Issues](#filing-issues)
 - [Building From Source](#building-from-source)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,10 @@ This is a library to generate and consume the source map format
 
 ---
 
-<!-- `npm run toc` to regenerate the Table of Contents -->
+## Table of Contents
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-## Table of Contents
 
 - [Examples](#examples)
   - [Consuming a source map](#consuming-a-source-map)

--- a/package.json
+++ b/package.json
@@ -76,10 +76,10 @@
     "dev": "npm-run-all -p --silent dev:*",
     "prettier": "prettier --write .",
     "clean": "rm -rf coverage .nyc_output",
-    "toc": "doctoc --title '## Table of Contents' README.md && doctoc --title '## Table of Contents' CONTRIBUTING.md"
+    "toc": "doctoc --github --notitle README.md CONTRIBUTING.md"
   },
   "devDependencies": {
-    "doctoc": "^1.3.1",
+    "doctoc": "^2.2.1",
     "eslint": "^8.24.0",
     "eslint-config-prettier": "^8.5.0",
     "live-server": "^1.2.0",


### PR DESCRIPTION
This also adds a check to the lint task to validate the current TOCs.