### PR TITLE
Fix wasm-mappings build failure on Rust 1.96+

### DIFF
--- a/wasm-mappings/source-map-mappings-wasm-api/src/lib.rs
+++ b/wasm-mappings/source-map-mappings-wasm-api/src/lib.rs
@@ -251,6 +251,7 @@ unsafe fn mappings_mut<'a>(
     mappings.as_mut().unwrap()
 }
 
+#[link(wasm_import_module = "env")]
 extern "C" {
     fn mapping_callback(
         // These two parameters are always valid.


### PR DESCRIPTION
As stated in #530, `wasm-mappings` fails to build on Rust 1.96 or newer because they stopped passing `--allow-undefined` to `wasm-ld` by default.

This PR fixes the issue by following upstream's [recommendation](https://github.com/rust-lang/rust/pull/149868#issuecomment-3730522786) and explicitly linking to `env`. Switching to my branch, the build should work on both old and new toolchains.

## Steps to reproduce

```
$ cd wasm-mappings/source-map-mappings-wasm-api
$ rustup update nightly
$ cargo +1.95.0 build --target wasm32-unknown-unknown
$ cargo +nightly build --target wasm32-unknown-unknown
```

## Expected result

The build should succeed on both toolchains.