### PR TITLE
chore: don't fix with lint target

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "lint": "eslint --fix *.js lib/ test/",
+    "fix": "npm run lint -- --fix",
+    "lint": "eslint . --ignore-path .prettierignore",
     "test": "node test/run-tests.js",
     "coverage": "c8 --reporter=text --reporter=html npm test",
     "prettier": "prettier --write .",


### PR DESCRIPTION
Since the `lint` target is called with the `--fix` parameter, the CI wouldn't fail if there were autofixable issues. Split the fix vs lint targets, and reused Prettiers ignore file instead of creating a `.eslintignore` file