### PR TITLE
Using WASM instantiateStreaming when using URL in browser

### DIFF
--- a/lib/read-wasm-browser.js
+++ b/lib/read-wasm-browser.js
@@ -4,7 +4,7 @@ let mappingsWasm = null;
 
 module.exports = function readWasm() {
   if (typeof mappingsWasm === "string") {
-    return fetch(mappingsWasm).then(response => response.arrayBuffer());
+    return fetch(mappingsWasm);
   }
   if (mappingsWasm instanceof ArrayBuffer) {
     return Promise.resolve(mappingsWasm);

--- a/lib/wasm.js
+++ b/lib/wasm.js
@@ -23,8 +23,8 @@ module.exports = function wasm() {
   const callbackStack = [];
 
   cachedWasm = readWasm()
-    .then(buffer => {
-      return WebAssembly.instantiate(buffer, {
+    .then(bufferOrResponse => {
+      const opts = {
         env: {
           mapping_callback(
             generatedLine,
@@ -114,7 +114,18 @@ module.exports = function wasm() {
             console.timeEnd("sort_by_original_location");
           },
         },
-      });
+      };
+      let source;
+      if (bufferOrResponse instanceof Response) {
+        if (WebAssembly.instantiateStreaming) {
+          source = WebAssembly.instantiateStreaming(bufferOrResponse, opts);
+        } else {
+          source = WebAssembly.instantiate(bufferOrResponse.arrayBuffer(), opts);
+        }
+      } else {
+        source = WebAssembly.instantiate(bufferOrResponse, opts);
+      }
+      return source;
     })
     .then(Wasm => {
       return {


### PR DESCRIPTION
This PR is to leverage the `instantiateStreaming` API when loading the WASM code, in order to keep the URI link intact, and overcome CSP rules when they will be able to cover the current gap about WASM same-origin policies.

https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static

It seems that the minimum browser version requirements are more or less the same.
I added a check by the way in case polyfills or older browsers are used, to keep the same previous logic.

Thx, L.