### PR TITLE
Allow initializing WASM contents in Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,12 @@ sourceMap.SourceMapConsumer.initialize({
 });
 ```
 
+In node.js, initialization is optional: the module loads its bundled
+`lib/mappings.wasm` file by default. When a bundler relocates the module, you can
+instead provide an `ArrayBuffer` containing the WASM bytes. Call `initialize`
+before constructing any `SourceMapConsumer`s. URL initialization is only supported
+outside of node.js.
+
 #### new SourceMapConsumer(rawSourceMap)
 
 The only parameter is the raw source map (either as a string which can be

--- a/lib/read-wasm.js
+++ b/lib/read-wasm.js
@@ -6,7 +6,13 @@
 const fs = require("fs");
 const path = require("path");
 
+let mappingsWasm = null;
+
 module.exports = function readWasm() {
+  if (mappingsWasm instanceof ArrayBuffer) {
+    return Promise.resolve(mappingsWasm);
+  }
+
   return new Promise((resolve, reject) => {
     const wasmPath = path.join(__dirname, "mappings.wasm");
     fs.readFile(wasmPath, null, (error, data) => {
@@ -20,8 +26,12 @@ module.exports = function readWasm() {
   });
 };
 
-module.exports.initialize = _ => {
+module.exports.initialize = input => {
+  mappingsWasm = input;
+  if (mappingsWasm instanceof ArrayBuffer) {
+    return;
+  }
   console.debug(
-    "SourceMapConsumer.initialize is a no-op when running in node.js"
+    "SourceMapConsumer.initialize only supports ArrayBuffer contents in node.js"
   );
 };

--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -229,6 +229,9 @@ export interface SourceMapConsumerConstructor {
    * When using SourceMapConsumer outside of node.js, for example on the Web, it
    * needs to know from what URL to load lib/mappings.wasm. You must inform it
    * by calling initialize before constructing any SourceMapConsumers.
+   * In node.js, initialization is optional and accepts ArrayBuffer contents
+   * instead of loading the bundled lib/mappings.wasm file. URLs are not supported
+   * in node.js.
    *
    * @param mappings an object with the following property:
    *   - "lib/mappings.wasm": A String containing the URL of the

--- a/test/test-read-wasm.js
+++ b/test/test-read-wasm.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Mozilla Foundation and contributors
+ * Licensed under the New BSD license. See LICENSE or:
+ * http://opensource.org/licenses/BSD-3-Clause
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+function freshReadWasm() {
+  const modulePath = require.resolve("../lib/read-wasm");
+  const cachedModule = require.cache[modulePath];
+  delete require.cache[modulePath];
+  const readWasm = require(modulePath);
+  if (cachedModule) {
+    require.cache[modulePath] = cachedModule;
+  } else {
+    delete require.cache[modulePath];
+  }
+  return readWasm;
+}
+
+exports["test readWasm uses initialized ArrayBuffer contents"] =
+  async function (assert) {
+    const readWasm = freshReadWasm();
+    const contents = new ArrayBuffer(8);
+    readWasm.initialize(contents);
+    assert.ok(
+      (await readWasm()) === contents,
+      "uses the provided WASM contents"
+    );
+  };
+
+exports["test readWasm still loads the bundled wasm by default"] =
+  async function (assert) {
+    const readWasm = freshReadWasm();
+    const expected = fs.readFileSync(
+      path.join(__dirname, "../lib/mappings.wasm")
+    );
+    assert.ok(Buffer.from(await readWasm()).equals(expected));
+  };
+
+exports["test Node consumers can initialize without an adjacent wasm file"] =
+  function (assert) {
+    // Use a fresh process so the shared WebAssembly cache cannot hide a failed
+    // initialization. Bundling relocates read-wasm.js away from mappings.wasm.
+    const output = execFileSync(
+      process.execPath,
+      [
+        "-e",
+        `
+          const assert = require("assert");
+          const fs = require("fs");
+          const { SourceMapConsumer } = require("./source-map");
+          const bytes = fs.readFileSync("./lib/mappings.wasm");
+          const contents = bytes.buffer.slice(
+            bytes.byteOffset, bytes.byteOffset + bytes.byteLength
+          );
+          fs.readFile = (_path, _options, callback) => {
+            callback(new Error("No adjacent mappings.wasm"));
+          };
+          SourceMapConsumer.initialize({ "lib/mappings.wasm": contents });
+          SourceMapConsumer.with({
+            version: 3,
+            sources: ["original.js"],
+            names: [],
+            mappings: "AAAA"
+          }, null, consumer => {
+            assert.deepStrictEqual(
+              consumer.originalPositionFor({ line: 1, column: 0 }),
+              { source: "original.js", line: 1, column: 0, name: null }
+            );
+            console.log("initialized");
+          }).catch(error => {
+            console.error(error);
+            process.exitCode = 1;
+          });
+        `,
+      ],
+      { cwd: path.join(__dirname, ".."), encoding: "utf8" }
+    );
+    assert.strictEqual(output.trim(), "initialized");
+  };


### PR DESCRIPTION
Fixes #527.

`SourceMapConsumer.initialize()` ignores supplied WASM bytes in Node.js, so a bundle still tries to read `mappings.wasm` next to the relocated module.

Use a supplied `ArrayBuffer` when available, keeping the filesystem loader as the default. The README and API comments now describe this Node.js behavior. Callers must initialize before constructing consumers; an existing WASM instance is not replaced.

The regression test starts a fresh process, makes filesystem loading fail, and checks a source position using the real WASM. It fails before this change and passes afterward. Separate tests cover the supplied bytes and default loader.

Tested on Windows with Node.js v24.19.0:

- `node test/run-tests.js`: 193/193 passed.
- ESLint on the changed JavaScript files: passed.