### PR TITLE
Fix SourceNode.children type to include strings

### DIFF
--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -381,7 +381,7 @@ export class SourceMapGenerator {
 }
 
 export class SourceNode {
-  children: SourceNode[];
+  children: Array<SourceNode | string>;
   sourceContents: any;
   line: number;
   column: number;


### PR DESCRIPTION
Fixes #482.

`SourceNode.add()` and `prepend()` store both strings and `SourceNode` instances in `children`, but the declaration only allows `SourceNode[]`. This rejects valid string children and lets callers access node methods without narrowing.

Change the element type to `SourceNode | string`, matching the implementation and the existing chunk parameter types.

Verified with TypeScript 5.9.3 (`--strict --noEmit --lib es2015`): mixed children and string narrowing fail before this change and pass afterward; node-only access without narrowing and numeric children are rejected. The 18 existing SourceNode runtime tests also pass.