### PR TITLE
Preventing an index access error on undefined 

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -235,7 +235,7 @@ function buildSafeBase(str) {
 
 const ABSOLUTE_SCHEME = /^[A-Za-z0-9\+\-\.]+:/;
 function getURLType(url) {
-  if (url[0] === "/") {
+  if (url && url[0] === "/") {
     if (url[1] === "/") return "scheme-relative";
     return "path-absolute";
   }


### PR DESCRIPTION
I have faced with trouble when `url` comes as `undefined` (using `nollup` bundler). So it throws an error `Cannot read property '0' of undefined`. The problem I solved by a one-line check: 

```js
if (url && url[0] === "/")
/// instead of `if (url[0] === "/")`
```
Is it ok?