### PR TITLE
ci: use setup-node caching

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci
       - run: npm test
 
@@ -29,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+        with:
+          cache: npm
       - run: npm ci
       - run: npm run lint
       - run: npm run toc


### PR DESCRIPTION
The setup-node action supports built-in package caching since v2