### PR TITLE
Filter out unnecessary rust tasks

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,6 +1,9 @@
 on:
   pull_request:
     branches: [master]
+    paths:
+      - wasm-mappings/**
+      - .github/workflows/cargo.yml
   push:
     branches: [master]
   workflow_dispatch:

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 bench/
 coverage/
 node_modules/
+target/


### PR DESCRIPTION
1. We shouldn't prettify stuff in `wasm-mappings/target/`.
2. We don't need to run the heavier rust tests if we don't change any of the relevant code.