### PR TITLE
Fix reference to LICENSE file

### DIFF
--- a/source-map.js
+++ b/source-map.js
@@ -1,6 +1,6 @@
 /*
  * Copyright 2009-2011 Mozilla Foundation and contributors
- * Licensed under the New BSD license. See LICENSE.txt or:
+ * Licensed under the New BSD license. See LICENSE or:
  * http://opensource.org/licenses/BSD-3-Clause
  */
 exports.SourceMapGenerator =


### PR DESCRIPTION
Fixed a reference to the license file which was LICENSE.txt, but the license filename is actually LICENSE.