### PR TITLE
fix: convert result of allocate_mappings from signed to unsigned

### DIFF
--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -301,7 +301,7 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
     const aStr = this._mappings;
     const size = aStr.length;
 
-    const mappingsBufPtr = this._wasm.exports.allocate_mappings(size);
+    const mappingsBufPtr = this._wasm.exports.allocate_mappings(size) >>> 0;
     const mappingsBuf = new Uint8Array(
       this._wasm.exports.memory.buffer,
       mappingsBufPtr,

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -301,6 +301,8 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
     const aStr = this._mappings;
     const size = aStr.length;
 
+    // Interpret signed result of allocate_mappings as unsigned, otherwise
+    // addresses higher than 2GB will be negative.
     const mappingsBufPtr = this._wasm.exports.allocate_mappings(size) >>> 0;
     const mappingsBuf = new Uint8Array(
       this._wasm.exports.memory.buffer,

--- a/test/test-source-map-consumer.js
+++ b/test/test-source-map-consumer.js
@@ -2200,7 +2200,7 @@ exports["test >2GB of source maps"] = async function (
         line: 1,
         column: 1,
       })
-      if (map._mappingsPtr > 2*1024*1024*1024)
+      if (map._wasm.exports.memory.buffer.byteLength > 2*1024*1024*1024)
         break
     }
   } finally {

--- a/test/test-source-map-consumer.js
+++ b/test/test-source-map-consumer.js
@@ -2172,38 +2172,3 @@ exports["test SourceMapConsumer.with and exceptions"] = async function (
   assert.equal(error, 6);
   assert.equal(consumer._mappingsPtr, 0);
 };
-
-exports["test >2GB of source maps"] = async function (
-  assert
-) {
-
-  const maps = []
-  try {
-    const generator = new SourceMapGenerator({
-      file: "generated-foo.js",
-      sourceRoot: ".",
-    });
-
-    // ~50 KB of mappings
-    for (let j = 1; j < 10000; j++)
-      generator.addMapping({
-        original: { line: j, column: 1 },
-        generated: { line: j, column: 1 },
-        source: "foo.js"
-      });
-
-    const mapJson = generator.toJSON()
-    while (true) {
-      const map = await new SourceMapConsumer(mapJson);
-      maps.push(map)
-      map.originalPositionFor({
-        line: 1,
-        column: 1,
-      })
-      if (map._wasm.exports.memory.buffer.byteLength > 3*1024*1024*1024)
-        break
-    }
-  } finally {
-    maps.forEach(m => m.destroy())
-  }
-}

--- a/test/test-source-map-consumer.js
+++ b/test/test-source-map-consumer.js
@@ -2200,7 +2200,7 @@ exports["test >2GB of source maps"] = async function (
         line: 1,
         column: 1,
       })
-      if (map._wasm.exports.memory.buffer.byteLength > 2*1024*1024*1024)
+      if (map._wasm.exports.memory.buffer.byteLength > 3*1024*1024*1024)
         break
     }
   } finally {


### PR DESCRIPTION
I haven't yet tested this because I don't have a good repro locally, but this might fix https://github.com/mozilla/source-map/issues/412? I noticed that the rust bundle returns a signed integer, and I'm seeing it sometimes come back as negative (i.e. > 2GB). I think this maybe started being an issue with https://v8.dev/blog/4gb-wasm-memory.