### PR TITLE
use a fresh WebAssembly instance for each SourceMapConsumer

### DIFF
--- a/lib/wasm.js
+++ b/lib/wasm.js
@@ -13,18 +13,21 @@ function Mapping() {
   this.name = null;
 }
 
-let cachedWasm = null;
+let cachedCompiledWasm = null;
+async function compile() {
+  if (!cachedCompiledWasm) {
+    const buf = await readWasm()
+    cachedCompiledWasm = await WebAssembly.compile(buf)
+  }
+  return cachedCompiledWasm
+}
 
 module.exports = function wasm() {
-  if (cachedWasm) {
-    return cachedWasm;
-  }
-
   const callbackStack = [];
 
-  cachedWasm = readWasm()
-    .then(buffer => {
-      return WebAssembly.instantiate(buffer, {
+  return compile()
+    .then(module => {
+      return WebAssembly.instantiate(module, {
         env: {
           mapping_callback(
             generatedLine,
@@ -116,9 +119,9 @@ module.exports = function wasm() {
         },
       });
     })
-    .then(Wasm => {
+    .then(instance => {
       return {
-        exports: Wasm.instance.exports,
+        exports: instance.exports,
         withMappingCallback: (mappingCallback, f) => {
           callbackStack.push(mappingCallback);
           try {
@@ -129,10 +132,4 @@ module.exports = function wasm() {
         },
       };
     })
-    .then(null, e => {
-      cachedWasm = null;
-      throw e;
-    });
-
-  return cachedWasm;
 };


### PR DESCRIPTION
This works around WebAssembly memory limits.

Fixes #412.