### PR TITLE
Improve coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+comment:
+  require_changes: true
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,3 +35,5 @@ jobs:
       - run: git diff --stat --exit-code
       - run: npx prettier --check .
       - run: npm run coverage
+      - run: npx c8 report --reporter=lcov
+      - uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ package-lock.json
 bench/*.svg
 bench/dist/
 bench/node_modules
-.nyc_output/
 coverage/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-.nyc_output/
 bench/
 coverage/
 node_modules/

--- a/package.json
+++ b/package.json
@@ -67,16 +67,16 @@
   "scripts": {
     "lint": "eslint --fix *.js lib/ test/",
     "test": "node test/run-tests.js",
-    "coverage": "nyc --reporter=text --reporter=html npm test",
+    "coverage": "c8 --reporter=text --reporter=html npm test",
     "prettier": "prettier --write .",
-    "clean": "rm -rf coverage .nyc_output",
+    "clean": "rm -rf coverage",
     "toc": "doctoc --github --notitle README.md CONTRIBUTING.md"
   },
   "devDependencies": {
+    "c8": "^7.12.0",
     "doctoc": "^2.2.1",
     "eslint": "^8.24.0",
     "eslint-config-prettier": "^8.5.0",
-    "nyc": "^11.7.1",
     "prettier": "^2.7.1"
   },
   "dependencies": {


### PR DESCRIPTION
As a follow-on to #468, this switches the coverage tool from `nyc` to `c8`, which use's Node's built-in coverage tooling to generate compatible results.

Those results are then made visible via codecov.io, where I've enabled reporting for the `mozilla/source-map` repo. I'm not sure about their GH bot having access to writing statuses & comments to PRs yet, though.

As a side effect, this gets rid of all the remaining known vulnerable npm dependencies.