### PR TITLE
Fix wasm-mappings build failures and warnings

### DIFF
--- a/wasm-mappings/source-map-mappings-wasm-api/Cargo.toml
+++ b/wasm-mappings/source-map-mappings-wasm-api/Cargo.toml
@@ -6,6 +6,7 @@ name = "source-map-mappings-wasm-api"
 readme = "../README.md"
 repository = "https://github.com/mozilla/source-map"
 version = "0.5.0"
+edition = "2024"
 
 [dependencies]
 source-map-mappings = { version = "0.5.0", path = ".." }

--- a/wasm-mappings/source-map-mappings-wasm-api/src/lib.rs
+++ b/wasm-mappings/source-map-mappings-wasm-api/src/lib.rs
@@ -19,7 +19,7 @@
 //! 6. When finished with `Mappings` structure, dispose of it with
 //! `free_mappings`.
 
-// NB: every exported function must be `#[no_mangle]` and `pub extern "C"`.
+// NB: every exported function must be `#[unsafe(no_mangle)]` and `pub extern "C"`.
 
 #![deny(missing_docs)]
 
@@ -43,7 +43,8 @@ mod observer {
             impl Default for $name {
                 #[inline]
                 fn default() -> $name {
-                    extern "C" {
+                   #[cfg_attr(target_arch = "wasm32", link(wasm_import_module = "env"))]
+                    unsafe extern "C" {
                         fn $ctor();
                     }
                     unsafe {
@@ -56,7 +57,8 @@ mod observer {
             impl Drop for $name {
                 #[inline]
                 fn drop(&mut self) {
-                    extern "C" {
+                    #[cfg_attr(target_arch = "wasm32", link(wasm_import_module = "env"))]
+                    unsafe extern "C" {
                         fn $dtor();
                     }
                     unsafe {
@@ -125,7 +127,7 @@ static mut LAST_ERROR: Option<Error> = None;
 /// Get the last error's error code, or 0 if there was none.
 ///
 /// See `source_map_mappings::Error` for the error code definitions.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn get_last_error() -> u32 {
     unsafe {
         match LAST_ERROR {
@@ -145,7 +147,7 @@ fn assert_pointer_is_word_aligned(p: *mut u8) {
 /// It is the JS callers responsibility to initialize the resulting buffer by
 /// copying the JS `String` holding the source map's "mappings" into it (encoded
 /// in ascii).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn allocate_mappings(size: usize) -> *mut u8 {
     // Make sure that we don't lose any bytes from size in the remainder.
     let size_in_units_of_usize = (size + mem::size_of::<usize>() - 1) / mem::size_of::<usize>();
@@ -191,7 +193,7 @@ where
 ///
 /// In both the success or failure cases, the caller gives up ownership of the
 /// input mappings string and must not use it again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn parse_mappings(mappings: *mut u8) -> *mut Mappings<Observer> {
     assert_pointer_is_word_aligned(mappings);
     let mappings = mappings as *mut usize;
@@ -236,10 +238,10 @@ pub extern "C" fn parse_mappings(mappings: *mut u8) -> *mut Mappings<Observer> {
 /// Destroy the given `Mappings` structure.
 ///
 /// The caller gives up ownership of the mappings and must not use them again.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn free_mappings(mappings: *mut Mappings<Observer>) {
     unsafe {
-        Box::from_raw(mappings);
+      let _ = Box::from_raw(mappings);
     }
 }
 
@@ -247,11 +249,12 @@ pub extern "C" fn free_mappings(mappings: *mut Mappings<Observer>) {
 unsafe fn mappings_mut<'a>(
     _scope: &'a (),
     mappings: *mut Mappings<Observer>,
-) -> &'a mut Mappings<Observer> {
+) -> &'a mut Mappings<Observer> { unsafe {
     mappings.as_mut().unwrap()
-}
+}}
 
-extern "C" {
+#[cfg_attr(target_arch = "wasm32", link(wasm_import_module = "env"))]
+unsafe extern "C" {
     fn mapping_callback(
         // These two parameters are always valid.
         generated_line: u32,
@@ -276,7 +279,7 @@ extern "C" {
 }
 
 #[inline]
-unsafe fn invoke_mapping_callback(mapping: &Mapping) {
+unsafe fn invoke_mapping_callback(mapping: &Mapping) { unsafe {
     let generated_line = mapping.generated_line;
     let generated_column = mapping.generated_column;
 
@@ -319,11 +322,11 @@ unsafe fn invoke_mapping_callback(mapping: &Mapping) {
         has_name,
         name,
     );
-}
+}}
 
 /// Invoke the `mapping_callback` on each mapping in the given `Mappings`
 /// structure, in order of generated location.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn by_generated_location(mappings: *mut Mappings<Observer>) {
     let this_scope = ();
     let mappings = unsafe { mappings_mut(&this_scope, mappings) };
@@ -337,7 +340,7 @@ pub extern "C" fn by_generated_location(mappings: *mut Mappings<Observer>) {
 }
 
 /// Compute column spans for the given mappings.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn compute_column_spans(mappings: *mut Mappings<Observer>) {
     let this_scope = ();
     let mappings = unsafe { mappings_mut(&this_scope, mappings) };
@@ -348,7 +351,7 @@ pub extern "C" fn compute_column_spans(mappings: *mut Mappings<Observer>) {
 /// Invoke the `mapping_callback` on each mapping in the given `Mappings`
 /// structure that has original location information, in order of original
 /// location.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn by_original_location(mappings: *mut Mappings<Observer>) {
     let this_scope = ();
     let mappings = unsafe { mappings_mut(&this_scope, mappings) };
@@ -381,7 +384,7 @@ fn u32_to_bias(bias: u32) -> Bias {
 ///
 /// If a mapping is found, the `mapping_callback` is invoked with it
 /// once. Otherwise, the `mapping_callback` is not invoked at all.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn original_location_for(
     mappings: *mut Mappings<Observer>,
     generated_line: u32,
@@ -403,7 +406,7 @@ pub extern "C" fn original_location_for(
 ///
 /// If a mapping is found, the `mapping_callback` is invoked with it
 /// once. Otherwise, the `mapping_callback` is not invoked at all.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn generated_location_for(
     mappings: *mut Mappings<Observer>,
     source: u32,
@@ -431,7 +434,7 @@ pub extern "C" fn generated_location_for(
 /// `false`, then the `original_column` argument is ignored, and the
 /// `mapping_callback` is invoked on all mappings with matching source and
 /// original line.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn all_generated_locations_for(
     mappings: *mut Mappings<Observer>,
     source: u32,

--- a/wasm-mappings/src/comparators.rs
+++ b/wasm-mappings/src/comparators.rs
@@ -7,7 +7,7 @@ use std::fmt;
 /// A function that can compare two `T`s.
 pub trait ComparatorFunction<T>: fmt::Debug {
     /// Compare the given values.
-    fn compare(&T, &T) -> Ordering;
+    fn compare(_: &T, _: &T) -> Ordering;
 }
 
 impl<T, F> ComparatorFunction<Option<T>> for F

--- a/wasm-mappings/src/lib.rs
+++ b/wasm-mappings/src/lib.rs
@@ -131,7 +131,7 @@ where
                 items
             }
         };
-        mem::replace(self, LazilySorted::Sorted(items, PhantomData, PhantomData));
+        let _ = mem::replace(self, LazilySorted::Sorted(items, PhantomData, PhantomData));
         unwrap(self.sorted())
     }
 
@@ -274,7 +274,7 @@ impl<O: Observer> Mappings<O> {
     /// Iterate over all mappings that contain original location information,
     /// sorted by their original location information.
     #[inline]
-    pub fn by_original_location(&mut self) -> ByOriginalLocation<O::SortByOriginalLocation> {
+    pub fn by_original_location(&mut self) -> ByOriginalLocation<'_, O::SortByOriginalLocation> {
         ByOriginalLocation {
             buckets: self.source_buckets().iter_mut(),
             this_bucket: [].iter(),
@@ -389,7 +389,7 @@ impl<O: Observer> Mappings<O> {
         source: u32,
         original_line: u32,
         original_column: Option<u32>,
-    ) -> AllGeneratedLocationsFor {
+    ) -> AllGeneratedLocationsFor<'_> {
         let _observer = O::AllGeneratedLocationsFor::default();
 
         let query_column = original_column.unwrap_or(0);


### PR DESCRIPTION
This patch
 - Fixes wasm32 callback import linkage in source-map-mappings-wasm-api
 - Sets the rust edition for the package to 2024 (latest) and fixes related warnings accordingly
 - Tries to cleanup most of the build warnings