### PR TITLE
Support the standard ignoreList source map field

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ following attributes:
   of indices refering to urls in the sources array. This is used to identify third-party
   sources, that the developer might want to avoid when debugging. [Read more](https://developer.chrome.com/articles/x-google-ignore-list/)
 
+A `BasicSourceMapConsumer` also exposes the standard `ignoreList` field described
+in the [source map specification](https://tc39.es/ecma426/#sec-source-map-format).
+It falls back to `x_google_ignoreList` only when `ignoreList` is absent, or `null`
+when neither is present. An explicit empty array takes precedence over the
+legacy field. The `x_google_ignoreList` property retains the legacy field's value.
+
 The promise of the constructed souce map consumer is returned.
 
 When the `SourceMapConsumer` will no longer be used anymore, you must call its

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -220,6 +220,11 @@ class BasicSourceMapConsumer extends SourceMapConsumer {
       that._mappings = mappings;
       that._sourceMapURL = aSourceMapURL;
       that.file = file;
+      that.ignoreList = util.getArg(
+        sourceMap,
+        "ignoreList",
+        x_google_ignoreList
+      );
       that.x_google_ignoreList = x_google_ignoreList;
 
       that._computedColumnSpans = false;

--- a/source-map.d.ts
+++ b/source-map.d.ts
@@ -20,6 +20,8 @@ export interface RawSourceMap {
   sourcesContent?: string[];
   mappings: string;
   file: string;
+  ignoreList?: number[];
+  x_google_ignoreList?: number[];
 }
 
 export interface RawIndexMap extends StartOfSourceMap {
@@ -294,6 +296,8 @@ export interface BasicSourceMapConsumer extends SourceMapConsumer {
   sourceRoot: string;
   sources: string[];
   sourcesContent: string[];
+  ignoreList: number[] | null;
+  x_google_ignoreList: number[] | null;
 }
 
 export interface BasicSourceMapConsumerConstructor {

--- a/test/test-ignore-list.js
+++ b/test/test-ignore-list.js
@@ -1,0 +1,49 @@
+/* -*- Mode: js; js-indent-level: 2; -*- */
+/*
+ * Licensed under the New BSD license. See LICENSE or:
+ * http://opensource.org/licenses/BSD-3-Clause
+ */
+
+const { SourceMapConsumer } = require("../source-map");
+
+const cases = [
+  ["standard field", { ignoreList: [1] }, [1]],
+  ["legacy fallback", { x_google_ignoreList: [0] }, [0]],
+  ["standard precedence", { ignoreList: [1], x_google_ignoreList: [0] }, [1]],
+  ["empty standard field", { ignoreList: [], x_google_ignoreList: [0] }, []],
+  ["absent fields", {}, null],
+];
+
+for (const [name, fields, expected] of cases) {
+  exports["test ignoreList " + name] = async function (assert) {
+    const raw = {
+      version: 3,
+      sources: ["app.js", "vendor.js"],
+      names: [],
+      mappings: "AAAA,CCAA",
+      ...fields,
+    };
+    for (const input of [raw, JSON.stringify(raw)]) {
+      await SourceMapConsumer.with(input, null, consumer => {
+        if (expected === null) {
+          assert.strictEqual(consumer.ignoreList, null);
+        } else {
+          assert.ok(Array.isArray(consumer.ignoreList));
+          assert.equal(consumer.ignoreList.length, expected.length);
+          expected.forEach((sourceIndex, i) => {
+            assert.equal(consumer.ignoreList[i], sourceIndex);
+            assert.equal(
+              consumer.sources[sourceIndex],
+              raw.sources[sourceIndex]
+            );
+          });
+        }
+        // The legacy property continues to reflect only the legacy input.
+        assert.equal(
+          JSON.stringify(consumer.x_google_ignoreList),
+          JSON.stringify(fields.x_google_ignoreList || null)
+        );
+      });
+    }
+  };
+}


### PR DESCRIPTION
Fixes #497.

Source maps using the standard `ignoreList` field currently lose their ignored-source indexes when read by `SourceMapConsumer`. Only the older `x_google_ignoreList` field is exposed.

Expose `ignoreList` on basic consumers, falling back to the legacy field only when the standard field is absent. An explicit empty array wins over a legacy list. Keep the existing `x_google_ignoreList` property unchanged, and document the behavior and types.

The field and fallback are described in the [source map specification](https://tc39.es/ecma426/#sec-source-map-format).

Tests cover standard and legacy inputs, precedence, empty lists, and absent fields, both as objects and JSON strings. All five regressions fail before the change. The full suite passes 195/195 afterward; ESLint and a strict TypeScript 5.9.3 usage check pass too.