### PR TITLE
fixed `read properties of undefined (reading 'replace')` 

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -247,8 +247,9 @@ exports.isAbsolute = function(aPath) {
  * @param aRoot The root path or URL.
  * @param aPath The path or URL to be made relative to aRoot.
  */
-function relative(aRoot, aPath) {
-  if (aRoot === "") {
+function relative(aRoot, aPath) {  
+
+  if (typeof aRoot == 'undefined' || aRoot === "") {
     aRoot = ".";
   }
 


### PR DESCRIPTION
fixed `read properties of undefined (reading 'replace')`  inside relative function.

![image](https://github.com/mozilla/source-map/assets/40761960/ff4e6cfc-4194-440e-84bf-7a1e8b7dd76d)

I've faced with the error by merging `linaria` source maps with the rest maps during building under `rollup-plugin-hot-css` via nollup 

After the fix maps hasn't merged suckessfully, but at least has gone away unwanted error

