### PR TITLE
Fix a few typos with codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,10 @@ following attributes:
 - `file`: Optional. The generated filename this source map is associated with.
 
 - `x_google_ignoreList`: Optional. An additional extension field which is an array
-  of indices refering to urls in the sources array. This is used to identify third-party
+  of indices referring to urls in the sources array. This is used to identify third-party
   sources, that the developer might want to avoid when debugging. [Read more](https://developer.chrome.com/articles/x-google-ignore-list/)
 
-The promise of the constructed souce map consumer is returned.
+The promise of the constructed source map consumer is returned.
 
 When the `SourceMapConsumer` will no longer be used anymore, you must call its
 `destroy` method.

--- a/bench/README.md
+++ b/bench/README.md
@@ -4,7 +4,7 @@ This directory contains helpers for benchmarking the `mozilla/source-map`
 library.
 
 Ensure that you have built the library, as these benchmarks rely on
-`dist/source-map.js`. See the main README.md for detais on building.
+`dist/source-map.js`. See the main README.md for details on building.
 
 Run a local webserver from the root of the repository:
 

--- a/bench/plot.r
+++ b/bench/plot.r
@@ -76,7 +76,7 @@ jitterBoxPlot <- function(data, operation, titleText) {
 largeData <- subset(data, Mappings.Size==14964446)
 
 jitterBoxPlot(largeData, "set.first.breakpoint", "Set First Breakpoint")
-jitterBoxPlot(largeData, "subsequent.setting.breakpoints", "Subsquent Setting Breakpoints")
+jitterBoxPlot(largeData, "subsequent.setting.breakpoints", "Subsequent Setting Breakpoints")
 
 jitterBoxPlot(largeData, "first.pause.at.exception", "First Pause at Exception")
 jitterBoxPlot(largeData, "subsequent.pausing.at.exceptions", "Subsequent Pausing at Exceptions")

--- a/lib/source-map-generator.js
+++ b/lib/source-map-generator.js
@@ -161,7 +161,7 @@ class SourceMapGenerator {
    * Applies the mappings of a sub-source-map for a specific source file to the
    * source map being generated. Each mapping to the supplied source file is
    * rewritten using the supplied source map. Note: The resolution for the
-   * resulting mappings is the minimium of this map and the supplied map.
+   * resulting mappings is the minimum of this map and the supplied map.
    *
    * @param aSourceMapConsumer The source map to be applied.
    * @param aSourceFile Optional. The filename of the source file.

--- a/lib/util.js
+++ b/lib/util.js
@@ -427,7 +427,7 @@ function computeSourceURL(sourceRoot, sourceURL, sourceMapURL) {
   // must behave as "some-dir/some-path.js".
   //
   // With this library's the transition to a more URL-focused implementation, that behavior is
-  // preserved here. To acheive that, we trim the "/" from absolute-path when a sourceRoot value
+  // preserved here. To achieve that, we trim the "/" from absolute-path when a sourceRoot value
   // is present in order to make the sources entries behave as if they are relative to the
   // "sourceRoot", as they would have if the two strings were simply concated.
   if (sourceRoot && getURLType(sourceURL) === "path-absolute") {

--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -357,7 +357,7 @@ export class SourceMapGenerator {
    * Applies the mappings of a sub-source-map for a specific source file to the
    * source map being generated. Each mapping to the supplied source file is
    * rewritten using the supplied source map. Note: The resolution for the
-   * resulting mappings is the minimium of this map and the supplied map.
+   * resulting mappings is the minimum of this map and the supplied map.
    *
    * @param sourceMapConsumer The source map to be applied.
    * @param sourceFile Optional. The filename of the source file.


### PR DESCRIPTION
Happened to be running `codespell` against one of my repos too broadly, 
and it caught some typos here.

(I didn't change `self-source-map.js`, since I assume that's automatically 
generated)
