### PR TITLE
Update source map spec tests to latest

### DIFF
--- a/test/test-spec-tests.js
+++ b/test/test-spec-tests.js
@@ -49,7 +49,14 @@ const skippedTests = [
   "ignoreListWrongType1",
   "ignoreListWrongType2",
   "ignoreListWrongType3",
-  "ignoreListOutOfBounds",
+  "ignoreListWrongType4",
+  "ignoreListOutOfBounds1",
+  "ignoreListOutOfBounds2",
+  // These 'file' checks aren't currently done
+  "fileNotAString1",
+  "fileNotAString2",
+  "indexMapFileWrongType1",
+  "indexMapFileWrongType2",
 ];
 
 // The source-map library converts null sources to the "null" URL in its
@@ -62,7 +69,7 @@ function nullish(nullOrString) {
 }
 
 function mapLine(line) {
-  return line + 1;
+  return line === null ? null : line + 1;
 }
 
 async function testMappingAction(assert, rawSourceMap, action) {


### PR DESCRIPTION
This is a periodic update to pull in the latest source map tests submodule. Only minor updates were made.

Note: I'm also interested in adding more validation checks so that more tests can be un-skipped if that would be of interest.